### PR TITLE
PS-9195: JS Stored Routines: console log support

### DIFF
--- a/components/js_lang/CMakeLists.txt
+++ b/components/js_lang/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+# Copyright (c) 2023, 2025 Percona LLC and/or its affiliates. All rights
 # reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -34,6 +34,7 @@ MYSQL_ADD_COMPONENT(js_lang
   js_lang_core.cc
   js_lang_param.cc
   js_lang_udf.cc
-  LINK_LIBRARIES ext::v8
+  js_lang_console.cc
+  LINK_LIBRARIES ext::v8 extra::rapidjson
   MODULE_ONLY
 )

--- a/components/js_lang/README.md
+++ b/components/js_lang/README.md
@@ -89,7 +89,6 @@ TODO/Future work:
 Short-term
 ----------
 
-- Console support
 - Memory tracking/limiting?
 - Handling of async JS features
 - Execution of SQL

--- a/components/js_lang/component.cc
+++ b/components/js_lang/component.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+/* Copyright (c) 2023, 2025 Percona LLC and/or its affiliates. All rights
    reserved.
 
    This program is free software; you can redistribute it and/or
@@ -39,6 +39,8 @@
 #include "js_lang_common.h"
 #include "js_lang_core.h"
 
+REQUIRES_SERVICE_PLACEHOLDER(component_sys_variable_register);
+REQUIRES_SERVICE_PLACEHOLDER(component_sys_variable_unregister);
 REQUIRES_SERVICE_PLACEHOLDER(dynamic_privilege_register);
 REQUIRES_SERVICE_PLACEHOLDER(global_grants_check);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_charset);
@@ -230,9 +232,19 @@ static mysql_service_status_t component_init() {
   // The below call can fail if one of UDF names is already occupied.
   if (register_udfs()) return 1;
 
+  // The below call can fail, when, for example, while executing INSTALL
+  // COMPONENT statement, we use SET clause to set one of component's
+  // system variables to some wrong value.
+  if (register_sys_vars()) {
+    // We can't do much if unregistiring UDFs fails here.
+    (void)unregister_udfs();
+    return 1;
+  }
+
   // Play safe, even though the below can't fail at the moment.
   if (register_create_privilege()) {
-    // We can't do much if unregistiring UDFs fails here.
+    // We can't do much if unregistiring sys vars or UDFs fails here.
+    (void)unregister_sys_vars();
     (void)unregister_udfs();
     return 1;
   }
@@ -276,8 +288,8 @@ static mysql_service_status_t component_deinit() {
   */
   if (unregister_udfs()) return 1;
 
-  // Play safe, even though the below can't fail at the moment.
-  if (unregister_create_privilege()) return 1;
+  // Play safe, even though the below calls should not fail at the moment.
+  if (unregister_sys_vars() || unregister_create_privilege()) return 1;
 
   Js_thd::unregister_slot();
 
@@ -305,6 +317,8 @@ BEGIN_COMPONENT_PROVIDES(js_lang)
 END_COMPONENT_PROVIDES();
 
 BEGIN_COMPONENT_REQUIRES(js_lang)
+  REQUIRES_SERVICE(component_sys_variable_register),
+  REQUIRES_SERVICE(component_sys_variable_unregister),
   REQUIRES_SERVICE(dynamic_privilege_register),
   REQUIRES_SERVICE(global_grants_check),
   REQUIRES_SERVICE(mysql_charset),

--- a/components/js_lang/js_lang_common.h
+++ b/components/js_lang/js_lang_common.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+/* Copyright (c) 2023, 2025 Percona LLC and/or its affiliates. All rights
    reserved.
 
    This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@
   Services and helper headers provided by SQL core which our component uses.
 */
 #include <mysql/components/services/bits/stored_program_bits.h>
+#include <mysql/components/services/component_sys_var_service.h>
 #include <mysql/components/services/dynamic_privilege.h>
 #include <mysql/components/services/mysql_current_thread_reader.h>
 #include <mysql/components/services/mysql_runtime_error_service.h>
@@ -46,6 +47,8 @@
 /*
   Placeholders for services from SQL core used by our component.
 */
+extern REQUIRES_SERVICE_PLACEHOLDER(component_sys_variable_register);
+extern REQUIRES_SERVICE_PLACEHOLDER(component_sys_variable_unregister);
 extern REQUIRES_SERVICE_PLACEHOLDER(dynamic_privilege_register);
 extern REQUIRES_SERVICE_PLACEHOLDER(global_grants_check);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_charset);
@@ -102,5 +105,10 @@ static constexpr const char LANGUAGE_NAME[] = "JS";
 // Name of global privilege required from user creating JS routine
 // in addition to usual CREATE ROUTINE privilege on the schema.
 static constexpr std::string_view CREATE_PRIVILEGE_NAME = "CREATE_JS_ROUTINE";
+
+// Name of system variable which limits the size of console log buffer.
+//
+// Defined as a macro so we can easier concatenate it with other literals.
+#define MAX_CONSOLE_LOG_SIZE_VAR_NAME "max_console_log_size"
 
 #endif /* COMPONENT_JS_LANG_JS_LANG_COMMON_H */

--- a/components/js_lang/js_lang_console.cc
+++ b/components/js_lang/js_lang_console.cc
@@ -1,0 +1,1018 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights
+   reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+/*
+  This and corresponding header file contain implementation of debugging
+  console support for our JS routines.
+
+  Notes on high-level design of debugging console support in JS routines
+  ======================================================================
+
+  In general, in our implementation we try to follow Console Standard
+  as described at https://console.spec.whatwg.org/ and MDN documentation
+  at https://developer.mozilla.org/en-US/docs/Web/API/console,
+
+  At this point we support most of functions which are mentioned in the
+  standard. Only support for table(), trace(), dir() and dirxml() is
+  missing (they can be invoked but do nothing).
+
+  TODO: We need to improve the way in which objects are logged. We need
+        to show their internal structure in the log similarly to Node.JS.
+
+  Our implementation supports Debug, Info, Warning and Error log severity
+  levels. This is identical to what is supported by Chrome and Edge
+  browsers.
+
+  For obvious reasons, we do not support such interactive features of
+  debugging console as collapsed groups or drilling down object structure
+  like browsers do. Nor do we support CSS styling of output. In this
+  respect we are similar to Node.JS.
+
+  OTOH in addition to giving users access to plain version of console
+  output, similar to what Node.JS provides, through JS_GET_CONSOLE_LOG()
+  UDF, we also provide access to extended structured representation of
+  console output in JSON format through JS_GET_CONSOLE_LOG_JSON() UDF.
+  This representation provides additional information (like message
+  timestamps) and enables further flexible processing of the console log.
+  For exampe, one can convert console output to an SQL table form by
+  applying JSON_TABLE() function to this JSON representation.
+*/
+
+#include "js_lang_console.h"
+
+#include <iomanip>
+#include <sstream>
+
+// We use RapidJSON to produce console log in JSON format.
+#ifdef RAPIDJSON_NO_SIZETYPEDEFINE
+#include "my_rapidjson_size_t.h"
+#endif
+#include <rapidjson/prettywriter.h>
+#include <string_with_len.h>
+
+#include "js_lang_core.h"
+
+void Js_console::write_log(Log_level_type level, std::string &&msg,
+                           bool is_group_label) {
+  Log_line line(log_line_clock::now(), level, m_group_stack.size(),
+                get_group_stack_json(), is_group_label, std::move(msg));
+
+  // We read system variable value once, and then use this value
+  // for all checks below to avoid breaking assumptions about buffer
+  // emptiness.
+  const size_t max_log_size = s_max_log_size;
+
+  if (line.get_approx_size() > max_log_size) {
+    /*
+      Extreme case. We are asked to log message so huge that it exceeds
+      console buffer size limit. We handle this unlikely case by clearing
+      the log and adding special dummy message to it instead.
+    */
+    line.group_level = 0;
+    line.group_stack_json = "[]";
+    line.message =
+        "<The message and part of its context have been suppressed as they "
+        "exceed " MAX_CONSOLE_LOG_SIZE_VAR_NAME " limit>";
+
+    m_log.clear();
+    m_approx_log_size = line.get_approx_size();
+    m_log.push_back(std::move(line));
+    return;
+  }
+
+  // We need to remove some old lines from the log buffer if adding new
+  // message will exceed the size limit. Thanks to the above check we
+  // can be sure that this is always possible.
+  while (m_approx_log_size + line.get_approx_size() > max_log_size) {
+    assert(!m_log.empty());
+    m_approx_log_size -= m_log.front().get_approx_size();
+    m_log.pop_front();
+  }
+
+  m_approx_log_size += line.get_approx_size();
+  m_log.push_back(std::move(line));
+}
+
+/**
+  Build message from the arguments of one of console.log() family of JS calls.
+
+  @param prepend_message  String prepend to the built message (or nullptr).
+  @param first_arg        Index of the first argument of JS call to be
+                          processed.
+  @param args             Object representing arguments of JS call.
+
+  @note This method is similar to a combination of Formatter and Printer
+        operations described by Console standard.
+        See: https://console.spec.whatwg.org/#formatter
+
+  @return String with message or std::nullopt in case of error. In the latter
+          case the JS call is also marked as ending with exception.
+*/
+static std::optional<std::string> build_message(
+    const char *prepend_message, int first_arg,
+    const v8::FunctionCallbackInfo<v8::Value> &args) {
+  std::string result;
+  v8::Isolate *isolate = args.GetIsolate();
+  int i = first_arg;
+
+  if (prepend_message != nullptr) result.append(prepend_message);
+
+  // If JS call from console.log() family we are executing has more than
+  // one argument and its first argument is JS String, we need to process
+  // this string, by replacing format specifiers in it with converted
+  // values of later arguments, where conversion procedure for each
+  // argument is prescribed by corresponding specifier.
+  //
+  // So below we will loop through this String from one specifier to
+  // another.
+  if (args.Length() > (i + 1) && args[i]->IsString()) {
+    // As in other places we assume here that conversions of JS string
+    // to UTF8 can't fail (as OOM will abort the process).
+    v8::String::Utf8Value message(isolate, args[i]);
+    const char *chunk_start = *message;
+    const char *end = chunk_start + message.length();
+    ++i;
+
+    while (chunk_start < end) {
+      // We do not need to process specifiers if there are no unprocessed
+      // arguments left. So we simply copy the remainder of the first
+      // argument in this case.
+      if (i >= args.Length()) {
+        result.append(chunk_start, end - chunk_start);
+        break;
+      }
+
+      // Find next format specifier occurrence. Nice that we can use
+      // strchr(..., '%') to do this even for UTF-8 string.
+      const char *pos;
+      pos = strchr(chunk_start, '%');
+
+      // Handle no format specifier case.
+      if (pos == nullptr || pos + 1 >= end) {
+        result.append(chunk_start, end - chunk_start);
+        break;
+      }
+
+      // Copy part of the string until the specifier found.
+      result.append(chunk_start, pos - chunk_start);
+
+      switch (*(pos + 1)) {
+        // %s means that argument should be converted to String.
+        case 's': {
+          v8::TryCatch try_catch(isolate);
+          v8::Local<v8::String> arg_str;
+          if (!(args[i]
+                    ->ToString(isolate->GetCurrentContext())
+                    .ToLocal(&arg_str))) {
+            // Conversion to String might fail. We need to rethrow
+            // error to caller in this case.
+            args.GetReturnValue().Set(try_catch.ReThrow());
+            return std::nullopt;
+          }
+
+          // Again, we assume that conversion of JS String to UTF-8
+          // can't fail (since OOM kills the process).
+          v8::String::Utf8Value val(isolate, arg_str);
+          result.append(*val, val.length());
+          ++i;
+          break;
+        }
+        // %d and %i mean that argument should be converted to integer.
+        // Spec says that this should be done by calling JS parseInt(arg, 10)
+        // function, but we take much simpler approach instead (for now).
+        //
+        // The main difference between two is that parseInt() uses JS
+        // Number (i.e. floating-point) number internally, hence it can
+        // handle bigger numbers than our implementation at the price of
+        // precision loss for values bigger than 2^53-1.
+        //
+        // TODO. Study if it is really necessary and feasible to use
+        //       approach suggested by the standard.
+        case 'd':
+        case 'i': {
+          // Like parseInt() we convert argument to String first.
+          v8::TryCatch try_catch(isolate);
+          v8::Local<v8::String> arg_str;
+          if (!(args[i]
+                    ->ToString(isolate->GetCurrentContext())
+                    .ToLocal(&arg_str))) {
+            args.GetReturnValue().Set(try_catch.ReThrow());
+            return std::nullopt;
+          }
+          // Converting JS String to UTF-8 should not fail (unless OOM).
+          v8::String::Utf8Value val(isolate, arg_str);
+
+          char *str_end;
+          long long arg_i = std::strtoll(*val, &str_end, 10);
+          if (arg_i == 0 && str_end == *val) {
+            result.append("NaN");
+          } else {
+            // 25 is more than enough for any 64-bit int value.
+            char buff[25];
+            snprintf(buff, sizeof(buff), "%lld", arg_i);
+            result.append(buff);
+          }
+          ++i;
+          break;
+        }
+        // %f means that argument should be converted to floating point
+        // number. Again console standard says to use parseFloat(arg, 10),
+        // but we use a bit simpler approach, instead.
+        //
+        // Unlike for %i/%d case the main difference between the standard
+        // and our approach is probably related to how floating point value
+        // is converted to a string.
+        //
+        // TODO. Study if it is really necessary and feasible to use
+        //       approach suggested by the standard.
+        case 'f': {
+          // Like parseFloat() we convert argument to String first.
+          v8::TryCatch try_catch(isolate);
+          v8::Local<v8::String> arg_str;
+          if (!(args[i]
+                    ->ToString(isolate->GetCurrentContext())
+                    .ToLocal(&arg_str))) {
+            args.GetReturnValue().Set(try_catch.ReThrow());
+            return std::nullopt;
+          }
+          // Converting JS String to UTF-8 should not fail (unless OOM).
+          v8::String::Utf8Value val(isolate, arg_str);
+
+          char *str_end;
+          double arg_f = std::strtod(*val, &str_end);
+          if (arg_f == 0 && str_end == *val) {
+            result.append("NaN");
+          } else {
+            // The question about buffer which is sufficient to print
+            // double is non-trivial, so we cheat (for now).
+            std::stringstream f_str;
+            f_str << arg_f;
+            result.append(f_str.str());
+          }
+          ++i;
+          break;
+        }
+        // %O and %o mean that call argument should be treated as object
+        // and the specifier should be replaced with JS generic object
+        // formatting of this object or optimally useful formatting.
+        // This is non-trivial task. For example, Node.JS uses special
+        // util.inspect() function to produce such formatting.
+        //
+        // For now we take simpler approach and use V8 Value::ToDetailString()
+        // method which produces string representation useful for debugging
+        // purposes. Unfortunately, for objects it doesn't show much info.
+        //
+        // TODO: Implement something similar to util.inspect() which will
+        //       print object properties, methods and so on.
+        case 'o':
+        case 'O': {
+          // ToDetailString() should succeed, unless execution is
+          // terminated. Try to handle the latter case gracefully.
+          v8::TryCatch try_catch(isolate);
+          v8::Local<v8::String> arg_det_str;
+          if (!(args[i]
+                    ->ToDetailString(isolate->GetCurrentContext())
+                    .ToLocal(&arg_det_str))) {
+            args.GetReturnValue().Set(try_catch.ReThrow());
+            return std::nullopt;
+          }
+          // Converting JS String to UTF-8 should not fail (unless OOM).
+          v8::String::Utf8Value val(isolate, arg_det_str);
+          result.append(*val, val.length());
+          ++i;
+          break;
+        }
+        // %c indicates that argument contains CSS which should be used to
+        // style further text logged. In our case we simple omit this
+        // specifier and call argument corresponding to it.
+        case 'c': {
+          ++i;
+          break;
+        }
+        // %% is replaced with %. It doesn't consume call argument.
+        case '%': {
+          result.push_back('%');
+          break;
+        }
+        // Not one of supported specifiers. Keep % and char that follows as is.
+        default:
+          result.push_back('%');
+          result.push_back(*(pos + 1));
+          break;
+      }
+      chunk_start = pos + 2;
+    }
+  }
+
+  // In case when there is only one argument or the first argument is not
+  // a String, or there are extra arguments left after processing format
+  // specifiers on the previous stage, we convert these unprocessed
+  // arguments to string representations useful for debugging purposes
+  // and add to result concatenation of these strings separated by ' '.
+  while (i < args.Length()) {
+    // ToDetailString() should succeed, unless execution is
+    // terminated. Try to handle the latter case gracefully.
+    v8::TryCatch try_catch(isolate);
+    v8::Local<v8::String> arg_det_str;
+    if (!(args[i]
+              ->ToDetailString(isolate->GetCurrentContext())
+              .ToLocal(&arg_det_str))) {
+      args.GetReturnValue().Set(try_catch.ReThrow());
+      return std::nullopt;
+    }
+    // Converting JS String to UTF-8 should not fail (unless OOM).
+    v8::String::Utf8Value val(isolate, arg_det_str);
+    if (i > first_arg) result.push_back(' ');
+    result.append(*val, val.length());
+    ++i;
+  }
+  return result;
+}
+
+void Js_console::build_and_write_log(
+    Log_level_type level, const char *prepend_message, int first_arg,
+    const v8::FunctionCallbackInfo<v8::Value> &args) {
+  // Per console standard we should log nothing if our log()-like call
+  // didn't get any arguments.
+  if (prepend_message != nullptr || (args.Length() > first_arg)) {
+    auto opt_log_line = build_message(prepend_message, first_arg, args);
+
+    if (!opt_log_line.has_value()) {
+      // Error while building message, exception object has been stored
+      // in return value already.
+      return;
+    }
+
+    // Get Auth_id_context in which calling JavaScript code is run.
+    //
+    // TODO: Here in other similar places - consider if ther is a better
+    //       way to get console object. Perhaps we can store pointer to
+    //       Auth_id_ctx in global object as internal field?
+    //       Or even pointer to Js_console object itself in our JS
+    //       console object (i.e. "this" of the current JS call).
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+    auth_id_ctx->console.write_log(level, std::move(*opt_log_line));
+  }
+
+  args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+}
+
+void Js_console::prepare_object(v8::Local<v8::Context> context) {
+  v8::Isolate *isolate = context->GetIsolate();
+
+  v8::HandleScope handle_scope(isolate);
+
+  // Replace built-in console object (which doesn't do anything by default) with
+  // out own implementation.
+  //
+  // Due to presence of this built-in we cannot simply add template for our own
+  // console to template for global object.
+  //
+  // TODO: Study pros and cons of using/implementing V8's non-public
+  //       debug::ConsoleDelegate API instead, like D8 does. Perhaps we can
+  //       get support for some format specifiers like %d and %f for free
+  //       thanks to this?
+  //
+  // TODO: Study if console object methods should be made read-only and
+  //       non-deletable.
+  v8::Local<v8::ObjectTemplate> console_templ =
+      v8::ObjectTemplate::New(isolate);
+
+  /*
+    Implementation of console.assert([condition], ...data) call.
+    It is a conditional form of error(...data) call.
+  */
+  auto console_assert_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+    if (args.Length() == 0 || !args[0]->BooleanValue(isolate)) {
+      if (args.Length() > 1) {
+        build_and_write_log(Log_level_type::ERROR, "Assertion failed: ", 1,
+                            args);
+      } else {
+        build_and_write_log(Log_level_type::ERROR, "Assertion failed", 1, args);
+      }
+    }
+  };
+  console_templ->Set(
+      isolate, "assert",
+      v8::FunctionTemplate::New(isolate, console_assert_cb_lambda));
+
+  /*
+    Implementations of console.debug(...data), error(...data), info(...data),
+    log(...data) and warn(...data) calls. They only differ in log level used.
+
+    Also, in our case log() call is just an alias for info() call.
+  */
+  auto console_debug_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    build_and_write_log(Log_level_type::DEBUG, nullptr, 0, args);
+  };
+  console_templ->Set(
+      isolate, "debug",
+      v8::FunctionTemplate::New(isolate, console_debug_cb_lambda));
+
+  auto console_error_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    build_and_write_log(Log_level_type::ERROR, nullptr, 0, args);
+  };
+  console_templ->Set(
+      isolate, "error",
+      v8::FunctionTemplate::New(isolate, console_error_cb_lambda));
+
+  auto console_info_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    build_and_write_log(Log_level_type::INFO, nullptr, 0, args);
+  };
+  console_templ->Set(
+      isolate, "info",
+      v8::FunctionTemplate::New(isolate, console_info_cb_lambda));
+  console_templ->Set(
+      isolate, "log",
+      v8::FunctionTemplate::New(isolate, console_info_cb_lambda));
+
+  auto console_warn_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    build_and_write_log(Log_level_type::WARNING, nullptr, 0, args);
+  };
+  console_templ->Set(
+      isolate, "warn",
+      v8::FunctionTemplate::New(isolate, console_warn_cb_lambda));
+
+  /*
+    Implementation of console.count([label]) call.
+  */
+  auto console_count_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+
+    // Console standard says to use 'default' if no label provided.
+    std::string label("default");
+
+    /*
+      We follow standard JS practice and allow passing to this function
+      more arguments than one argument it should take per specification.
+      We just ignore those extra arguments.
+
+      This allows to directly use this call as a callback to, e.g.
+      Array.prototype.forEach() method.
+    */
+    if (args.Length() > 0) {
+      // Conversion to String might fail. Handle that gracefully
+      // by ensuring that exception generated is passed to caller.
+      v8::TryCatch try_catch(isolate);
+      v8::Local<v8::String> arg_str;
+      if (!(args[0]
+                ->ToString(isolate->GetCurrentContext())
+                .ToLocal(&arg_str))) {
+        args.GetReturnValue().Set(try_catch.ReThrow());
+        return;
+      }
+
+      v8::String::Utf8Value utf8(isolate, arg_str);
+      // Converting JS String to UTF-8 should not fail (unless OOM).
+      label = std::string(*utf8, utf8.length());
+    }
+
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+    auto count = auth_id_ctx->console.count(label);
+
+    std::string log_line;
+    log_line.append(label);
+    log_line.append(": ");
+    log_line.append(std::to_string(count));
+
+    auth_id_ctx->console.write_log(Log_level_type::INFO, std::move(log_line));
+
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  };
+  console_templ->Set(
+      isolate, "count",
+      v8::FunctionTemplate::New(isolate, console_count_cb_lambda));
+
+  /*
+    Implementation of console.countReset([label]) call.
+  */
+  auto console_count_reset_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+
+    // Console standard says to use 'default' if no label provided.
+    std::string label("default");
+
+    // Again we follow standard JS practice and just ignore extra arguments.
+    if (args.Length() > 0) {
+      // Conversion to String might fail. Handle that gracefully
+      // by ensuring that exception generated is passed to caller.
+      v8::TryCatch try_catch(isolate);
+      v8::Local<v8::String> arg_str;
+      if (!(args[0]
+                ->ToString(isolate->GetCurrentContext())
+                .ToLocal(&arg_str))) {
+        args.GetReturnValue().Set(try_catch.ReThrow());
+        return;
+      }
+
+      v8::String::Utf8Value utf8(isolate, arg_str);
+      // Converting JS String to UTF-8 should not fail (unless OOM).
+      label = std::string(*utf8, utf8.length());
+    }
+
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    if (auth_id_ctx->console.count_reset(label)) {
+      std::string log_line;
+      log_line.append(label);
+      log_line.append(": there is no counter to reset");
+      auth_id_ctx->console.write_log(Log_level_type::WARNING,
+                                     std::move(log_line));
+    }
+
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  };
+  console_templ->Set(
+      isolate, "countReset",
+      v8::FunctionTemplate::New(isolate, console_count_reset_cb_lambda));
+
+  /*
+    Implementation of console.group([...label]) and groupCollapsed([...label])
+    calls. The latter is alias for the former in our case.
+  */
+  auto console_group_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    if (args.Length() > 0) {
+      // Build group label using the same logic as we produce
+      // message in log() call.
+      auto opt_group_label = build_message(nullptr, 0, args);
+
+      // In case of error no value is returned, and the exception
+      // object already stored as a return value of the call.
+      if (opt_group_label.has_value()) {
+        auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+        auth_id_ctx->console.start_group(*opt_group_label);
+      }
+    } else {
+      // If no argument is provided we start group with special
+      // null label. The label/group start is not logged to console
+      // in this case.
+      auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+      auth_id_ctx->console.start_group(std::nullopt);
+    }
+
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  };
+  console_templ->Set(
+      isolate, "group",
+      v8::FunctionTemplate::New(isolate, console_group_cb_lambda));
+  console_templ->Set(
+      isolate, "groupCollapsed",
+      v8::FunctionTemplate::New(isolate, console_group_cb_lambda));
+
+  /*
+    Implementation of console.groupEnd() function.
+  */
+  auto console_group_end_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    // We follow standard JS practice and just ignore extra (i.e. all)
+    // arguments.
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+    auth_id_ctx->console.end_group();
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  };
+  console_templ->Set(
+      isolate, "groupEnd",
+      v8::FunctionTemplate::New(isolate, console_group_end_cb_lambda));
+
+  /*
+    Implementation of console.time([label]) call.
+  */
+  auto console_time_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+
+    /*
+      Per standard absent label means 'default' should be used.
+      And again follow standard JS practice and ignore extra arguments.
+    */
+    std::string label("default");
+
+    if (args.Length() > 0) {
+      // Conversion to String might fail. Handle that gracefully
+      // by ensuring that exception generated is passed to caller.
+      v8::TryCatch try_catch(isolate);
+      v8::Local<v8::String> arg_str;
+      if (!(args[0]
+                ->ToString(isolate->GetCurrentContext())
+                .ToLocal(&arg_str))) {
+        args.GetReturnValue().Set(try_catch.ReThrow());
+        return;
+      }
+
+      v8::String::Utf8Value utf8(isolate, arg_str);
+      // Converting JS String to UTF-8 should not fail (unless OOM).
+      label = std::string(*utf8, utf8.length());
+    }
+
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    if (auth_id_ctx->console.start_timer(label)) {
+      std::string log_line;
+      log_line.append(label);
+      log_line.append(": timer has been started already");
+      auth_id_ctx->console.write_log(Log_level_type::WARNING,
+                                     std::move(log_line));
+    }
+
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  };
+  console_templ->Set(
+      isolate, "time",
+      v8::FunctionTemplate::New(isolate, console_time_cb_lambda));
+
+  /*
+    Implementation of console.timeLog([label] [...data]) call.
+  */
+  auto console_time_log_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+
+    // Similarly to time() we use 'default' label if one is not provided.
+    std::string label("default");
+
+    if (args.Length() > 0) {
+      // Conversion to String might fail. Handle that gracefully
+      // by ensuring that exception generated is passed to caller.
+      v8::TryCatch try_catch(isolate);
+      v8::Local<v8::String> arg_str;
+      if (!(args[0]
+                ->ToString(isolate->GetCurrentContext())
+                .ToLocal(&arg_str))) {
+        args.GetReturnValue().Set(try_catch.ReThrow());
+        return;
+      }
+
+      v8::String::Utf8Value utf8(isolate, arg_str);
+      // Converting JS String to UTF-8 should not fail (unless OOM).
+      label = std::string(*utf8, utf8.length());
+    }
+
+    std::stringstream log_line_str;
+    log_line_str << label << ": ";
+
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    auto opt_elapsed = auth_id_ctx->console.get_timer(label);
+
+    if (opt_elapsed.has_value()) {
+      // We output elapsed time in milliseconds, but with microsecond
+      // precision (this is similar to Node.JS).
+      double elapsed =
+          std::chrono::duration_cast<std::chrono::microseconds>(*opt_elapsed)
+              .count() /
+          1000.0;
+
+      log_line_str << std::fixed << std::setprecision(3) << elapsed << " ms";
+
+      // We convert values of 2nd and later arguments to string form useful
+      // for debugging purposes and add to result concatenation of these
+      // strings separated by ' '.
+      int i = 1;
+      while (i < args.Length()) {
+        // Gracefully handle the case when ToDetailString() fails
+        // due to execution termination.
+        v8::TryCatch try_catch(isolate);
+        v8::Local<v8::String> arg_det_str;
+        if (!(args[i]
+                  ->ToDetailString(isolate->GetCurrentContext())
+                  .ToLocal(&arg_det_str))) {
+          args.GetReturnValue().Set(try_catch.ReThrow());
+          return;
+        }
+        // Converting JS String to UTF-8 should not fail (unless OOM).
+        v8::String::Utf8Value val(isolate, arg_det_str);
+
+        log_line_str << ' ' << std::string_view(*val, val.length());
+        ++i;
+      }
+      auth_id_ctx->console.write_log(Log_level_type::INFO,
+                                     std::move(log_line_str.str()));
+    } else {
+      log_line_str << "no such timer";
+      auth_id_ctx->console.write_log(Log_level_type::WARNING,
+                                     std::move(log_line_str.str()));
+    }
+
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  };
+  console_templ->Set(
+      isolate, "timeLog",
+      v8::FunctionTemplate::New(isolate, console_time_log_cb_lambda));
+
+  /*
+    Implementation of console.timeEnd([label]) call.
+  */
+  auto console_time_end_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+
+    /*
+      Similarly to time() we use 'default' label if one is not provided
+      and ignore extra arguments if there are more than one.
+    */
+    std::string label("default");
+
+    if (args.Length() > 0) {
+      // Pass exception to the caller if conversion to String fails.
+      v8::TryCatch try_catch(isolate);
+      v8::Local<v8::String> arg_str;
+      if (!(args[0]
+                ->ToString(isolate->GetCurrentContext())
+                .ToLocal(&arg_str))) {
+        args.GetReturnValue().Set(try_catch.ReThrow());
+        return;
+      }
+
+      // Converting JS String to UTF-8 should not fail (unless OOM).
+      v8::String::Utf8Value utf8(isolate, arg_str);
+      label = std::string(*utf8, utf8.length());
+    }
+
+    std::stringstream log_line_str;
+    log_line_str << label << ": ";
+
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    auto opt_elapsed = auth_id_ctx->console.end_timer(label);
+
+    if (opt_elapsed.has_value()) {
+      // We output elapsed time in milliseconds, but with microsecond
+      // precision (this is similar to Node.JS).
+      double elapsed =
+          std::chrono::duration_cast<std::chrono::microseconds>(*opt_elapsed)
+              .count() /
+          1000.0;
+
+      log_line_str << std::fixed << std::setprecision(3) << elapsed << " ms";
+
+      auth_id_ctx->console.write_log(Log_level_type::INFO,
+                                     std::move(log_line_str.str()));
+    } else {
+      log_line_str << "no such timer";
+      auth_id_ctx->console.write_log(Log_level_type::WARNING,
+                                     std::move(log_line_str.str()));
+    }
+
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  };
+  console_templ->Set(
+      isolate, "timeEnd",
+      v8::FunctionTemplate::New(isolate, console_time_end_cb_lambda));
+
+  /*
+    Implementation of console.clear() call.
+  */
+  auto console_clear_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    v8::Isolate *isolate = args.GetIsolate();
+
+    // Similarly to other calls we follow standard JS practice and ignore
+    // extra arguments, which means all arguments in this case.
+
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    auth_id_ctx->console.clear_log();
+    auth_id_ctx->console.reset_group_stack();
+
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  };
+  console_templ->Set(
+      isolate, "clear",
+      v8::FunctionTemplate::New(isolate, console_clear_cb_lambda));
+
+  /*
+    console.table(), trace(), dir() and dirxml() are not implement yet.
+    So we install no-op handler for them.
+  */
+  auto console_noop_cb_lambda =
+      [](const v8::FunctionCallbackInfo<v8::Value> &args) -> void {
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  };
+  console_templ->Set(
+      isolate, "table",
+      v8::FunctionTemplate::New(isolate, console_noop_cb_lambda));
+  console_templ->Set(
+      isolate, "trace",
+      v8::FunctionTemplate::New(isolate, console_noop_cb_lambda));
+  console_templ->Set(
+      isolate, "dir",
+      v8::FunctionTemplate::New(isolate, console_noop_cb_lambda));
+  console_templ->Set(
+      isolate, "dirxml",
+      v8::FunctionTemplate::New(isolate, console_noop_cb_lambda));
+
+  // Failure to create 'console' object instance probably means
+  // OOM or logic error in our case, so we don't try to handle it
+  // gracefully.
+  v8::Local<v8::Object> console =
+      console_templ->NewInstance(context).ToLocalChecked();
+
+  context->Global()
+      ->Set(context, v8::String::NewFromUtf8Literal(isolate, "console"),
+            console)
+      .Check();  // Set() is not supposed to fail per V8 docs.
+}
+
+std::string Js_console::get_log() const {
+  // TODO: See what users will say about the fact that we print messages with
+  //       Debug level by default (browsers don't do this). Does it create
+  //       too much noise? Perhaps separate less noisy version of UDF
+  //       should be implemented or alternatively we should not print
+  //       Debug messages by default, but make them available through
+  //       separate UDF with _VERBOSE suffix instead.
+  std::string result;
+
+  for (const auto &line : m_log) {
+    constexpr size_t GROUP_INDENT_SIZE = 2;
+    // TODO: Consider indenting all lines from the message, and not only
+    //       the part before first \n (Node.JS does this).
+    //       Requires splitting message on \n before output.
+    result.append(GROUP_INDENT_SIZE * line.group_level, ' ');
+    result.append(line.message);
+    result.append("\n");
+  }
+
+  return result;
+}
+
+// Define convenience aliases for RapidJSON types.
+using Json_string_buffer = rapidjson::StringBuffer;
+using Json_writer = rapidjson::PrettyWriter<Json_string_buffer>;
+
+/**
+  Helper which adds string representation of log entry timestamp into JSON.
+*/
+static void put_ts(Json_writer *json_writer, Js_console::log_line_ts_type ts) {
+  // Prepare broken-down rerpresentation timestamp in SYSTEM time zone.
+  time_t t = Js_console::log_line_clock::to_time_t(ts);
+  struct tm t_tm;
+  localtime_r(&t, &t_tm);
+
+  // Calculate fractional part of timestamp in microseconds.
+  auto micros = std::chrono::duration_cast<std::chrono::microseconds>(
+                    ts - floor<std::chrono::seconds>(ts))
+                    .count();
+
+  char ts_buff[sizeof("YYYY-MM-DD HH:MM:SS.FFFFFF")];
+  size_t dot_pos = strftime(ts_buff, sizeof(ts_buff), "%F %T.", &t_tm);
+  snprintf(ts_buff + dot_pos, sizeof(ts_buff) - dot_pos, "%06u",
+           static_cast<unsigned int>(micros));
+
+  json_writer->String(ts_buff);
+}
+
+/**
+  Helper which adds string representation of console log level into JSON.
+*/
+static void put_log_level(Json_writer *json_writer,
+                          Js_console::Log_level_type level) {
+  switch (level) {
+    case Js_console::Log_level_type::ERROR:
+      json_writer->String(STRING_WITH_LEN("Error"));
+      break;
+    case Js_console::Log_level_type::WARNING:
+      json_writer->String(STRING_WITH_LEN("Warning"));
+      break;
+    case Js_console::Log_level_type::INFO:
+      json_writer->String(STRING_WITH_LEN("Info"));
+      break;
+    case Js_console::Log_level_type::DEBUG:
+      json_writer->String(STRING_WITH_LEN("Debug"));
+      break;
+    default:
+      assert(false);
+      json_writer->String(STRING_WITH_LEN(""));  // Safety.
+      break;
+  }
+}
+
+std::string Js_console::get_group_stack_json() const {
+  // Use fast-path for the most common case.
+  if (m_group_stack.empty()) return std::string("[]");
+
+  Json_string_buffer string_buffer;
+  Json_writer json_writer(string_buffer);
+  // We want to use more compact representation for groups array.
+  json_writer.SetFormatOptions(rapidjson::kFormatSingleLineArray);
+
+  json_writer.StartArray();
+  for (const auto &group : m_group_stack) {
+    if (group.has_value()) {
+      json_writer.String(*group);
+    } else {
+      json_writer.Null();
+    }
+  }
+  json_writer.EndArray();
+
+  return std::string(string_buffer.GetString(), string_buffer.GetSize());
+}
+
+std::string Js_console::get_log_json() const {
+  Json_string_buffer string_buffer;
+  Json_writer json_writer(string_buffer);
+
+  json_writer.StartArray();
+
+  for (const auto &line : m_log) {
+    json_writer.StartObject();
+
+    json_writer.Key(STRING_WITH_LEN("timestamp"));
+    put_ts(&json_writer, line.ts);
+
+    json_writer.Key(STRING_WITH_LEN("level"));
+    put_log_level(&json_writer, line.level);
+
+    if (line.group_level != 0) {
+      json_writer.Key(STRING_WITH_LEN("groups"));
+      json_writer.RawValue(line.group_stack_json.c_str(),
+                           line.group_stack_json.length(),
+                           rapidjson::kArrayType);
+    }
+
+    if (line.is_group_label) {
+      json_writer.Key(STRING_WITH_LEN("isGroupLabel"));
+      json_writer.Bool(true);
+    }
+
+    json_writer.Key(STRING_WITH_LEN("message"));
+    json_writer.String(line.message);
+
+    json_writer.EndObject();
+  }
+
+  json_writer.EndArray();
+
+  return std::string(string_buffer.GetString(), string_buffer.GetSize());
+}
+
+constexpr unsigned int MAX_LOG_SIZE_DEFAULT = 1024 * 1024;
+unsigned int Js_console::s_max_log_size = MAX_LOG_SIZE_DEFAULT;
+
+bool Js_console::register_sys_var() {
+  INTEGRAL_CHECK_ARG(uint) max_console_log_size_check;
+
+  // We use 1Mb as a default for max console buffer size which translates
+  // to approximately 10000 of lines. It should be enough for most of uses
+  // (e.g. it is a common default for terminal backscroll buffer on Linux).
+  max_console_log_size_check.def_val = MAX_LOG_SIZE_DEFAULT;
+  // Console Standard suggests that we should be able to buffer at least
+  // on the order of 100 lines, which is close enough to 10K,
+  max_console_log_size_check.min_val = 10 * 1024;
+  // 1Gb of console buffer should be enough for everyone!
+  max_console_log_size_check.max_val = 1024 * 1024 * 1024;
+  max_console_log_size_check.blk_sz = 0;
+
+  if (mysql_service_component_sys_variable_register->register_variable(
+          CURRENT_COMPONENT_NAME_STR, MAX_CONSOLE_LOG_SIZE_VAR_NAME,
+          PLUGIN_VAR_INT | PLUGIN_VAR_UNSIGNED,
+          "Approximate maximum size of messages in bytes which are allowed "
+          "to be buffered by JS console for each connection/user pair.",
+          nullptr, nullptr, (void *)&max_console_log_size_check,
+          (void *)&Js_console::s_max_log_size)) {
+    // Implementation of component_sys_variable_register service is non-trivial,
+    // and can fail for reasons other than OOM, so we play safe and try to
+    // handle error gracefully here.
+    my_error(ER_LANGUAGE_COMPONENT, MYF(0),
+             "Can't register " MAX_CONSOLE_LOG_SIZE_VAR_NAME
+             " system variable for " CURRENT_COMPONENT_NAME_STR " component.");
+    return true;
+  }
+
+  return false;
+}
+
+bool Js_console::unregister_sys_var() {
+  if (mysql_service_component_sys_variable_unregister->unregister_variable(
+          CURRENT_COMPONENT_NAME_STR, "max_console_log_size")) {
+    // The above should not fail normally. Still we play safe.
+    my_error(ER_LANGUAGE_COMPONENT, MYF(0),
+             "Can't unregister " MAX_CONSOLE_LOG_SIZE_VAR_NAME
+             " system variable for " CURRENT_COMPONENT_NAME_STR " component.");
+    return true;
+  }
+  return false;
+}

--- a/components/js_lang/js_lang_console.h
+++ b/components/js_lang/js_lang_console.h
@@ -1,0 +1,303 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights
+   reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+/*
+  This and corresponding .cc file contain implementation of debugging console
+  support for our JS routines.
+
+  See also comment for js_lang_console.cc file for high-level design
+  considerations for this debugging console implementation.
+*/
+
+#ifndef COMPONENT_JS_LANG_JS_LANG_CONSOLE_H
+#define COMPONENT_JS_LANG_JS_LANG_CONSOLE_H
+
+#include <chrono>
+#include <deque>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <v8.h>
+
+/**
+  Class which represents JS debugging console instance for specific
+  user and connection pair.
+*/
+class Js_console {
+ public:
+  /**
+    Enum type for severity level of messages stored in console log.
+
+    @note This is really an implementation detail, it is public only to
+          simplify implementation of JSON printer for this type.
+  */
+  enum class Log_level_type { ERROR, WARNING, INFO, DEBUG };
+
+  /**
+    Clock and timestamp types for messages stored in console log.
+
+    These are really implementation details, they are public only to
+    simplify implementation of JSON printer for timestamps.
+  */
+  using log_line_clock = std::chrono::system_clock;
+  using log_line_ts_type = log_line_clock::time_point;
+
+  // Use default implementation of ctor.
+  Js_console() = default;
+
+  // Block default copy/move semantics.
+  Js_console(Js_console const &rhs) = delete;
+  Js_console(Js_console &&rhs) = delete;
+  Js_console &operator=(Js_console const &rhs) = delete;
+  Js_console &operator=(Js_console &&rhs) = delete;
+
+  /** Prepare 'console' object and its methods for the JS context. */
+  static void prepare_object(v8::Local<v8::Context> context);
+
+  /** Get simplified version of console log contents. */
+  std::string get_log() const;
+
+  /** Get full version of console log contents in JSON format. */
+  std::string get_log_json() const;
+
+  /** Clear console log. Returns number of messages which were removed. */
+  size_t clear_log() {
+    size_t result = m_log.size();
+    m_approx_log_size = 0;
+    m_log.clear();
+    m_log.shrink_to_fit();
+    return result;
+  }
+
+  /**
+    Register/unregister system variable which controls JS console
+    maximum log size.
+
+    @retval False - Success.
+    @retval True  - Failure (error has been reported).
+  */
+  static bool register_sys_var();
+  static bool unregister_sys_var();
+
+ private:
+  /**
+    Helper struct which represents console log entry/bundles all the
+    information which we store for each message logged to console.
+  */
+  struct Log_line {
+    log_line_ts_type ts;
+    Log_level_type level;
+    size_t group_level;
+    std::string group_stack_json;
+    bool is_group_label;
+    std::string message;
+
+    Log_line(log_line_ts_type ts_arg, Log_level_type level_arg,
+             size_t group_level_arg, std::string &&group_stack_json_arg,
+             bool group_label_arg, std::string &&message_arg)
+        : ts(ts_arg),
+          level(level_arg),
+          group_level(group_level_arg),
+          group_stack_json(std::move(group_stack_json_arg)),
+          is_group_label(group_label_arg),
+          message(std::move(message_arg)) {}
+
+    // Use default implementation of move constructor.
+    Log_line(Log_line &&rhs) = default;
+    Log_line &operator=(Log_line &&rhs) = delete;
+
+    // Block default copy semantics.
+    Log_line(Log_line const &rhs) = delete;
+    Log_line &operator=(Log_line const &rhs) = delete;
+
+    /**
+      Get approximate size of console log entry for the purpose of
+      limiting log buffering.
+    */
+    size_t get_approx_size() const {
+      return group_stack_json.length() + message.length();
+    }
+  };
+
+  /**
+    Clock which is used by time()/timeLog()/timeEnd() series of JS calls
+    to measure time elapsed between them.
+  */
+  using timer_clock = std::chrono::steady_clock;
+
+  /** Write string message with specified severity level to console log. */
+  void write_log(Log_level_type level, std::string &&msg,
+                 bool is_group_label = false);
+
+  /**
+    Build message from the arguments of one of console.log() family of JS
+    calls and write it to the console log.
+
+    @param level            Log level to use.
+    @param prepend_message  String prepend to the built message before
+                            writing (or nullptr).
+    @param first_arg        Index of the first argument of JS call to
+                            be processed.
+    @param args             Object representing arguments and return value
+                            of JS call.
+
+    @note This helper implements core of console.log(), info(), error() and
+          some other similar JS calls.
+  */
+  static void build_and_write_log(
+      Log_level_type level, const char *prepend_message, int first_arg,
+      const v8::FunctionCallbackInfo<v8::Value> &args);
+
+  /**
+    Increment counter in console's counters table for the label.
+
+    @return Updated counter value.
+  */
+  size_t count(const std::string &label) { return ++(m_counters[label]); }
+
+  /**
+    'Reset' counter in console's counters table for the label.
+
+    @retval False on success.
+    @retval True if no counter were present in the table for the label.
+
+    @note Console standard says that countReset() call should simply
+          reset counter table for label to 0. However, implementations,
+          like browsers or Node.JS, delete entry from the counters table
+          instead. We stick to the latter approach and delete entry
+          instead of zeroing it out as well.
+  */
+  bool count_reset(const std::string &label) {
+    auto it = m_counters.find(label);
+    if (it == m_counters.end()) return true;
+    m_counters.erase(it);
+    return false;
+  }
+
+  /**
+    Push new group with the label provided to the top of console group stack,
+    if label is present add log message with group label to the console.
+  */
+  void start_group(const std::optional<std::string> &&label) {
+    if (label.has_value()) {
+      std::string label_msg(*label);
+      write_log(Log_level_type::INFO, std::move(label_msg), true);
+    }
+    m_group_stack.push_back(std::move(label));
+  }
+
+  /** Pop group from the top of console group stack, if present. */
+  void end_group() {
+    if (!m_group_stack.empty()) m_group_stack.pop_back();
+  }
+
+  /** Reset console group stack. */
+  void reset_group_stack() { m_group_stack.clear(); }
+
+  /** Get JSON array representing current state of console group stack. */
+  std::string get_group_stack_json() const;
+
+  /**
+    Start timer and add it to console timers table under the label.
+
+    @retval False - success.
+    @retval True - there is already timer for this label in the table.
+  */
+  bool start_timer(const std::string &label) {
+    auto it = m_timers.find(label);
+    if (it != m_timers.end()) return true;
+    m_timers.emplace(label, timer_clock::now());
+    return false;
+  }
+
+  /**
+    Get time elapsed for the timer with the label.
+
+    @return Elapsed time or std::nullopt if there is no timer active for
+            the label.
+  */
+  std::optional<timer_clock::duration> get_timer(const std::string &label) {
+    auto it = m_timers.find(label);
+    if (it == m_timers.end()) return std::nullopt;
+    return (timer_clock::now() - it->second);
+  }
+
+  /**
+    Stop timer for the label (and delete it from timers table).
+
+    @return Elapsed time or std::nullopt if there is no timer active for
+            the label.
+  */
+  std::optional<timer_clock::duration> end_timer(const std::string &label) {
+    auto it = m_timers.find(label);
+    if (it == m_timers.end()) return std::nullopt;
+    auto result = timer_clock::now() - it->second;
+    m_timers.erase(it);
+    return result;
+  }
+
+  /**
+    Buffered console log lines.
+
+    @note New lines are added to the back of the buffer. Old lines are
+          removed from its front once limit on size of buffered log lines
+          is exceeded.
+  */
+  std::deque<Log_line> m_log;
+
+  /**
+    Approximate size of log lines which are buffered (in bytes).
+
+    @note We track approximate size, instead of exact one, since it is hard
+          to define what actually exact size means. The exact size of memory
+          representation doesn't make much sense to users, and size of
+          user-visible representation may vary. So we go with good enough
+          approximate size instead.
+  */
+  size_t m_approx_log_size = 0;
+
+  /**
+    Console's counters table (aka counter map).
+
+    Used by JS console.count() and countReset() calls.
+  */
+  std::unordered_map<std::string, size_t> m_counters;
+
+  /**
+    Console's timers table.
+
+    Used by JS console.time(), timeLog() and timeEnd() calls.
+  */
+  std::unordered_map<std::string, timer_clock::time_point> m_timers;
+
+  /**
+    Current group stack.
+
+    Controlled by JS console.group(), groupCollapsed() and groupEnd() calls.
+  */
+  std::vector<std::optional<std::string>> m_group_stack;
+
+  /**
+    Approximate maximum size of console log lines which can be buffered
+    (in bytes).
+  */
+  static unsigned int s_max_log_size;
+};
+
+#endif /* COMPONENT_JS_LANG_JS_LANG_CONSOLE_H */

--- a/components/js_lang/js_lang_core.cc
+++ b/components/js_lang/js_lang_core.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+/* Copyright (c) 2023, 2025 Percona LLC and/or its affiliates. All rights
    reserved.
 
    This program is free software; you can redistribute it and/or
@@ -679,5 +679,15 @@ bool unregister_create_privilege() {
              " component.");
     return true;
   }
+  return false;
+}
+
+bool register_sys_vars() {
+  if (Js_console::register_sys_var()) return true;
+  return false;
+}
+
+bool unregister_sys_vars() {
+  if (Js_console::unregister_sys_var()) return true;
   return false;
 }

--- a/components/js_lang/js_lang_core.h
+++ b/components/js_lang/js_lang_core.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+/* Copyright (c) 2023, 2025 Percona LLC and/or its affiliates. All rights
    reserved.
 
    This program is free software; you can redistribute it and/or
@@ -34,6 +34,7 @@
 #include <mysql/components/services/language_service.h>  // stored_program_handle
 
 #include "js_lang_common.h"
+#include "js_lang_console.h"
 
 /**
   Representation of V8 engine in our component.
@@ -252,6 +253,9 @@ class Js_thd {
     */
     v8::Global<v8::Context> context;
 
+    /** JS console for the specific connection and user pair. */
+    Js_console console;
+
     Auth_id_context(const std::shared_ptr<Js_isolate> &iso_ptr,
                     v8::Local<v8::Context> &ctx)
         : isolate_ptr(iso_ptr), context(iso_ptr->get_v8_isolate(), ctx) {}
@@ -324,7 +328,13 @@ class Js_thd {
 
       v8::HandleScope handle_scope(isolate);
 
+      // Create JS context with our custom built-ins.
+      //
+      // First, create context using global object template.
       v8::Local<v8::Context> context = v8::Context::New(isolate);
+
+      // Then, setup our custom 'console' object.
+      Js_console::prepare_object(context);
 
       auto r = m_auth_id_contexts.try_emplace(auth_id, isolate_ptr, context);
 
@@ -667,5 +677,21 @@ bool register_udfs();
   @retval True  - Failure (error has been reported).
 */
 bool unregister_udfs();
+
+/**
+  Register system variables allowing to control some of JS routines behavior.
+
+  @retval False - Success.
+  @retval True  - Failure (error has been reported).
+*/
+bool register_sys_vars();
+
+/**
+  Unregister system variables allowing to control some of JS routines behavior.
+
+  @retval False - Success.
+  @retval True  - Failure (error has been reported).
+*/
+bool unregister_sys_vars();
 
 #endif /* COMPONENT_JS_LANG_JS_LANG_CORE_H */

--- a/components/js_lang/js_lang_udf.cc
+++ b/components/js_lang/js_lang_udf.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+/* Copyright (c) 2023, 2025 Percona LLC and/or its affiliates. All rights
    reserved.
 
    This program is free software; you can redistribute it and/or
@@ -43,6 +43,22 @@ static constexpr char UTF8_DEFAULT_COLLATION_NAME[] = "utf8mb4_0900_ai_ci";
   (including implicit temporary table case).
 */
 static constexpr std::size_t MAX_TEXT_RESULT_LENGTH = ((1 << 16) - 1) / 4;
+
+/**
+  Max result length for UDFs which return string values and for which we
+  decided to return results of LONGTEXT type (as opposed to TINYTEXT, TEXT,
+  or MEDIUMTEXT). It's 2^32-1 (max LONGTEXT length in bytes) divided by 4
+  (max number of bytes per utf8mb4_* character).
+
+  Note that SQL layer tries to cap max return value size reported by UDF
+  at MAX_BLOB_WIDTH, which is supposed to be mapped to MEDIUMTEXT size.
+  However, since at some point the capped value multiplied by 4 (max
+  number of by per utf8mb4 character) we still end up with LONGTEXT type.
+  If this (bug?) ever fixed UDF will start returning MEDIUMTEXT type instead
+  of the correct one.
+*/
+static constexpr std::size_t MAX_LONGTEXT_RESULT_LENGTH =
+    ((1ULL << 32) - 1) / 4;
 
 /**
   Implementation of JS_GET_LAST_ERROR() UDF for getting error message for the
@@ -159,13 +175,128 @@ class js_clear_last_error_impl {
   }
 };
 
+/**
+  Implementation of JS_GET_CONSOLE_LOG() UDF for getting console output
+  for the connection and the current user pair.
+*/
+class js_get_console_log_impl {
+ public:
+  js_get_console_log_impl(mysqlpp::udf_context &ctx) {
+    // TODO: Same here consider supporting retrieval of console log
+    // for different users.
+    if (ctx.get_number_of_args() != 0)
+      throw std::invalid_argument{"Wrong argument list: should be ()"};
+
+    ctx.mark_result_nullable(false);
+    ctx.mark_result_const(false);
+
+    /*
+      Probably, in most cases buffered console output should fit into
+      MEDIUMTEXT type (i.e. be smaller than < 16Mb). This works well
+      for default value of js_lang.max_console_log_size variable, which
+      caps maximum approximate size of buffered console messages.
+      However, the maximum supported value for this variabel is 1Gb
+      so we resort to using LONGTEXT type.
+    */
+    ctx.set_result_max_length(MAX_LONGTEXT_RESULT_LENGTH);
+
+    const char *const UTF8_DEFAULT_COLLATION_NAME = "utf8mb4_0900_ai_ci";
+    mysqlpp::udf_context_charset_extension charset_ext{
+        mysql_service_mysql_udf_metadata};
+    charset_ext.set_return_value_collation(ctx, UTF8_DEFAULT_COLLATION_NAME);
+  }
+  mysqlpp::udf_result_t<STRING_RESULT> calculate(const mysqlpp::udf_context &) {
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    // Handle the case when JavaScript was never run for this user and/or
+    // this connection.
+    if (auth_id_ctx == nullptr) return "";
+
+    return auth_id_ctx->console.get_log();
+  }
+};
+
+/**
+  Implementation of JS_GET_CONSOLE_LOG_JSON() UDF for getting console
+  output in JSON format for the connection and the current user pair.
+*/
+class js_get_console_log_json_impl {
+ public:
+  js_get_console_log_json_impl(mysqlpp::udf_context &ctx) {
+    // TODO: Same here consider supporting retrieval of console log
+    // for different users.
+    if (ctx.get_number_of_args() != 0)
+      throw std::invalid_argument{"Wrong argument list: should be ()"};
+
+    ctx.mark_result_nullable(false);
+    ctx.mark_result_const(false);
+
+    /*
+      Use LONGTEXT as a type of return value for this UDF.
+
+      Since JSON representation might add quite some overhead to the log
+      message size, shorter MEDIUMTEXT type (which can store up to 16Mb)
+      might not be ehough to store JSON of console log output which fits
+      within default 1Mb value of js_lang.max_console_log_size variable.
+    */
+    ctx.set_result_max_length(MAX_LONGTEXT_RESULT_LENGTH);
+
+    const char *const UTF8_DEFAULT_COLLATION_NAME = "utf8mb4_0900_ai_ci";
+    mysqlpp::udf_context_charset_extension charset_ext{
+        mysql_service_mysql_udf_metadata};
+    charset_ext.set_return_value_collation(ctx, UTF8_DEFAULT_COLLATION_NAME);
+  }
+  mysqlpp::udf_result_t<STRING_RESULT> calculate(const mysqlpp::udf_context &) {
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    // Handle the case when JS was never run for this user and/or
+    // this connection.
+    if (auth_id_ctx == nullptr) return "[\n]";
+
+    return auth_id_ctx->console.get_log_json();
+  }
+};
+
+/**
+  Implementation of JS_CLEAR_CONSOLE_LOG() UDF for clearing contents of console
+  for the connection and the current user pair.
+*/
+class js_clear_console_log_impl {
+ public:
+  js_clear_console_log_impl(mysqlpp::udf_context &ctx) {
+    // TODO: Same here consider supporting clearing of console log for
+    // different users.
+    if (ctx.get_number_of_args() != 0)
+      throw std::invalid_argument{"Wrong argument list: should be ()"};
+
+    ctx.mark_result_nullable(false);
+    ctx.mark_result_const(false);
+  }
+  mysqlpp::udf_result_t<INT_RESULT> calculate(const mysqlpp::udf_context &) {
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    // Handle the case when JS was never run for this user and/or
+    // this connection.
+    if (auth_id_ctx == nullptr) return 0;
+
+    return auth_id_ctx->console.clear_log();
+  }
+};
+
 DECLARE_STRING_UDF_AUTO(js_get_last_error)
 DECLARE_STRING_UDF_AUTO(js_get_last_error_info)
 DECLARE_INT_UDF_AUTO(js_clear_last_error)
+DECLARE_STRING_UDF_AUTO(js_get_console_log)
+DECLARE_STRING_UDF_AUTO(js_get_console_log_json)
+DECLARE_INT_UDF_AUTO(js_clear_console_log)
 
 static std::array udfs{DECLARE_UDF_INFO_AUTO(js_get_last_error),
                        DECLARE_UDF_INFO_AUTO(js_get_last_error_info),
-                       DECLARE_UDF_INFO_AUTO(js_clear_last_error)};
+                       DECLARE_UDF_INFO_AUTO(js_clear_last_error),
+                       DECLARE_UDF_INFO_AUTO(js_get_console_log),
+                       DECLARE_UDF_INFO_AUTO(js_get_console_log_json),
+                       DECLARE_UDF_INFO_AUTO(js_clear_console_log)};
+
 using udf_bitset_type = mysqlpp::udf_bitset<std::tuple_size_v<decltype(udfs)>>;
 static udf_bitset_type registered_udfs;
 

--- a/mysql-test/suite/component_js_lang/r/js_lang_console.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_console.result
@@ -1,0 +1,2485 @@
+# Prepare playground.
+INSTALL COMPONENT 'file://component_js_lang';
+GRANT CREATE_JS_ROUTINE ON *.* TO root@localhost;
+#
+# 0) Some basic tests,
+#
+CREATE PROCEDURE p1() LANGUAGE JS AS $$ console.log("Test!") $$;
+#
+# JS_GET_CONSOLE_LOG() and JS_GET_CONSOLE_LOG_JSON() prior to
+# any writes to console.
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[]
+#
+# Let us do some writes to console and check output.
+CALL p1();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Test!
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Test!"
+    }
+]
+CALL p1();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Test!
+Test!
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Test!"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Test!"
+    }
+]
+#
+# Also let us test JS_CLEAR_CONSOLE_LOG().
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+2
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[]
+DROP PROCEDURE p1;
+#
+# 1) Test coverage for console.log().
+#
+#
+# 1.1) console.log() - empty argument list case.
+#
+# Nothing (not even an empty line) should be added to the
+# console output in this case.
+CREATE PROCEDURE p_empty() LANGUAGE JS AS $$ console.log() $$;
+CALL p_empty();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+DROP PROCEDURE p_empty;
+#
+# 1.2) console.log(val1) - case with a single non-String argument.
+#
+# Line with a representation of argument which is useful for
+# debugging purposes is added to the console output in this case.
+# It is not necessarily the same thing as result of argument
+# conversion to String. It might also change without much notice.
+#
+CREATE PROCEDURE p_val1() LANGUAGE JS AS $$
+console.log(null);
+console.log(undefined);
+console.log(10);
+console.log(12.5);
+console.log(BigInt(100));
+console.log(true);
+console.log([1, 2, 3]);
+console.log({ x: 1, y: "alpha", m() { return 1; } });
+console.log(function (a) { return a; });
+console.log(new Uint8Array([0, 1, 2, 3]));
+$$|
+CALL p_val1();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+null
+undefined
+10
+12.5
+100
+true
+[object Array]
+#<Object>
+function (a) { return a; }
+[object Uint8Array]
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+10
+DROP PROCEDURE p_val1;
+#
+# Conversion to such debugging representation should work even
+# when conversion to String is broken.
+CREATE PROCEDURE p_val1_err() LANGUAGE JS AS $$ console.log({ toString() { throw "Oops!" } }) $$;
+CALL p_val1_err();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+[object Object]
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+DROP PROCEDURE p_val1_err;
+#
+# 1.3) console.log(val1, ..., valN) - case with a multiple arguments
+#      (where first argument is non-String).
+#
+# Line with concatenated represenations of arguments which are useful for
+# debugging separated by spaces added to the console output.
+CREATE PROCEDURE p_valN() LANGUAGE JS AS $$
+console.log(null, undefined);
+console.log(10, 12.5, BigInt(100));
+console.log(false, "alpha", "0.1", "123");
+console.log([1, 2, 3], { x: 1, y: "alpha", m() { return 1; } },
+(function (a) { return a; }), new Uint8Array([0, 1, 2, 3]));
+$$|
+CALL p_valN();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+null undefined
+10 12.5 100
+false alpha 0.1 123
+[object Array] #<Object> function (a) { return a; } [object Uint8Array]
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+4
+DROP PROCEDURE p_valN;
+#
+# 1.4) console.log(msg) - case with a single String argument.
+#
+# Line with the verbatim argument is added to console log.
+# Format specifiers which are present in the string are
+# kept as is (unlike in the next case).
+CREATE PROCEDURE p_str1() LANGUAGE JS AS $$
+console.log("");
+console.log("alpha");
+console.log("%s %d %i %f %o %O %c %%");
+$$|
+CALL p_str1();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+alpha
+%s %d %i %f %o %O %c %%
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+3
+DROP PROCEDURE p_str1;
+#
+# 1.5) console.log(msg, val1, ... valN) - case with multiple arguments
+#      where the first one is a String.
+#
+# The first argument might contain format specifiers which are replaced
+# by converted values of later arguments, where conversion procedure for
+# each argument is prescribed by corresponding specifier.
+CREATE PROCEDURE p_strN() LANGUAGE JS AS $$
+const arg_desc = ["null", "undefined", "10", "12.5", "BigInt(123)", "true",
+"'alpha'", "'0.6'", "'123'", "'123abc'",
+"[1, 2, 3]", "({ x: 1, y: 'alpha' })",
+"({ toString() { return 'Wow!'; } })",
+"({ toString() { return '123.45'; } })",
+"(function (a) { return a; })",
+"new Uint8Array([0, 1, 2, 3])"];
+const arg_vals = arg_desc.map((s) => eval(s));
+function test_specifier(spec) {
+const msg_string =  arg_desc.reduce(
+(m, d) => m + " Arg <" + d + "> converted <" + spec + "> ",
+"");
+console.log("Testing specifier :", spec);
+console.log(msg_string, ...arg_vals);
+}
+// %s specifier is replaced with argument value converted to String.
+test_specifier("%s");
+// %d and %i specifiers are replaced with argument value converted to integer.
+// Conversion is done by converting to String first and then to integer.
+test_specifier("%d");
+test_specifier("%i");
+// %f specifier is replaced with argument value converted to floating-point
+// number. Conversion is done by converting to String first and then to
+// floating-point number.
+test_specifier("%f");
+// %o and %O specifiers are replaced with argument converted to representation
+// useful for debugging.
+test_specifier("%o");
+test_specifier("%O");
+// %c is supposed to allow specify CSS for the following text. This does not
+// make sense in our case. So this specifier is omitted and corresponding
+// argument is skipped.
+test_specifier("%c");
+// %% is replaced with a single %. Argument is not consumed.
+test_specifier("%%");
+// Case when there are more specifiers than arguments.
+// Specifiers without corresponding arguments are
+// kept in the message as is.
+console.log("1 : %s 2 : %s 3 : %s", "a", "b");
+// Case when there are more arguments than specifiers.
+// Representations of extra arguments useful for debugging are
+// appended at the end.
+console.log("1 : %s", "a", "b", "c");
+// Case when message does not contain any specifiers at all.
+console.log("No specifiers:", "a","b","c");
+$$|
+CALL p_strN();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Testing specifier : %s
+ Arg <null> converted <null>  Arg <undefined> converted <undefined>  Arg <10> converted <10>  Arg <12.5> converted <12.5>  Arg <BigInt(123)> converted <123>  Arg <true> converted <true>  Arg <'alpha'> converted <alpha>  Arg <'0.6'> converted <0.6>  Arg <'123'> converted <123>  Arg <'123abc'> converted <123abc>  Arg <[1, 2, 3]> converted <1,2,3>  Arg <({ x: 1, y: 'alpha' })> converted <[object Object]>  Arg <({ toString() { return 'Wow!'; } })> converted <Wow!>  Arg <({ toString() { return '123.45'; } })> converted <123.45>  Arg <(function (a) { return a; })> converted <function (a) { return a; }>  Arg <new Uint8Array([0, 1, 2, 3])> converted <0,1,2,3> 
+Testing specifier : %d
+ Arg <null> converted <NaN>  Arg <undefined> converted <NaN>  Arg <10> converted <10>  Arg <12.5> converted <12>  Arg <BigInt(123)> converted <123>  Arg <true> converted <NaN>  Arg <'alpha'> converted <NaN>  Arg <'0.6'> converted <0>  Arg <'123'> converted <123>  Arg <'123abc'> converted <123>  Arg <[1, 2, 3]> converted <1>  Arg <({ x: 1, y: 'alpha' })> converted <NaN>  Arg <({ toString() { return 'Wow!'; } })> converted <NaN>  Arg <({ toString() { return '123.45'; } })> converted <123>  Arg <(function (a) { return a; })> converted <NaN>  Arg <new Uint8Array([0, 1, 2, 3])> converted <0> 
+Testing specifier : %i
+ Arg <null> converted <NaN>  Arg <undefined> converted <NaN>  Arg <10> converted <10>  Arg <12.5> converted <12>  Arg <BigInt(123)> converted <123>  Arg <true> converted <NaN>  Arg <'alpha'> converted <NaN>  Arg <'0.6'> converted <0>  Arg <'123'> converted <123>  Arg <'123abc'> converted <123>  Arg <[1, 2, 3]> converted <1>  Arg <({ x: 1, y: 'alpha' })> converted <NaN>  Arg <({ toString() { return 'Wow!'; } })> converted <NaN>  Arg <({ toString() { return '123.45'; } })> converted <123>  Arg <(function (a) { return a; })> converted <NaN>  Arg <new Uint8Array([0, 1, 2, 3])> converted <0> 
+Testing specifier : %f
+ Arg <null> converted <NaN>  Arg <undefined> converted <NaN>  Arg <10> converted <10>  Arg <12.5> converted <12.5>  Arg <BigInt(123)> converted <123>  Arg <true> converted <NaN>  Arg <'alpha'> converted <NaN>  Arg <'0.6'> converted <0.6>  Arg <'123'> converted <123>  Arg <'123abc'> converted <123>  Arg <[1, 2, 3]> converted <1>  Arg <({ x: 1, y: 'alpha' })> converted <NaN>  Arg <({ toString() { return 'Wow!'; } })> converted <NaN>  Arg <({ toString() { return '123.45'; } })> converted <123.45>  Arg <(function (a) { return a; })> converted <NaN>  Arg <new Uint8Array([0, 1, 2, 3])> converted <0> 
+Testing specifier : %o
+ Arg <null> converted <null>  Arg <undefined> converted <undefined>  Arg <10> converted <10>  Arg <12.5> converted <12.5>  Arg <BigInt(123)> converted <123>  Arg <true> converted <true>  Arg <'alpha'> converted <alpha>  Arg <'0.6'> converted <0.6>  Arg <'123'> converted <123>  Arg <'123abc'> converted <123abc>  Arg <[1, 2, 3]> converted <[object Array]>  Arg <({ x: 1, y: 'alpha' })> converted <#<Object>>  Arg <({ toString() { return 'Wow!'; } })> converted <[object Object]>  Arg <({ toString() { return '123.45'; } })> converted <[object Object]>  Arg <(function (a) { return a; })> converted <function (a) { return a; }>  Arg <new Uint8Array([0, 1, 2, 3])> converted <[object Uint8Array]> 
+Testing specifier : %O
+ Arg <null> converted <null>  Arg <undefined> converted <undefined>  Arg <10> converted <10>  Arg <12.5> converted <12.5>  Arg <BigInt(123)> converted <123>  Arg <true> converted <true>  Arg <'alpha'> converted <alpha>  Arg <'0.6'> converted <0.6>  Arg <'123'> converted <123>  Arg <'123abc'> converted <123abc>  Arg <[1, 2, 3]> converted <[object Array]>  Arg <({ x: 1, y: 'alpha' })> converted <#<Object>>  Arg <({ toString() { return 'Wow!'; } })> converted <[object Object]>  Arg <({ toString() { return '123.45'; } })> converted <[object Object]>  Arg <(function (a) { return a; })> converted <function (a) { return a; }>  Arg <new Uint8Array([0, 1, 2, 3])> converted <[object Uint8Array]> 
+Testing specifier : %c
+ Arg <null> converted <>  Arg <undefined> converted <>  Arg <10> converted <>  Arg <12.5> converted <>  Arg <BigInt(123)> converted <>  Arg <true> converted <>  Arg <'alpha'> converted <>  Arg <'0.6'> converted <>  Arg <'123'> converted <>  Arg <'123abc'> converted <>  Arg <[1, 2, 3]> converted <>  Arg <({ x: 1, y: 'alpha' })> converted <>  Arg <({ toString() { return 'Wow!'; } })> converted <>  Arg <({ toString() { return '123.45'; } })> converted <>  Arg <(function (a) { return a; })> converted <>  Arg <new Uint8Array([0, 1, 2, 3])> converted <> 
+Testing specifier : %%
+ Arg <null> converted <%>  Arg <undefined> converted <%>  Arg <10> converted <%>  Arg <12.5> converted <%>  Arg <BigInt(123)> converted <%>  Arg <true> converted <%>  Arg <'alpha'> converted <%>  Arg <'0.6'> converted <%>  Arg <'123'> converted <%>  Arg <'123abc'> converted <%>  Arg <[1, 2, 3]> converted <%>  Arg <({ x: 1, y: 'alpha' })> converted <%>  Arg <({ toString() { return 'Wow!'; } })> converted <%>  Arg <({ toString() { return '123.45'; } })> converted <%>  Arg <(function (a) { return a; })> converted <%>  Arg <new Uint8Array([0, 1, 2, 3])> converted <%>  null undefined 10 12.5 123 true alpha 0.6 123 123abc [object Array] #<Object> [object Object] [object Object] function (a) { return a; } [object Uint8Array]
+1 : a 2 : b 3 : %s
+1 : a b c
+No specifiers: a b c
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+19
+DROP PROCEDURE p_strN;
+#
+# 1.6) Test cases when conversion of console.log() argument fails.
+#
+# Conversion of argument to representation useful for debugging
+# should not fail even if conversion of argument to String fails.
+CREATE PROCEDURE p_val_err() LANGUAGE JS AS $$ console.log({ toString() { throw "Ooops!" } }) $$;
+CALL p_val_err();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+[object Object]
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+DROP PROCEDURE p_val_err;
+#
+# Conversion to string can fail and the exception should be propagated
+# from console.log() to JS code. If uncaught it results in SQL CALL
+# statement failure with error set accordingly. If caught execution
+# of JS code should continue.
+CREATE PROCEDURE p_str_err() LANGUAGE JS AS $$ console.log("%s", { toString() { throw "Ooops!" } }) $$;
+CALL p_str_err();
+ERROR HY000: Ooops!
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_GET_LAST_ERROR_INFO();
+JS_GET_LAST_ERROR_INFO()
+Error: Ooops!
+At: SQL PROCEDURE test.p_str_err:1:34
+Line:  console.log("%s", { toString() { throw "Ooops!" } }) 
+                                        ^
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+0
+DROP PROCEDURE p_str_err;
+CREATE PROCEDURE p_str_err_catch() LANGUAGE JS AS $$
+try {
+console.log("%s", { toString() { throw "Ooops!" } });
+} catch (e) {
+console.log("Got exception:", e);
+}
+$$|
+CALL p_str_err_catch();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Got exception: Ooops!
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+DROP PROCEDURE p_str_err_catch;
+#
+# 1.7) Test that console.log() produces console messages with "Info"
+#      log level.
+CREATE PROCEDURE p_level() LANGUAGE JS AS $$
+console.log(1, "st message");
+console.log("Message 2");
+console.log("Message %s", "Three");
+$$|
+CALL p_level();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	1 st message
+Info	Message 2
+Info	Message Three
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+3
+DROP PROCEDURE p_level;
+#
+# 2) Test coverage for console.info(), warn(), error() and
+#    debug() methods.
+#
+#    They behave exactly the same way as console.log() does
+#    except that they use different log level for messages.
+CREATE PROCEDURE p_log_like(name VARCHAR(10)) LANGUAGE JS AS $$
+eval("console."+name+"()");
+eval("console."+name+"('')");
+eval("console."+name+"(1)");
+eval("console."+name+"(2, 3, 'Four')");
+eval("console."+name+"('Message five - %d')");
+eval("console."+name+"('Message %s', 'Six')");
+eval("console."+name+"('Message %d', 7.6, 8, 9)");
+$$|
+#
+# 2.1) In our implementation console.info() is just an alias for
+#      console.log(), so it uses "Info" level as well.
+CALL p_log_like("info");
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+1
+2 3 Four
+Message five - %d
+Message Six
+Message 7 8 9
+
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	
+Info	1
+Info	2 3 Four
+Info	Message five - %d
+Info	Message Six
+Info	Message 7 8 9
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+6
+#
+# 2.2) console.warn() uses "Warning" log level.
+CALL p_log_like("warn");
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+1
+2 3 Four
+Message five - %d
+Message Six
+Message 7 8 9
+
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Warning	
+Warning	1
+Warning	2 3 Four
+Warning	Message five - %d
+Warning	Message Six
+Warning	Message 7 8 9
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+6
+#
+# 2.3) console.error() uses "Error" log level.
+CALL p_log_like("error");
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+1
+2 3 Four
+Message five - %d
+Message Six
+Message 7 8 9
+
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Error	
+Error	1
+Error	2 3 Four
+Error	Message five - %d
+Error	Message Six
+Error	Message 7 8 9
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+6
+#
+# 2.4) console.debug() uses "Debug" log level.
+CALL p_log_like("debug");
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+1
+2 3 Four
+Message five - %d
+Message Six
+Message 7 8 9
+
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Debug	
+Debug	1
+Debug	2 3 Four
+Debug	Message five - %d
+Debug	Message Six
+Debug	Message 7 8 9
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+6
+DROP PROCEDURE p_log_like;
+#
+# 3) Test coverage for console.assert().
+#
+# console.assert() can be considered conditional form of error() call.
+#
+# - Does nothing if its first argument is truthy.
+# - If there are no arguments or there is only one argument which is
+#   falsy "Assertion failed" message is logged with "Error" level.
+# - If there are more than one argument and the first argument is falsy,
+#   it works like the error() call works, when it is passed all the
+#   arguments starting from the second one. "Assertion failed:"
+#   message is prepended to the console log message.
+CREATE PROCEDURE p_assert() LANGUAGE JS AS $$
+// Let us check how different condition values are handled.
+const arg_desc = ["", "null", "undefined", "0", "123", "0.0", "12.5",
+"BigInt(0)", "BigInt(123)", "true", "false",
+"''", "'alpha'", "'0'", "'0.0'", "'123'",
+"[1, 2, 3]", "({ x: 1, y: 'alpha' })",
+"({ toString() { return ''; } })",
+"({ toString() { throw 'Oops!'; } })",
+"(function (a) { return a; })",
+"new Uint8Array([0, 1, 2, 3])"];
+for (const a of arg_desc) {
+console.log("Calling console.assert(%s) results in :", a);
+eval("console.assert(" + a + ")");
+}
+console.log("Test console.assert() with more than 1 argument:");
+console.assert(false, 1, 2, 3);
+console.assert(false, "four");
+console.assert(false, "five %s %d", "six", 7.65, 8);
+$$|
+CALL p_assert();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Calling console.assert() results in :
+Assertion failed
+Calling console.assert(null) results in :
+Assertion failed
+Calling console.assert(undefined) results in :
+Assertion failed
+Calling console.assert(0) results in :
+Assertion failed
+Calling console.assert(123) results in :
+Calling console.assert(0.0) results in :
+Assertion failed
+Calling console.assert(12.5) results in :
+Calling console.assert(BigInt(0)) results in :
+Assertion failed
+Calling console.assert(BigInt(123)) results in :
+Calling console.assert(true) results in :
+Calling console.assert(false) results in :
+Assertion failed
+Calling console.assert('') results in :
+Assertion failed
+Calling console.assert('alpha') results in :
+Calling console.assert('0') results in :
+Calling console.assert('0.0') results in :
+Calling console.assert('123') results in :
+Calling console.assert([1, 2, 3]) results in :
+Calling console.assert(({ x: 1, y: 'alpha' })) results in :
+Calling console.assert(({ toString() { return ''; } })) results in :
+Calling console.assert(({ toString() { throw 'Oops!'; } })) results in :
+Calling console.assert((function (a) { return a; })) results in :
+Calling console.assert(new Uint8Array([0, 1, 2, 3])) results in :
+Test console.assert() with more than 1 argument:
+Assertion failed: 1 2 3
+Assertion failed: four
+Assertion failed: five six 7 8
+
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	Calling console.assert() results in :
+Error	Assertion failed
+Info	Calling console.assert(null) results in :
+Error	Assertion failed
+Info	Calling console.assert(undefined) results in :
+Error	Assertion failed
+Info	Calling console.assert(0) results in :
+Error	Assertion failed
+Info	Calling console.assert(123) results in :
+Info	Calling console.assert(0.0) results in :
+Error	Assertion failed
+Info	Calling console.assert(12.5) results in :
+Info	Calling console.assert(BigInt(0)) results in :
+Error	Assertion failed
+Info	Calling console.assert(BigInt(123)) results in :
+Info	Calling console.assert(true) results in :
+Info	Calling console.assert(false) results in :
+Error	Assertion failed
+Info	Calling console.assert('') results in :
+Error	Assertion failed
+Info	Calling console.assert('alpha') results in :
+Info	Calling console.assert('0') results in :
+Info	Calling console.assert('0.0') results in :
+Info	Calling console.assert('123') results in :
+Info	Calling console.assert([1, 2, 3]) results in :
+Info	Calling console.assert(({ x: 1, y: 'alpha' })) results in :
+Info	Calling console.assert(({ toString() { return ''; } })) results in :
+Info	Calling console.assert(({ toString() { throw 'Oops!'; } })) results in :
+Info	Calling console.assert((function (a) { return a; })) results in :
+Info	Calling console.assert(new Uint8Array([0, 1, 2, 3])) results in :
+Info	Test console.assert() with more than 1 argument:
+Error	Assertion failed: 1 2 3
+Error	Assertion failed: four
+Error	Assertion failed: five six 7 8
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+34
+DROP PROCEDURE p_assert;
+#
+# 4) Tests for console.count() and console.countReset() calls.
+#
+# 4.1) Basic test for count() and countReset() functionality.
+CREATE PROCEDURE p_count_basic() LANGUAGE JS AS $$
+console.log("Call count() for label 'a' thrice and for 'b' once.");
+console.count("a");
+console.count("a");
+console.count("a");
+console.count("b");
+console.log("Call count() for label 'a' one more time (so its count is 4)");
+console.count("a");
+console.log("Call countReset() for label 'a'");
+console.countReset("a");
+console.log("Now call count() for label 'a' one more time and observe " +
+"that counting has been restarted.");
+console.count("a");
+console.log("Counter for 'b' should not be affected.");
+console.count("b");
+console.log("Clean up counters for 'a' and 'b'.");
+console.countReset("a");
+console.countReset("b");
+$$|
+CALL p_count_basic();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Call count() for label 'a' thrice and for 'b' once.
+a: 1
+a: 2
+a: 3
+b: 1
+Call count() for label 'a' one more time (so its count is 4)
+a: 4
+Call countReset() for label 'a'
+Now call count() for label 'a' one more time and observe that counting has been restarted.
+a: 1
+Counter for 'b' should not be affected.
+b: 2
+Clean up counters for 'a' and 'b'.
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+13
+DROP PROCEDURE p_count_basic;
+#
+# 4.2) Arity tests.
+#
+# When no arguments are passed to count() and countReset()
+# 'default' label is used.
+# Extra (second and later) arguments are ignored per standard
+# JS practice.
+CREATE PROCEDURE p_count_arity() LANGUAGE JS AS $$
+console.log("Call count() without arguments to show that for label " +
+"'default' is used.");
+console.count();
+console.count();
+console.log("Call count('default') to show that it is the same label.");
+console.count('default');
+console.log("Call countReset() and then count() without arguments to show " +
+"'default' counter is reset.");
+console.countReset();
+console.count();
+console.log("Extra arguments in count() and countReset() are ignored");
+console.count("a", "b");
+console.count("b");
+console.countReset("a", "b");
+console.count("a");
+console.count("b");
+console.log("Clean up counters for 'a', 'b' and 'default'.");
+console.countReset("a");
+console.countReset("b");
+console.countReset();
+$$|
+CALL p_count_arity();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Call count() without arguments to show that for label 'default' is used.
+default: 1
+default: 2
+Call count('default') to show that it is the same label.
+default: 3
+Call countReset() and then count() without arguments to show 'default' counter is reset.
+default: 1
+Extra arguments in count() and countReset() are ignored
+a: 1
+b: 1
+a: 1
+b: 2
+Clean up counters for 'a', 'b' and 'default'.
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+13
+DROP PROCEDURE p_count_arity;
+#
+# 4.3) Test how arguments of different types are handled and
+#      what happens in case of error.
+#
+# First argument to count()/countReset() is converted to String
+# to get label value. If error happens during this conversion it
+# should be propagated to JS.
+CREATE PROCEDURE p_count_arg_conv() LANGUAGE JS AS $$
+console.log("count() - normal case, String argument.");
+console.count("");
+console.count("alpha");
+console.count("123");
+console.log("count() - exotic, non-String arguments, which are converted to String.");
+console.count(0);
+console.count(123);
+console.count(1.5);
+console.count(true);
+console.count(BigInt(100));
+console.count({ toString() { return "Label"; } });
+console.count([1, 2, 3]);
+console.log("countReset() - normal case, String argument.");
+console.countReset("");
+console.countReset("alpha");
+console.countReset("123");
+console.log("Check values after reset.");
+console.count("");
+console.count("alpha");
+console.count("123");
+console.log("countReset() - exotic, non-String arguments, which are converted to String.");
+console.countReset(0);
+console.countReset(123);
+console.countReset(1.5);
+console.countReset(true);
+console.countReset(BigInt(100));
+console.countReset({ toString() { return "Label"; } });
+console.countReset([1, 2, 3]);
+console.log("Check values after reset.");
+console.count(0);
+console.count(123);
+console.count(1.5);
+console.count(true);
+console.count(BigInt(100));
+console.count({ toString() { return "Label"; } });
+console.count([1, 2, 3]);
+console.log("Check what happens if error occurs while converting argument value to String.");
+try {
+console.count({ toString() { throw "Ooops!"; } });
+} catch (e) {
+console.error("Exception %s caught while calling count().", e);
+}
+try {
+console.countReset({ toString() { throw "Arghh!"; } });
+} catch (e) {
+console.error("Exception %s caught while calling countReset().", e);
+}
+console.log("Clean up by resetting counters.");
+console.countReset("");
+console.countReset("alpha");
+console.countReset("123");
+console.countReset(0);
+console.countReset(1.5);
+console.countReset(true);
+console.countReset(BigInt(100));
+console.countReset({ toString() { return "Label"; } });
+console.countReset([1, 2, 3]);
+$$|
+CALL p_count_arg_conv();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	count() - normal case, String argument.
+Info	: 1
+Info	alpha: 1
+Info	123: 1
+Info	count() - exotic, non-String arguments, which are converted to String.
+Info	0: 1
+Info	123: 2
+Info	1.5: 1
+Info	true: 1
+Info	100: 1
+Info	Label: 1
+Info	1,2,3: 1
+Info	countReset() - normal case, String argument.
+Info	Check values after reset.
+Info	: 1
+Info	alpha: 1
+Info	123: 1
+Info	countReset() - exotic, non-String arguments, which are converted to String.
+Info	Check values after reset.
+Info	0: 1
+Info	123: 1
+Info	1.5: 1
+Info	true: 1
+Info	100: 1
+Info	Label: 1
+Info	1,2,3: 1
+Info	Check what happens if error occurs while converting argument value to String.
+Error	Exception Ooops! caught while calling count().
+Error	Exception Arghh! caught while calling countReset().
+Info	Clean up by resetting counters.
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+30
+DROP PROCEDURE p_count_arg_conv;
+#
+# 4.4) Test how labels are compared by count() and countReset() calls.
+#
+# Labels should be compared in the same way as Strings are compared
+# in JS by default (i.e. using binary comparison).
+CREATE PROCEDURE p_count_label() LANGUAGE JS AS $$
+console.count("a");
+console.count("A");
+console.count("â");
+console.log("Call countReset() for 2 out of 3 labels.");
+console.countReset("A");
+console.countReset("â");
+console.log("Check that 2 out of 3 counters were reset.");
+console.count("a");
+console.count("A");
+console.count("â");
+console.log("Clean up counters.");
+console.countReset("a");
+console.countReset("A");
+console.countReset("â");
+$$|
+CALL p_count_label();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+a: 1
+A: 1
+â: 1
+Call countReset() for 2 out of 3 labels.
+Check that 2 out of 3 counters were reset.
+a: 2
+A: 1
+â: 1
+Clean up counters.
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+9
+DROP PROCEDURE p_count_label;
+#
+# 4.5) Test that count() produces messages with 'Info' log level.
+#
+CREATE PROCEDURE p_count_log_level() LANGUAGE JS AS $$
+console.count("label");
+console.count();
+console.countReset("label");
+console.countReset();
+$$|
+CALL p_count_log_level();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	label: 1
+Info	default: 1
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+2
+DROP PROCEDURE p_count_log_level;
+#
+# 4.6) Finally, test that countReset() produces a warning if label
+#      was not used with count() before.
+#
+CREATE PROCEDURE p_count_no_label() LANGUAGE JS AS $$
+console.log("Test what happens if label was not used before at all.");
+console.countReset("no-such-label");
+console.log("Also test case when the label was used but its count has ");
+console.log("been reset already. Spec says there should be no warning ");
+console.log("in this case, but implementations still warn.");
+console.count("label");
+console.countReset("label");
+console.countReset("label");
+console.log("Same for 'default' case.");
+console.countReset();
+$$|
+CALL p_count_no_label();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	Test what happens if label was not used before at all.
+Warning	no-such-label: there is no counter to reset
+Info	Also test case when the label was used but its count has 
+Info	been reset already. Spec says there should be no warning 
+Info	in this case, but implementations still warn.
+Info	label: 1
+Warning	label: there is no counter to reset
+Info	Same for 'default' case.
+Warning	default: there is no counter to reset
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+9
+DROP PROCEDURE p_count_no_label;
+#
+# 5) Tests for console.time(), timeEnd() and timeLog() calls.
+#
+# 5.1) Basic tests for time(), timeLog() and timeEnd() functionality.
+CREATE PROCEDURE p_time_basic() LANGUAGE JS AS $$
+console.log("Start timers 'a', 'b', and 'c'.");
+console.time("a");
+console.time("b");
+console.time("c");
+console.timeLog("c", "Call timeLog for 'c'.");
+console.log("Stop timer 'c'.");
+console.timeEnd("c");
+console.timeLog("b", "Call timeLog for 'b' and then stop it.");
+console.timeEnd("b");
+console.log("Start timer'b' again");
+console.time("b");
+console.log("Stop timers 'a' and 'b'.");
+console.timeEnd("b");
+console.timeEnd("a");
+$$|
+CALL p_time_basic();
+# Mask elapsed times in the output as they are of course not repeatable.
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Start timers 'a', 'b', and 'c'.
+c: X.XXX ms Call timeLog for 'c'.
+Stop timer 'c'.
+c: X.XXX ms
+b: X.XXX ms Call timeLog for 'b' and then stop it.
+b: X.XXX ms
+Start timer'b' again
+Stop timers 'a' and 'b'.
+b: X.XXX ms
+a: X.XXX ms
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+10
+DROP PROCEDURE p_time_basic;
+#
+# 5.2) Arity tests.
+#
+# When no arguments are passed to time(), timeLog() and timeEnd()
+# 'default' label is used.
+# Extra (second and later) arguments for time() and timeEnd() are
+# ignored per standard JS practice.
+CREATE PROCEDURE p_time_arity() LANGUAGE JS AS $$
+console.log("Call time() , timeLog() and timeEnd() without arguments to" +
+" show 'default' is used as label in this case.");
+console.time();
+console.timeLog();
+console.timeEnd();
+console.log("Call time() and than timeLog('default') and timeEnd('default')" +
+"to show that it is the same label.");
+console.time();
+console.timeLog("default");
+console.timeEnd("default");
+console.log("Extra arguments in time() and timeEnd() are ignored");
+console.time("a", "b");
+console.timeEnd("a");
+console.time("c");
+console.timeEnd("c", "d");
+console.log("The 2nd and later arguments of timeLog() are appended to the message.");
+console.time("e");
+console.timeLog("e", 1, -2, "three");
+console.log("Unlike for assert format specifiers are not supported.");
+console.timeLog("e", "%s message", "four");
+console.timeEnd("e");
+$$|
+CALL p_time_arity();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Call time() , timeLog() and timeEnd() without arguments to show 'default' is used as label in this case.
+default: X.XXX ms
+default: X.XXX ms
+Call time() and than timeLog('default') and timeEnd('default')to show that it is the same label.
+default: X.XXX ms
+default: X.XXX ms
+Extra arguments in time() and timeEnd() are ignored
+a: X.XXX ms
+c: X.XXX ms
+The 2nd and later arguments of timeLog() are appended to the message.
+e: X.XXX ms 1 -2 three
+Unlike for assert format specifiers are not supported.
+e: X.XXX ms %s message four
+e: X.XXX ms
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+14
+DROP PROCEDURE p_time_arity;
+#
+# 5.3) Test how time(), timeLog() and timeEnd() handle values of
+#      different types passed to them as the first argument and
+#      what happens in case of error.
+#
+# The first argument in these calls is converted to String to get
+# label value. If error happens during this conversion it should
+# be propagated to JS.
+CREATE PROCEDURE p_time_arg_conv() LANGUAGE JS AS $$
+console.log("Normal case, String argument.");
+console.time("");
+console.time("alpha");
+console.time("123");
+console.timeLog("", "by timeLog()");
+console.timeLog("alpha", "by timeLog()");
+console.timeLog("123", "by timeLog()");
+console.timeEnd("");
+console.timeEnd("alpha");
+console.timeEnd("123");
+console.log("Exotic, non-String arguments, which are converted to String.");
+console.time(0);
+console.time(123);
+console.time(1.5);
+console.time(true);
+console.time(BigInt(100));
+console.time({ toString() { return "Label"; } });
+console.time([1, 2, 3]);
+console.timeLog(0, "by timeLog()");
+console.timeLog(123, "by timeLog()");
+console.timeLog(1.5, "by timeLog()");
+console.timeLog(true, "by timeLog()");
+console.timeLog(BigInt(100), "by timeLog()");
+console.timeLog({ toString() { return "Label"; } }, "by timeLog()");
+console.timeLog([1, 2, 3], "by timeLog()");
+console.timeEnd(0);
+console.timeEnd(123);
+console.timeEnd(1.5);
+console.timeEnd(true);
+console.timeEnd(BigInt(100));
+console.timeEnd({ toString() { return "Label"; } });
+console.timeEnd([1, 2, 3]);
+console.log("Check what happens if error occurs while converting the " +
+"first argument value to String.");
+try {
+console.time({ toString() { throw "Ooops!"; } });
+} catch (e) {
+console.error("Exception %s caught while calling time().", e);
+}
+try {
+console.timeLog({ toString() { throw "Arghh!"; } });
+} catch (e) {
+console.error("Exception %s caught while calling timeLog().", e);
+}
+try {
+console.timeEnd({ toString() { throw "Ouch!"; } });
+} catch (e) {
+console.error("Exception %s caught while calling timeEnd().", e);
+}
+$$|
+CALL p_time_arg_conv();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	Normal case, String argument.
+Info	: X.XXX ms by timeLog()
+Info	alpha: X.XXX ms by timeLog()
+Info	123: X.XXX ms by timeLog()
+Info	: X.XXX ms
+Info	alpha: X.XXX ms
+Info	123: X.XXX ms
+Info	Exotic, non-String arguments, which are converted to String.
+Info	0: X.XXX ms by timeLog()
+Info	123: X.XXX ms by timeLog()
+Info	1.5: X.XXX ms by timeLog()
+Info	true: X.XXX ms by timeLog()
+Info	100: X.XXX ms by timeLog()
+Info	Label: X.XXX ms by timeLog()
+Info	1,2,3: X.XXX ms by timeLog()
+Info	0: X.XXX ms
+Info	123: X.XXX ms
+Info	1.5: X.XXX ms
+Info	true: X.XXX ms
+Info	100: X.XXX ms
+Info	Label: X.XXX ms
+Info	1,2,3: X.XXX ms
+Info	Check what happens if error occurs while converting the first argument value to String.
+Error	Exception Ooops! caught while calling time().
+Error	Exception Arghh! caught while calling timeLog().
+Error	Exception Ouch! caught while calling timeEnd().
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+26
+DROP PROCEDURE p_time_arg_conv;
+#
+# 5.4) Test how timeLog() handles values of the second and later
+#      arguments of different types.
+#
+# These arguments are converted to String representation useful
+# for debugging purposes and they results are appended to the
+# message about elapsed time. Unlike in assert() format specifiers
+# in the second argument are not processed.
+CREATE PROCEDURE p_timelog_args() LANGUAGE JS AS $$
+// Let us check how different condition values are handled.
+const arg_desc = ["", "null", "undefined", "0", "123", "0.0", "12.5",
+"BigInt(0)", "BigInt(123)", "true", "false",
+"''", "'alpha'", "'0'", "'0.0'", "'123'",
+"[1, 2, 3]", "({ x: 1, y: 'alpha' })",
+"({ toString() { return 'Message'; } })",
+"({ toString() { throw 'Oops!'; } })",
+"(function (a) { return a; })",
+"new Uint8Array([0, 1, 2, 3])"];
+console.time('a');
+for (const a of arg_desc) {
+console.log("Calling console.timeLog('a', %s) results in :", a);
+eval("console.timeLog('a', " + a + ")");
+}
+console.log("Test console.timeLog() with more than 2 arguments:");
+console.timeLog('a', 1, 2, 3);
+console.timeLog('a', "four");
+console.log("Format specifiers should not be processed:");
+console.timeLog('a', "five %s %d", "six", 7.65, 8);
+console.timeEnd('a');
+$$|
+CALL p_timelog_args();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Calling console.timeLog('a', ) results in :
+a: X.XXX ms
+Calling console.timeLog('a', null) results in :
+a: X.XXX ms null
+Calling console.timeLog('a', undefined) results in :
+a: X.XXX ms undefined
+Calling console.timeLog('a', 0) results in :
+a: X.XXX ms 0
+Calling console.timeLog('a', 123) results in :
+a: X.XXX ms 123
+Calling console.timeLog('a', 0.0) results in :
+a: X.XXX ms 0
+Calling console.timeLog('a', 12.5) results in :
+a: X.XXX ms 12.5
+Calling console.timeLog('a', BigInt(0)) results in :
+a: X.XXX ms 0
+Calling console.timeLog('a', BigInt(123)) results in :
+a: X.XXX ms 123
+Calling console.timeLog('a', true) results in :
+a: X.XXX ms true
+Calling console.timeLog('a', false) results in :
+a: X.XXX ms false
+Calling console.timeLog('a', '') results in :
+a: X.XXX ms 
+Calling console.timeLog('a', 'alpha') results in :
+a: X.XXX ms alpha
+Calling console.timeLog('a', '0') results in :
+a: X.XXX ms 0
+Calling console.timeLog('a', '0.0') results in :
+a: X.XXX ms 0.0
+Calling console.timeLog('a', '123') results in :
+a: X.XXX ms 123
+Calling console.timeLog('a', [1, 2, 3]) results in :
+a: X.XXX ms [object Array]
+Calling console.timeLog('a', ({ x: 1, y: 'alpha' })) results in :
+a: X.XXX ms #<Object>
+Calling console.timeLog('a', ({ toString() { return 'Message'; } })) results in :
+a: X.XXX ms [object Object]
+Calling console.timeLog('a', ({ toString() { throw 'Oops!'; } })) results in :
+a: X.XXX ms [object Object]
+Calling console.timeLog('a', (function (a) { return a; })) results in :
+a: X.XXX ms function (a) { return a; }
+Calling console.timeLog('a', new Uint8Array([0, 1, 2, 3])) results in :
+a: X.XXX ms [object Uint8Array]
+Test console.timeLog() with more than 2 arguments:
+a: X.XXX ms 1 2 3
+a: X.XXX ms four
+Format specifiers should not be processed:
+a: X.XXX ms five %s %d six 7.65 8
+a: X.XXX ms
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+50
+DROP PROCEDURE p_timelog_args;
+#
+# 5.5) Test how labels are compared by time(), timeLog() and
+#      timeEnd() calls.
+#
+# Labels should be compared in the same way as Strings are compared
+# in JS by default (i.e. using binary comparison).
+CREATE PROCEDURE p_time_label() LANGUAGE JS AS $$
+console.log("Start timer 'a' and then call timeLog() for labels 'A' and 'â'.");
+console.time("a");
+console.timeLog("A");
+console.timeLog("â");
+console.log("Now try to end the time using labels 'A' and 'â'.");
+console.timeEnd("A");
+console.timeEnd("â");
+console.timeEnd("a");
+$$|
+CALL p_time_label();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	Start timer 'a' and then call timeLog() for labels 'A' and 'â'.
+Warning	A: no such timer
+Warning	â: no such timer
+Info	Now try to end the time using labels 'A' and 'â'.
+Warning	A: no such timer
+Warning	â: no such timer
+Info	a: X.XXX ms
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+7
+DROP PROCEDURE p_time_label;
+#
+# 5.6) Test that timeLog() and timeEnd() produce messages with 'Info'
+#      log level.
+#
+CREATE PROCEDURE p_time_log_level() LANGUAGE JS AS $$
+console.time("label");
+console.time();
+console.timeLog("label");
+console.timeLog("label", "Additional message.");
+console.timeLog();
+console.timeEnd();
+console.timeEnd("label");
+$$|
+CALL p_time_log_level();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	label: X.XXX ms
+Info	label: X.XXX ms Additional message.
+Info	default: X.XXX ms
+Info	default: X.XXX ms
+Info	label: X.XXX ms
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+5
+DROP PROCEDURE p_time_log_level;
+#
+# 5.7) Finally, test that time() produces a warning if timer
+#      already has been started for the label, and that
+#      timeLog() and timeEnd() produce warnings if there is
+#      no active timer for the label.
+#
+CREATE PROCEDURE p_time_warn() LANGUAGE JS AS $$
+console.log("Test what happens if we call time() for already used label.");
+console.time("label");
+console.time("label");
+console.log("But after timeEnd() calling time() for previously used " +
+"label should be OK.");
+console.timeEnd("label");
+console.time("label");
+console.log("Calling timeLog() and timeEnd() for label without timer " +
+"started should produce warning.");
+console.timeLog("no-such-label");
+console.timeEnd("no-such-label");
+console.log("Even if there was timer for the label in the past.");
+console.timeEnd("label");
+console.timeLog("label");
+console.timeEnd("label");
+$$|
+CALL p_time_warn();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	Test what happens if we call time() for already used label.
+Warning	label: timer has been started already
+Info	But after timeEnd() calling time() for previously used label should be OK.
+Info	label: X.XXX ms
+Info	Calling timeLog() and timeEnd() for label without timer started should produce warning.
+Warning	no-such-label: no such timer
+Warning	no-such-label: no such timer
+Info	Even if there was timer for the label in the past.
+Info	label: X.XXX ms
+Warning	label: no such timer
+Warning	label: no such timer
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+11
+DROP PROCEDURE p_time_warn;
+#
+# 6) Tests for console.group(), groupCollapsed() and groupEnd() calls.
+#
+# 6.1) Basic functionality tests for group(), groupCollapsed() and
+#      groupEnd().
+CREATE PROCEDURE p_group_basic() LANGUAGE JS AS $$
+console.log("No group at this level..");
+console.group("a");
+console.log("This should go to group 'a'.");
+console.group("b");
+console.log("This should go to group 'b' under group 'a'.");
+console.groupEnd();
+console.log("This should go to group 'a' again.");
+console.group("b");
+console.log("This should go to a new group 'b' under group 'a'.");
+console.groupEnd();
+console.group("c");
+console.log("This should go to group 'c' under group 'a'.");
+console.groupEnd();
+console.log("We should be back at group 'a' once again.");
+console.groupEnd();
+console.log("We should be back at basic level.");
+$$|
+CALL p_group_basic();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+No group at this level..
+a
+  This should go to group 'a'.
+  b
+    This should go to group 'b' under group 'a'.
+  This should go to group 'a' again.
+  b
+    This should go to a new group 'b' under group 'a'.
+  c
+    This should go to group 'c' under group 'a'.
+  We should be back at group 'a' once again.
+We should be back at basic level.
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "No group at this level.."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "message": "This should go to group 'a'."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "b"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "This should go to group 'b' under group 'a'."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "message": "This should go to group 'a' again."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "b"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "This should go to a new group 'b' under group 'a'."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "c"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "c"],
+        "message": "This should go to group 'c' under group 'a'."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "message": "We should be back at group 'a' once again."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "We should be back at basic level."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+12
+DROP PROCEDURE p_group_basic;
+#
+# 6.2) Test coverage for argument handling in group()/groupCollapsed()
+#      and groupEnd() calls.
+#
+# 6.2.1) group() call without argument creates a group without
+#        a lable (null in JSON represenation). This is different
+#        from empty ("") group label. No group label is logged
+#        in the former case.
+CREATE PROCEDURE p_group_no_label() LANGUAGE JS AS $$
+console.log("Group without label:");
+console.group();
+console.log("This should go into group without label/null in JSON.");
+console.groupEnd();
+console.log("Group with empty label:");
+console.group("");
+console.log("This should go into group with label name ('').");
+console.groupEnd();
+$$|
+CALL p_group_no_label();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Group without label:
+  This should go into group without label/null in JSON.
+Group with empty label:
+
+  This should go into group with label name ('').
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Group without label:"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": [null],
+        "message": "This should go into group without label/null in JSON."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Group with empty label:"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": ""
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": [""],
+        "message": "This should go into group with label name ('')."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+5
+DROP PROCEDURE p_group_no_label;
+#
+# 6.2.2) In case when group() call has arguments they are processed
+#        similarly to arguments of log() call to create group label.
+#
+# - If first argument is not a String, then group label is created by
+#   concatenating representations of each argument useful for debugging
+#   purposes separated by spaces.
+# - In case of single String argument it is used as group label as is.
+# - In case when there are more than one argument and first argument
+#   is String we build label by replacing format specifiers in the
+#   first argument string with by converted values of later arguments,
+#   where conversion procedure for each argument is prescribed by
+#   corresponding specifier.
+CREATE PROCEDURE p_group_args() LANGUAGE JS AS $$
+console.group(1);
+console.log("This goes into group with converted Number as label.");
+console.groupEnd();
+console.group(true, 1.0, "alpha", [1, 2, 3],
+{ toString() { return "label"; } });
+console.log("This goes into group with label constructed from debugging " +
+"representation of arguments.");
+console.groupEnd();
+console.group("String group label %% %s");
+console.log("This goes into group with label which is verbatim value of " +
+"single String argument.");
+console.groupEnd();
+console.group("String without specifiers.", 1, "One more String.", [1, 2, 3]);
+console.log("This goes into group with label which is built from the first " +
+"String argument without specifiers and some more arguments.");
+console.groupEnd();
+console.group("One %s three %d five", { toString() { return "two"; } }, 4);
+console.log("This goes into group with label which is built by processing " +
+"specifiers in the first String argument.");
+console.groupEnd();
+console.group("One %s", 2, [3, 4, 5]);
+console.log("This goes into group with label which is built by processing " +
+"specifiers in the first String argument and there more " +
+"arguments than specifiers.");
+console.groupEnd();
+console.group("One %s %d %s End!", "Two", "3");
+console.log("This goes into group with label which is built by processing " +
+"specifiers in the first String argument and there too few " +
+"arguments.");
+console.groupEnd();
+$$|
+CALL p_group_args();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+1
+  This goes into group with converted Number as label.
+true 1 alpha [object Array] [object Object]
+  This goes into group with label constructed from debugging representation of arguments.
+String group label %% %s
+  This goes into group with label which is verbatim value of single String argument.
+String without specifiers. 1 One more String. [object Array]
+  This goes into group with label which is built from the first String argument without specifiers and some more arguments.
+One two three 4 five
+  This goes into group with label which is built by processing specifiers in the first String argument.
+One 2 [object Array]
+  This goes into group with label which is built by processing specifiers in the first String argument and there more arguments than specifiers.
+One Two 3 %s End!
+  This goes into group with label which is built by processing specifiers in the first String argument and there too few arguments.
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+14
+DROP PROCEDURE p_group_args;
+#
+# 6.2.3) Also test what happens when group() gets an error while
+#        converting its arguments.
+CREATE PROCEDURE p_group_arg_error() LANGUAGE JS AS $$
+console.group({ toString() { throw "Ooops!!!"; } } );
+console.log("This should into group with a valid label.");
+console.groupEnd();
+try {
+console.group("Message %s", { toString() { throw "Ouch!!!"; } });
+console.log("This should have gone into group, but we have got error " +
+"while building label.");
+console.groupEnd();
+} catch (e) {
+console.error("Error while calling console.group() : ", e);
+}
+$$|
+CALL p_group_arg_error();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+[object Object]
+  This should into group with a valid label.
+Error while calling console.group() :  Ouch!!!
+
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+level VARCHAR(10) PATH "$.level",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+level	message
+Info	[object Object]
+Info	This should into group with a valid label.
+Error	Error while calling console.group() :  Ouch!!!
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+3
+DROP PROCEDURE p_group_arg_error;
+#
+# 6.2.4) "Arity" of groupEnd() call.
+#
+# We follow standard JS practice and just ignore all extra (that is all)
+# to this call.
+CREATE PROCEDURE p_groupend_arity() LANGUAGE JS AS $$
+console.group("a");
+console.log("This goes into group 'a'.");
+console.groupEnd("b");
+console.log("This should be outside any group.");
+console.group("a");
+console.group("b");
+console.log("This goes into group 'b' in group 'a'.");
+console.groupEnd("a");
+console.log("This still goes into group 'a'.");
+console.groupEnd();
+console.log("This should be outside any group as well.");
+console.group("c");
+console.log("This goes into group 'c'.");
+console.groupEnd("d", "e", 6, 7.1);
+console.log("And this should be outside any group too.");
+$$|
+CALL p_groupend_arity();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+"$[*]" COLUMNS(
+gs0 VARCHAR(3) PATH "$.groups[0]",
+gs1 VARCHAR(3) PATH "$.groups[1]",
+message VARCHAR(100) PATH "$.message")
+) AS jslog;
+gs0	gs1	message
+NULL	NULL	a
+a	NULL	This goes into group 'a'.
+NULL	NULL	This should be outside any group.
+NULL	NULL	a
+a	NULL	b
+a	b	This goes into group 'b' in group 'a'.
+a	NULL	This still goes into group 'a'.
+NULL	NULL	This should be outside any group as well.
+NULL	NULL	c
+c	NULL	This goes into group 'c'.
+NULL	NULL	And this should be outside any group too.
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+11
+DROP PROCEDURE p_groupend_arity;
+#
+# 6.3) Test case for groups with the label name on the group stack.
+#
+# Even though it is exotic case, it is perfectly legal to have nested
+# groups with the label. Group labels are mostly for user convinience
+# they do not identify groups.
+CREATE PROCEDURE p_group_dupname() LANGUAGE JS AS $$
+console.group("a");
+console.group("b");
+console.group("a");
+console.log("This goes to group 'a' under group 'b' under group 'a' " +
+"(different one!).");
+console.groupEnd();
+console.groupEnd();
+console.groupEnd();
+console.group();
+console.group();
+console.log("Another exotic case. This goes into 2nd level group. " +
+"Both levels do not have labels (null in JSON).");
+console.groupEnd();
+console.groupEnd();
+$$|
+CALL p_group_dupname();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "b"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b", "a"],
+        "message": "This goes to group 'a' under group 'b' under group 'a' (different one!)."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": [null, null],
+        "message": "Another exotic case. This goes into 2nd level group. Both levels do not have labels (null in JSON)."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+5
+DROP PROCEDURE p_group_dupname;
+#
+# 6.4) Test case for groupCollapsed() call.
+#
+# In our implementation groupCollapsed() is an alias for group() call.
+CREATE PROCEDURE p_groupcollapsed() LANGUAGE JS AS $$
+console.groupCollapsed("a");
+console.log("This goes to group 'a'");
+console.groupCollapsed("b %s", "Two", 3);
+console.log("This goes to group 'b Two 3' under group 'a'");
+console.groupEnd();
+console.log("This goes to group 'a' again.");
+console.group(123);
+console.log("This goes to group '123' under group 'a'");
+console.groupEnd();
+console.groupEnd();
+console.log("This goes outside any group.");
+$$|
+CALL p_groupcollapsed();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "message": "This goes to group 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "b Two 3"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b Two 3"],
+        "message": "This goes to group 'b Two 3' under group 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "message": "This goes to group 'a' again."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "123"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "123"],
+        "message": "This goes to group '123' under group 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "This goes outside any group."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+8
+DROP PROCEDURE p_groupcollapsed;
+#
+# 6.5) Test that console log entries with group labels generated by
+#      group()/groupCollapsed() calls get 'Info' log level.
+#
+CREATE PROCEDURE p_group_log_level() LANGUAGE JS AS $$
+console.group("g1");
+console.warn("This warning goes to group 'g1'");
+console.groupEnd();
+console.groupCollapsed("g2");
+console.error("This error goes to group 'g2'");
+console.group("g3");
+console.debug("This debug messages goes to group 'g3' under group 'g2'.");
+console.groupEnd();
+console.groupEnd();
+$$|
+CALL p_group_log_level();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "g1"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Warning",
+        "groups": ["g1"],
+        "message": "This warning goes to group 'g1'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "g2"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Error",
+        "groups": ["g2"],
+        "message": "This error goes to group 'g2'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["g2"],
+        "isGroupLabel": true,
+        "message": "g3"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Debug",
+        "groups": ["g2", "g3"],
+        "message": "This debug messages goes to group 'g3' under group 'g2'."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+6
+DROP PROCEDURE p_group_log_level;
+#
+# 6.6) Test that output of all console calls goes to the group on the
+#      top of the group stack.
+#
+CREATE PROCEDURE p_group_top() LANGUAGE JS AS $$
+console.group("a");
+console.group("b");
+console.assert(false, "assert() message should go to group 'b' under 'a'");
+console.debug("debug() message should go to group 'b' under 'a'");
+console.error("error() message should go to group 'b' under 'a'");
+console.info("info() message should go to group 'b' under 'a'");
+console.log("log() message should go to group 'b' under 'a'");
+console.warn("warn() message should go to group 'b' under 'a'");
+const cnt_label = "count() result should go to to group 'b' under 'a'";
+console.count(cnt_label);
+console.countReset(cnt_label);
+const time_label ="timeEnd()/timeLog() result should go to group 'b' too";
+console.time(time_label);
+console.timeLog(time_label, "extra");
+console.timeEnd(time_label);
+console.group("Finally label for nested group should go to 'b' as well");
+console.log("This goes into the nested group under 'b' under 'a'");
+console.groupEnd();
+console.groupEnd();
+console.groupEnd();
+$$|
+CALL p_group_top();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+a
+  b
+    Assertion failed: assert() message should go to group 'b' under 'a'
+    debug() message should go to group 'b' under 'a'
+    error() message should go to group 'b' under 'a'
+    info() message should go to group 'b' under 'a'
+    log() message should go to group 'b' under 'a'
+    warn() message should go to group 'b' under 'a'
+    count() result should go to to group 'b' under 'a': 1
+    timeEnd()/timeLog() result should go to group 'b' too: X.XXX ms extra
+    timeEnd()/timeLog() result should go to group 'b' too: X.XXX ms
+    Finally label for nested group should go to 'b' as well
+      This goes into the nested group under 'b' under 'a'
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "b"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Error",
+        "groups": ["a", "b"],
+        "message": "Assertion failed: assert() message should go to group 'b' under 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Debug",
+        "groups": ["a", "b"],
+        "message": "debug() message should go to group 'b' under 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Error",
+        "groups": ["a", "b"],
+        "message": "error() message should go to group 'b' under 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "info() message should go to group 'b' under 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "log() message should go to group 'b' under 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Warning",
+        "groups": ["a", "b"],
+        "message": "warn() message should go to group 'b' under 'a'"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "count() result should go to to group 'b' under 'a': 1"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "timeEnd()/timeLog() result should go to group 'b' too: X.XXX ms extra"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "timeEnd()/timeLog() result should go to group 'b' too: X.XXX ms"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "isGroupLabel": true,
+        "message": "Finally label for nested group should go to 'b' as well"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b", "Finally label for nested group should go to 'b' as well"],
+        "message": "This goes into the nested group under 'b' under 'a'"
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+13
+DROP PROCEDURE p_group_top;
+#
+# 6.7) Test special semantics of console.clear() for groups,
+#      it should empty group stack as a side-effect.
+#      OTOH JS_CLEAR_CONSOLE_LOG() should not have the same
+#      side-effect.
+#
+CREATE PROCEDURE p_group_clear() LANGUAGE JS AS $$
+console.group("a");
+console.group("b");
+console.log("This should go into group 'b' under group 'a'. " +
+"But we won't see this.");
+console.clear();
+console.log("console.clear() call resets groups stack, so this " +
+"should go to the top level.");
+$$|
+CREATE PROCEDURE p_group_clear_udf_begin() LANGUAGE JS AS $$
+console.group("a");
+console.group("b");
+console.log("This should go into group 'b' under group 'a'.");
+$$|
+CREATE PROCEDURE p_group_clear_udf_end() LANGUAGE JS AS $$
+console.log("This should go into group 'b' under group 'a' as well.");
+console.groupEnd();
+console.groupEnd();
+$$|
+# Test console.clear() call first.
+CALL p_group_clear();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+console.clear() call resets groups stack, so this should go to the top level.
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "console.clear() call resets groups stack, so this should go to the top level."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+# Now test how JS_CLEAR_CONSOLE_LOG() UDF behaves.
+CALL p_group_clear_udf_begin();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+a
+  b
+    This should go into group 'b' under group 'a'.
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "isGroupLabel": true,
+        "message": "b"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "This should go into group 'b' under group 'a'."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+3
+CALL p_group_clear_udf_end();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+    This should go into group 'b' under group 'a' as well.
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a", "b"],
+        "message": "This should go into group 'b' under group 'a' as well."
+    }
+]
+# Clean-up.
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+DROP PROCEDURE p_group_clear_udf_begin;
+DROP PROCEDURE p_group_clear_udf_end;
+DROP PROCEDURE p_group_clear;
+#
+# 6.8) Finally, let us test what happens when there is groupEnd()
+#      call without prior group() call.
+#
+CREATE PROCEDURE p_groupend_unbalanced() LANGUAGE JS AS $$
+console.log("This doesn't belong to any group.");
+console.groupEnd();
+console.log("Neither this.");
+console.group("a");
+console.log("This goes to group 'a'.");
+console.groupEnd();
+console.groupEnd();
+console.log("This doesn't belong to any group as well.");
+$$|
+CALL p_groupend_unbalanced();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+This doesn't belong to any group.
+Neither this.
+a
+  This goes to group 'a'.
+This doesn't belong to any group as well.
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "This doesn't belong to any group."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Neither this."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "a"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["a"],
+        "message": "This goes to group 'a'."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "This doesn't belong to any group as well."
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+5
+DROP PROCEDURE p_groupend_unbalanced;
+#
+# 7) Test coverage for console.clear() call.
+#
+# console.clear() should remove all messages from console log
+# and also reset the group stack.
+CREATE PROCEDURE p_clear() LANGUAGE JS AS $$
+console.clear("But first, test that clear()", "ignores its", "args...");
+console.assert(false, "This assert() message should be removed.");
+console.debug("So this debug() message.");
+console.error("And this error() message too.");
+console.info("Ditto this info() message.");
+console.log("And this log() message.");
+console.warn("And this warn() message as well.");
+const cnt_label = "count() result should be removed as well.";
+console.count(cnt_label);
+console.countReset(cnt_label);
+const time_label ="So the messages from timeEnd()/timeLog().";
+console.time(time_label);
+console.timeLog(time_label, "extra");
+console.timeEnd(time_label);
+console.group("Finally, this label for this group should be removed.");
+console.log("And the message which goes into this group.");
+console.clear();
+console.log("This message is the only which should be left. " +
+"Since clear() resets group stack it should go to top level.");
+$$|
+CALL p_clear();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+This message is the only which should be left. Since clear() resets group stack it should go to top level.
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+DROP PROCEDURE p_clear;
+#
+# 8) Test what happens when one invokes console calls which are
+#    present in specification but are not unsupported (yet?).
+#
+# These functions do not do anything at the moment.
+CREATE PROCEDURE p_unsupported() LANGUAGE JS AS $$
+console.table(["Output",  "of",  "table()", "is", "ignored"]);
+console.trace("trace() does nothing too.");
+console.dir({  a: "So dir() as well." });
+console.dirxml({  a: "Neither dirxml() does anything." });
+$$|
+CALL p_unsupported();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+0
+DROP PROCEDURE p_unsupported;
+#
+# 9) Test that we correctly escape strings in JS_GET_CONSOLE_LOG_JSON()
+#    output (at this point only message and group names need this).
+#
+CREATE PROCEDURE p_json_escaping() LANGUAGE JS AS $$
+console.log("RFC7159 says that the following characters need escaping:");
+console.log("- All control characters (0x00 - 0x1F), among them:");
+console.log("  * Bell <\u0007>");
+console.log("  * Backspace <\b>");
+console.log("  * Tab <\t>");
+console.log("  * New line <\n>");
+console.log('- Quotation mark (")');
+console.log("- Reverse solidus \\ (aka escape character)");
+console.log("Apostrophe doesn't neeed quoting, and in fact doing this " +
+"by simply adding reverse solidus before it is against RFC.");
+console.group("Escaping should be also done for group labels <\"example\">");
+console.log("This goes into group");
+console.groupEnd();
+$$|
+CALL p_json_escaping();
+# There should be no escaping in JS_GET_CONSOLE_LOG() output case.
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+RFC7159 says that the following characters need escaping:
+- All control characters (0x00 - 0x1F), among them:
+  * Bell <>
+  * Backspace <>
+  * Tab <	>
+  * New line <
+>
+- Quotation mark (")
+- Reverse solidus \ (aka escape character)
+Apostrophe doesn't neeed quoting, and in fact doing this by simply adding reverse solidus before it is against RFC.
+Escaping should be also done for group labels <"example">
+  This goes into group
+
+# But there should be when output is JSON!
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "RFC7159 says that the following characters need escaping:"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "- All control characters (0x00 - 0x1F), among them:"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "  * Bell <\u0007>"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "  * Backspace <\b>"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "  * Tab <\t>"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "  * New line <\n>"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "- Quotation mark (\")"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "- Reverse solidus \\ (aka escape character)"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Apostrophe doesn't neeed quoting, and in fact doing this by simply adding reverse solidus before it is against RFC."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "isGroupLabel": true,
+        "message": "Escaping should be also done for group labels <\"example\">"
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "groups": ["Escaping should be also done for group labels <\"example\">"],
+        "message": "This goes into group"
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+11
+DROP PROCEDURE p_json_escaping;
+#
+# 10) Test that one can limit how much console lines are buffered
+#     by using js_lang.max_console_log_size variable.
+#
+# 10.1) First, case when limit is exceeded due to total length of
+#       messages.
+#
+# Set limit to minimal supported value.
+SET GLOBAL js_lang.max_console_log_size = 10240;
+CREATE PROCEDURE p_log_10240_and_some() LANGUAGE JS AS $$
+for (let i = 0; i < 1024; i++) {
+console.log("0123456789");
+}
+console.log("And more...");
+$$|
+CALL p_log_10240_and_some();
+# Simple console output should be definitely within the limit.
+SELECT LENGTH(JS_GET_CONSOLE_LOG()) <= 1024 * 10;
+LENGTH(JS_GET_CONSOLE_LOG()) <= 1024 * 10
+1
+# JSON version of console output can easily exceed the limit
+# since it doesn't account for things like timestamps, severity,
+# JSON field names, indentation and quotes. Magic number 130
+# is there to take overhead from these factors into account.
+SELECT LENGTH(JS_GET_CONSOLE_LOG_JSON()) <= 1024 * (130 + 10);
+LENGTH(JS_GET_CONSOLE_LOG_JSON()) <= 1024 * (130 + 10)
+1
+# As each log messages needs at least 10 bytes total number
+# of messages should be below 1024.
+SELECT JS_CLEAR_CONSOLE_LOG() <= 1024;
+JS_CLEAR_CONSOLE_LOG() <= 1024
+1
+DROP PROCEDURE p_log_10240_and_some;
+#
+# 10.2) Then, case when limit is exceeded thanks to group stack info.
+CREATE PROCEDURE p_log_10240_and_some_group() LANGUAGE JS AS $$
+console.group("0123456789");
+for (let i = 0; i < 1024; i++) {
+console.log("");
+}
+console.groupEnd();
+$$|
+CALL p_log_10240_and_some_group();
+# Since each message takes at least 10 bytes thanks to group stack,
+# the total number of messages should be below 1024.
+# Simple console output will consist from this number of lines,
+# where each line contains 2 spaces (group indent) + '\n' char.
+SELECT LENGTH(JS_GET_CONSOLE_LOG()) <= 1024 * (2 + 1);
+LENGTH(JS_GET_CONSOLE_LOG()) <= 1024 * (2 + 1)
+1
+# Again JSON version of console output can exceed the limit.
+# Same magic number 130 as in case 10.1) to the rescue.
+SELECT LENGTH(JS_GET_CONSOLE_LOG_JSON()) <= 1024 * (130 + 10);
+LENGTH(JS_GET_CONSOLE_LOG_JSON()) <= 1024 * (130 + 10)
+1
+# Naturally total number of messages should be below 1024.
+SELECT JS_CLEAR_CONSOLE_LOG() <= 1024;
+JS_CLEAR_CONSOLE_LOG() <= 1024
+1
+DROP PROCEDURE p_log_10240_and_some_group;
+#
+# 10.3) Finally, extreme case with single huge message which exceeds
+#       the limit.
+CREATE PROCEDURE p_log_huge() LANGUAGE JS AS $$
+console.log("0123456789".repeat(1024 + 1));
+$$|
+CALL p_log_huge();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+<The message and part of its context have been suppressed as they exceed max_console_log_size limit>
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "<The message and part of its context have been suppressed as they exceed max_console_log_size limit>"
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+DROP PROCEDURE p_log_huge;
+SET GLOBAL js_lang.max_console_log_size = DEFAULT;
+#
+# 11) Now let us test security aspect of console support.
+#
+CREATE PROCEDURE p_definer() LANGUAGE JS AS $$
+console.log("Test definer!");
+$$|
+CREATE PROCEDURE p_invoker() SQL SECURITY INVOKER LANGUAGE JS AS $$
+console.log("Test invoker!");
+$$|
+CREATE FUNCTION f_log() RETURNS VARCHAR(100) RETURN JS_GET_CONSOLE_LOG() |
+CREATE USER u_other@localhost;
+GRANT EXECUTE ON test.* TO u_other@localhost;
+connect  con_other, localhost, u_other,,;
+# Test case when user never run any JS at all first.
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+0
+# Execution of SQL SECURITY DEFINER routine doesn't affect
+# current user's JS console log.
+CALL p_definer();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+0
+# Log contents should be visible from routine DEFINER context.
+SELECT f_log();
+f_log()
+Test definer!
+
+# Execution of SQL SECURITY INVOKER routine affects current user's
+# console log as expected.
+CALL p_invoker();
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+Test invoker!
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Test invoker!"
+    }
+]
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1
+SELECT JS_GET_CONSOLE_LOG();
+JS_GET_CONSOLE_LOG()
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+JS_GET_CONSOLE_LOG_JSON()
+[]
+# Console log associated with root@localhost security context was
+# not affected.
+SELECT f_log();
+f_log()
+Test definer!
+
+# Clean-up.
+disconnect con_other;
+connection default;
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+0
+DROP PROCEDURE p_definer;
+DROP PROCEDURE p_invoker;
+DROP FUNCTION f_log;
+DROP USER u_other@localhost;
+#
+# 12) Check types, charset and nullability of return values for
+#     JS_GET_CONSOLE_LOG() UDF and friends.
+#
+# 12.1) Test type, charset and nullability.
+CREATE PROCEDURE p_log_some() LANGUAGE JS AS $$
+console.log("Log something...");
+console.error("And then log something as error...");
+$$|
+CALL p_log_some();
+CREATE TABLE t_s AS SELECT JS_GET_CONSOLE_LOG();
+CREATE TABLE t_j AS SELECT JS_GET_CONSOLE_LOG_JSON();
+CREATE TABLE t_c AS SELECT JS_CLEAR_CONSOLE_LOG();
+SHOW CREATE TABLE t_s;
+Table	Create Table
+t_s	CREATE TABLE `t_s` (
+  `JS_GET_CONSOLE_LOG()` longtext NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t_s;
+JS_GET_CONSOLE_LOG()
+Log something...
+And then log something as error...
+
+SHOW CREATE TABLE t_j;
+Table	Create Table
+t_j	CREATE TABLE `t_j` (
+  `JS_GET_CONSOLE_LOG_JSON()` longtext NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t_j;
+JS_GET_CONSOLE_LOG_JSON()
+[
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Info",
+        "message": "Log something..."
+    },
+    {
+        "timestamp": "YYYY-MM-DD HH:MM:SS.FFFFFF",
+        "level": "Error",
+        "message": "And then log something as error..."
+    }
+]
+SHOW CREATE TABLE t_c;
+Table	Create Table
+t_c	CREATE TABLE `t_c` (
+  `JS_CLEAR_CONSOLE_LOG()` bigint NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t_c;
+JS_CLEAR_CONSOLE_LOG()
+2
+DROP TABLES t_s, t_j, t_c;
+DROP PROCEDURE p_log_some;
+#
+# 12.2) Let us also check what happens if we return fairly big result
+#       from JS_GET_CONSOLE_LOG() and JS_GET_CONSOLE_LOG_JSON() UDFs.
+SET GLOBAL js_lang.max_console_log_size = 21*1024*1024;
+CREATE PROCEDURE p_log_more_than_mediumtext() LANGUAGE JS AS $$
+for (let i = 0; i < 1024; i++) {
+console.log("01234567890123456789".repeat(1024));
+}
+$$|
+CALL p_log_more_than_mediumtext();
+SELECT LENGTH(JS_GET_CONSOLE_LOG()) > 20*1024*1024;
+LENGTH(JS_GET_CONSOLE_LOG()) > 20*1024*1024
+1
+SELECT LENGTH(JS_GET_CONSOLE_LOG_JSON()) > 20*1024*1024;
+LENGTH(JS_GET_CONSOLE_LOG_JSON()) > 20*1024*1024
+1
+# Also check that we correctly store returned output
+# when using CREATE TABLE ... SELECT UDF().
+CREATE TABLE t_s AS SELECT JS_GET_CONSOLE_LOG() AS l;
+CREATE TABLE t_j AS SELECT JS_GET_CONSOLE_LOG_JSON() AS l;
+SELECT LENGTH(l) > 20*1024*1024 FROM t_s;
+LENGTH(l) > 20*1024*1024
+1
+SELECT LENGTH(l) > 20*1024*1024 FROM t_j;
+LENGTH(l) > 20*1024*1024
+1
+SELECT JS_CLEAR_CONSOLE_LOG();
+JS_CLEAR_CONSOLE_LOG()
+1024
+DROP TABLES t_s, t_j;
+DROP PROCEDURE p_log_more_than_mediumtext;
+SET GLOBAL js_lang.max_console_log_size = DEFAULT;
+#
+# Final clean-up.
+REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
+# Disconnect of default connection to free the only remaining
+# connection context and isolate, so we can uninstall component.
+disconnect default;
+connect default,localhost,root;
+UNINSTALL COMPONENT 'file://component_js_lang';
+# Restart server to let subsequent tests to do INSTALL COMPONENT freely.
+# restart

--- a/mysql-test/suite/component_js_lang/t/js_lang_console.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_console.test
@@ -1,0 +1,1578 @@
+#
+# Test coverage for Console support in JS routines.
+#
+--source include/have_js_lang_component.inc
+
+--echo # Prepare playground.
+--enable_connect_log
+
+INSTALL COMPONENT 'file://component_js_lang';
+
+GRANT CREATE_JS_ROUTINE ON *.* TO root@localhost;
+
+--echo #
+--echo # 0) Some basic tests,
+--echo #
+CREATE PROCEDURE p1() LANGUAGE JS AS $$ console.log("Test!") $$;
+
+--echo #
+--echo # JS_GET_CONSOLE_LOG() and JS_GET_CONSOLE_LOG_JSON() prior to
+--echo # any writes to console.
+SELECT JS_GET_CONSOLE_LOG();
+
+SELECT JS_GET_CONSOLE_LOG_JSON();
+
+--echo #
+--echo # Let us do some writes to console and check output.
+CALL p1();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+CALL p1();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+
+--echo #
+--echo # Also let us test JS_CLEAR_CONSOLE_LOG().
+SELECT JS_CLEAR_CONSOLE_LOG();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+
+DROP PROCEDURE p1;
+
+--echo #
+--echo # 1) Test coverage for console.log().
+--echo #
+
+--echo #
+--echo # 1.1) console.log() - empty argument list case.
+--echo #
+--echo # Nothing (not even an empty line) should be added to the
+--echo # console output in this case.
+CREATE PROCEDURE p_empty() LANGUAGE JS AS $$ console.log() $$;
+CALL p_empty();
+SELECT JS_GET_CONSOLE_LOG();
+DROP PROCEDURE p_empty;
+
+--echo #
+--echo # 1.2) console.log(val1) - case with a single non-String argument.
+--echo #
+--echo # Line with a representation of argument which is useful for
+--echo # debugging purposes is added to the console output in this case.
+--echo # It is not necessarily the same thing as result of argument
+--echo # conversion to String. It might also change without much notice.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_val1() LANGUAGE JS AS $$
+  console.log(null);
+  console.log(undefined);
+  console.log(10);
+  console.log(12.5);
+  console.log(BigInt(100));
+  console.log(true);
+  console.log([1, 2, 3]);
+  console.log({ x: 1, y: "alpha", m() { return 1; } });
+  console.log(function (a) { return a; });
+  console.log(new Uint8Array([0, 1, 2, 3]));
+$$|
+DELIMITER ;|
+CALL p_val1();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_val1;
+
+--echo #
+--echo # Conversion to such debugging representation should work even
+--echo # when conversion to String is broken.
+CREATE PROCEDURE p_val1_err() LANGUAGE JS AS $$ console.log({ toString() { throw "Oops!" } }) $$;
+CALL p_val1_err();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_val1_err;
+
+--echo #
+--echo # 1.3) console.log(val1, ..., valN) - case with a multiple arguments
+--echo #      (where first argument is non-String).
+--echo #
+--echo # Line with concatenated represenations of arguments which are useful for
+--echo # debugging separated by spaces added to the console output.
+DELIMITER |;
+CREATE PROCEDURE p_valN() LANGUAGE JS AS $$
+  console.log(null, undefined);
+  console.log(10, 12.5, BigInt(100));
+  console.log(false, "alpha", "0.1", "123");
+  console.log([1, 2, 3], { x: 1, y: "alpha", m() { return 1; } },
+              (function (a) { return a; }), new Uint8Array([0, 1, 2, 3]));
+$$|
+DELIMITER ;|
+CALL p_valN();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_valN;
+
+--echo #
+--echo # 1.4) console.log(msg) - case with a single String argument.
+--echo #
+--echo # Line with the verbatim argument is added to console log.
+--echo # Format specifiers which are present in the string are
+--echo # kept as is (unlike in the next case).
+DELIMITER |;
+CREATE PROCEDURE p_str1() LANGUAGE JS AS $$
+  console.log("");
+  console.log("alpha");
+  console.log("%s %d %i %f %o %O %c %%");
+$$|
+DELIMITER ;|
+CALL p_str1();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_str1;
+
+--echo #
+--echo # 1.5) console.log(msg, val1, ... valN) - case with multiple arguments
+--echo #      where the first one is a String.
+--echo #
+--echo # The first argument might contain format specifiers which are replaced
+--echo # by converted values of later arguments, where conversion procedure for
+--echo # each argument is prescribed by corresponding specifier.
+DELIMITER |;
+CREATE PROCEDURE p_strN() LANGUAGE JS AS $$
+  const arg_desc = ["null", "undefined", "10", "12.5", "BigInt(123)", "true",
+                    "'alpha'", "'0.6'", "'123'", "'123abc'",
+                    "[1, 2, 3]", "({ x: 1, y: 'alpha' })",
+                    "({ toString() { return 'Wow!'; } })",
+                    "({ toString() { return '123.45'; } })",
+                    "(function (a) { return a; })",
+                    "new Uint8Array([0, 1, 2, 3])"];
+  const arg_vals = arg_desc.map((s) => eval(s));
+
+  function test_specifier(spec) {
+    const msg_string =  arg_desc.reduce(
+      (m, d) => m + " Arg <" + d + "> converted <" + spec + "> ",
+      "");
+    console.log("Testing specifier :", spec);
+    console.log(msg_string, ...arg_vals);
+  }
+
+  // %s specifier is replaced with argument value converted to String.
+  test_specifier("%s");
+
+  // %d and %i specifiers are replaced with argument value converted to integer.
+  // Conversion is done by converting to String first and then to integer.
+  test_specifier("%d");
+  test_specifier("%i");
+
+  // %f specifier is replaced with argument value converted to floating-point
+  // number. Conversion is done by converting to String first and then to
+  // floating-point number.
+  test_specifier("%f");
+
+  // %o and %O specifiers are replaced with argument converted to representation
+  // useful for debugging.
+  test_specifier("%o");
+  test_specifier("%O");
+
+  // %c is supposed to allow specify CSS for the following text. This does not
+  // make sense in our case. So this specifier is omitted and corresponding
+  // argument is skipped.
+  test_specifier("%c");
+
+  // %% is replaced with a single %. Argument is not consumed.
+  test_specifier("%%");
+
+  // Case when there are more specifiers than arguments.
+  // Specifiers without corresponding arguments are
+  // kept in the message as is.
+  console.log("1 : %s 2 : %s 3 : %s", "a", "b");
+
+  // Case when there are more arguments than specifiers.
+  // Representations of extra arguments useful for debugging are
+  // appended at the end.
+  console.log("1 : %s", "a", "b", "c");
+
+  // Case when message does not contain any specifiers at all.
+  console.log("No specifiers:", "a","b","c");
+$$|
+DELIMITER ;|
+CALL p_strN();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_strN;
+
+--echo #
+--echo # 1.6) Test cases when conversion of console.log() argument fails.
+--echo #
+--echo # Conversion of argument to representation useful for debugging
+--echo # should not fail even if conversion of argument to String fails.
+CREATE PROCEDURE p_val_err() LANGUAGE JS AS $$ console.log({ toString() { throw "Ooops!" } }) $$;
+CALL p_val_err();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_val_err;
+--echo #
+--echo # Conversion to string can fail and the exception should be propagated
+--echo # from console.log() to JS code. If uncaught it results in SQL CALL
+--echo # statement failure with error set accordingly. If caught execution
+--echo # of JS code should continue.
+CREATE PROCEDURE p_str_err() LANGUAGE JS AS $$ console.log("%s", { toString() { throw "Ooops!" } }) $$;
+--error ER_LANGUAGE_COMPONENT
+CALL p_str_err();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_GET_LAST_ERROR_INFO();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_str_err;
+DELIMITER |;
+CREATE PROCEDURE p_str_err_catch() LANGUAGE JS AS $$
+  try {
+    console.log("%s", { toString() { throw "Ooops!" } });
+  } catch (e) {
+    console.log("Got exception:", e);
+  }
+$$|
+DELIMITER ;|
+CALL p_str_err_catch();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_str_err_catch;
+
+--echo #
+--echo # 1.7) Test that console.log() produces console messages with "Info"
+--echo #      log level.
+DELIMITER |;
+CREATE PROCEDURE p_level() LANGUAGE JS AS $$
+  console.log(1, "st message");
+  console.log("Message 2");
+  console.log("Message %s", "Three");
+$$|
+DELIMITER ;|
+CALL p_level();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_level;
+
+--echo #
+--echo # 2) Test coverage for console.info(), warn(), error() and
+--echo #    debug() methods.
+--echo #
+--echo #    They behave exactly the same way as console.log() does
+--echo #    except that they use different log level for messages.
+DELIMITER |;
+CREATE PROCEDURE p_log_like(name VARCHAR(10)) LANGUAGE JS AS $$
+  eval("console."+name+"()");
+  eval("console."+name+"('')");
+  eval("console."+name+"(1)");
+  eval("console."+name+"(2, 3, 'Four')");
+  eval("console."+name+"('Message five - %d')");
+  eval("console."+name+"('Message %s', 'Six')");
+  eval("console."+name+"('Message %d', 7.6, 8, 9)");
+$$|
+DELIMITER ;|
+
+--echo #
+--echo # 2.1) In our implementation console.info() is just an alias for
+--echo #      console.log(), so it uses "Info" level as well.
+CALL p_log_like("info");
+SELECT JS_GET_CONSOLE_LOG();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+--echo #
+--echo # 2.2) console.warn() uses "Warning" log level.
+CALL p_log_like("warn");
+SELECT JS_GET_CONSOLE_LOG();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+--echo #
+--echo # 2.3) console.error() uses "Error" log level.
+CALL p_log_like("error");
+SELECT JS_GET_CONSOLE_LOG();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+--echo #
+--echo # 2.4) console.debug() uses "Debug" log level.
+CALL p_log_like("debug");
+SELECT JS_GET_CONSOLE_LOG();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+DROP PROCEDURE p_log_like;
+
+--echo #
+--echo # 3) Test coverage for console.assert().
+--echo #
+--echo # console.assert() can be considered conditional form of error() call.
+--echo #
+--echo # - Does nothing if its first argument is truthy.
+--echo # - If there are no arguments or there is only one argument which is
+--echo #   falsy "Assertion failed" message is logged with "Error" level.
+--echo # - If there are more than one argument and the first argument is falsy,
+--echo #   it works like the error() call works, when it is passed all the
+--echo #   arguments starting from the second one. "Assertion failed:"
+--echo #   message is prepended to the console log message.
+DELIMITER |;
+CREATE PROCEDURE p_assert() LANGUAGE JS AS $$
+  // Let us check how different condition values are handled.
+  const arg_desc = ["", "null", "undefined", "0", "123", "0.0", "12.5",
+                    "BigInt(0)", "BigInt(123)", "true", "false",
+                    "''", "'alpha'", "'0'", "'0.0'", "'123'",
+                    "[1, 2, 3]", "({ x: 1, y: 'alpha' })",
+                    "({ toString() { return ''; } })",
+                    "({ toString() { throw 'Oops!'; } })",
+                    "(function (a) { return a; })",
+                    "new Uint8Array([0, 1, 2, 3])"];
+
+  for (const a of arg_desc) {
+    console.log("Calling console.assert(%s) results in :", a);
+    eval("console.assert(" + a + ")");
+  }
+
+  console.log("Test console.assert() with more than 1 argument:");
+  console.assert(false, 1, 2, 3);
+  console.assert(false, "four");
+  console.assert(false, "five %s %d", "six", 7.65, 8);
+$$|
+DELIMITER ;|
+CALL p_assert();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_assert;
+
+--echo #
+--echo # 4) Tests for console.count() and console.countReset() calls.
+--echo #
+--echo # 4.1) Basic test for count() and countReset() functionality.
+DELIMITER |;
+CREATE PROCEDURE p_count_basic() LANGUAGE JS AS $$
+  console.log("Call count() for label 'a' thrice and for 'b' once.");
+  console.count("a");
+  console.count("a");
+  console.count("a");
+  console.count("b");
+
+  console.log("Call count() for label 'a' one more time (so its count is 4)");
+  console.count("a");
+
+  console.log("Call countReset() for label 'a'");
+  console.countReset("a");
+
+  console.log("Now call count() for label 'a' one more time and observe " +
+              "that counting has been restarted.");
+  console.count("a");
+
+  console.log("Counter for 'b' should not be affected.");
+  console.count("b");
+
+  console.log("Clean up counters for 'a' and 'b'.");
+  console.countReset("a");
+  console.countReset("b");
+$$|
+DELIMITER ;|
+CALL p_count_basic();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_count_basic;
+
+--echo #
+--echo # 4.2) Arity tests.
+--echo #
+--echo # When no arguments are passed to count() and countReset()
+--echo # 'default' label is used.
+--echo # Extra (second and later) arguments are ignored per standard
+--echo # JS practice.
+DELIMITER |;
+CREATE PROCEDURE p_count_arity() LANGUAGE JS AS $$
+  console.log("Call count() without arguments to show that for label " +
+              "'default' is used.");
+  console.count();
+  console.count();
+  console.log("Call count('default') to show that it is the same label.");
+  console.count('default');
+  console.log("Call countReset() and then count() without arguments to show " +
+              "'default' counter is reset.");
+  console.countReset();
+  console.count();
+
+  console.log("Extra arguments in count() and countReset() are ignored");
+  console.count("a", "b");
+  console.count("b");
+  console.countReset("a", "b");
+  console.count("a");
+  console.count("b");
+
+  console.log("Clean up counters for 'a', 'b' and 'default'.");
+  console.countReset("a");
+  console.countReset("b");
+  console.countReset();
+$$|
+DELIMITER ;|
+CALL p_count_arity();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_count_arity;
+
+--echo #
+--echo # 4.3) Test how arguments of different types are handled and
+--echo #      what happens in case of error.
+--echo #
+--echo # First argument to count()/countReset() is converted to String
+--echo # to get label value. If error happens during this conversion it
+--echo # should be propagated to JS.
+DELIMITER |;
+CREATE PROCEDURE p_count_arg_conv() LANGUAGE JS AS $$
+  console.log("count() - normal case, String argument.");
+  console.count("");
+  console.count("alpha");
+  console.count("123");
+
+  console.log("count() - exotic, non-String arguments, which are converted to String.");
+  console.count(0);
+  console.count(123);
+  console.count(1.5);
+  console.count(true);
+  console.count(BigInt(100));
+  console.count({ toString() { return "Label"; } });
+  console.count([1, 2, 3]);
+
+  console.log("countReset() - normal case, String argument.");
+  console.countReset("");
+  console.countReset("alpha");
+  console.countReset("123");
+
+  console.log("Check values after reset.");
+  console.count("");
+  console.count("alpha");
+  console.count("123");
+
+  console.log("countReset() - exotic, non-String arguments, which are converted to String.");
+  console.countReset(0);
+  console.countReset(123);
+  console.countReset(1.5);
+  console.countReset(true);
+  console.countReset(BigInt(100));
+  console.countReset({ toString() { return "Label"; } });
+  console.countReset([1, 2, 3]);
+
+  console.log("Check values after reset.");
+  console.count(0);
+  console.count(123);
+  console.count(1.5);
+  console.count(true);
+  console.count(BigInt(100));
+  console.count({ toString() { return "Label"; } });
+  console.count([1, 2, 3]);
+
+  console.log("Check what happens if error occurs while converting argument value to String.");
+  try {
+    console.count({ toString() { throw "Ooops!"; } });
+  } catch (e) {
+    console.error("Exception %s caught while calling count().", e);
+  }
+
+  try {
+    console.countReset({ toString() { throw "Arghh!"; } });
+  } catch (e) {
+    console.error("Exception %s caught while calling countReset().", e);
+  }
+
+  console.log("Clean up by resetting counters.");
+  console.countReset("");
+  console.countReset("alpha");
+  console.countReset("123");
+  console.countReset(0);
+  console.countReset(1.5);
+  console.countReset(true);
+  console.countReset(BigInt(100));
+  console.countReset({ toString() { return "Label"; } });
+  console.countReset([1, 2, 3]);
+$$|
+DELIMITER ;|
+CALL p_count_arg_conv();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_count_arg_conv;
+
+--echo #
+--echo # 4.4) Test how labels are compared by count() and countReset() calls.
+--echo #
+--echo # Labels should be compared in the same way as Strings are compared
+--echo # in JS by default (i.e. using binary comparison).
+DELIMITER |;
+CREATE PROCEDURE p_count_label() LANGUAGE JS AS $$
+  console.count("a");
+  console.count("A");
+  console.count("â");
+
+  console.log("Call countReset() for 2 out of 3 labels.");
+  console.countReset("A");
+  console.countReset("â");
+
+  console.log("Check that 2 out of 3 counters were reset.");
+  console.count("a");
+  console.count("A");
+  console.count("â");
+
+  console.log("Clean up counters.");
+  console.countReset("a");
+  console.countReset("A");
+  console.countReset("â");
+$$|
+DELIMITER ;|
+CALL p_count_label();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_count_label;
+
+--echo #
+--echo # 4.5) Test that count() produces messages with 'Info' log level.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_count_log_level() LANGUAGE JS AS $$
+  console.count("label");
+  console.count();
+
+  console.countReset("label");
+  console.countReset();
+$$|
+DELIMITER ;|
+CALL p_count_log_level();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_count_log_level;
+
+--echo #
+--echo # 4.6) Finally, test that countReset() produces a warning if label
+--echo #      was not used with count() before.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_count_no_label() LANGUAGE JS AS $$
+  console.log("Test what happens if label was not used before at all.");
+  console.countReset("no-such-label");
+
+  console.log("Also test case when the label was used but its count has ");
+  console.log("been reset already. Spec says there should be no warning ");
+  console.log("in this case, but implementations still warn.");
+  console.count("label");
+  console.countReset("label");
+  console.countReset("label");
+
+  console.log("Same for 'default' case.");
+  console.countReset();
+$$|
+DELIMITER ;|
+CALL p_count_no_label();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_count_no_label;
+
+--echo #
+--echo # 5) Tests for console.time(), timeEnd() and timeLog() calls.
+--echo #
+--echo # 5.1) Basic tests for time(), timeLog() and timeEnd() functionality.
+DELIMITER |;
+CREATE PROCEDURE p_time_basic() LANGUAGE JS AS $$
+  console.log("Start timers 'a', 'b', and 'c'.");
+  console.time("a");
+  console.time("b");
+  console.time("c");
+
+  console.timeLog("c", "Call timeLog for 'c'.");
+  console.log("Stop timer 'c'.");
+  console.timeEnd("c");
+
+  console.timeLog("b", "Call timeLog for 'b' and then stop it.");
+  console.timeEnd("b");
+
+  console.log("Start timer'b' again");
+  console.time("b");
+
+  console.log("Stop timers 'a' and 'b'.");
+  console.timeEnd("b");
+  console.timeEnd("a");
+$$|
+DELIMITER ;|
+CALL p_time_basic();
+--echo # Mask elapsed times in the output as they are of course not repeatable.
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_time_basic;
+
+--echo #
+--echo # 5.2) Arity tests.
+--echo #
+--echo # When no arguments are passed to time(), timeLog() and timeEnd()
+--echo # 'default' label is used.
+--echo # Extra (second and later) arguments for time() and timeEnd() are
+--echo # ignored per standard JS practice.
+
+DELIMITER |;
+CREATE PROCEDURE p_time_arity() LANGUAGE JS AS $$
+  console.log("Call time() , timeLog() and timeEnd() without arguments to" +
+              " show 'default' is used as label in this case.");
+  console.time();
+  console.timeLog();
+  console.timeEnd();
+  console.log("Call time() and than timeLog('default') and timeEnd('default')" +
+              "to show that it is the same label.");
+  console.time();
+  console.timeLog("default");
+  console.timeEnd("default");
+
+  console.log("Extra arguments in time() and timeEnd() are ignored");
+  console.time("a", "b");
+  console.timeEnd("a");
+  console.time("c");
+  console.timeEnd("c", "d");
+
+  console.log("The 2nd and later arguments of timeLog() are appended to the message.");
+  console.time("e");
+  console.timeLog("e", 1, -2, "three");
+  console.log("Unlike for assert format specifiers are not supported.");
+  console.timeLog("e", "%s message", "four");
+  console.timeEnd("e");
+$$|
+DELIMITER ;|
+CALL p_time_arity();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_time_arity;
+
+--echo #
+--echo # 5.3) Test how time(), timeLog() and timeEnd() handle values of
+--echo #      different types passed to them as the first argument and
+--echo #      what happens in case of error.
+--echo #
+--echo # The first argument in these calls is converted to String to get
+--echo # label value. If error happens during this conversion it should
+--echo # be propagated to JS.
+DELIMITER |;
+CREATE PROCEDURE p_time_arg_conv() LANGUAGE JS AS $$
+  console.log("Normal case, String argument.");
+  console.time("");
+  console.time("alpha");
+  console.time("123");
+
+  console.timeLog("", "by timeLog()");
+  console.timeLog("alpha", "by timeLog()");
+  console.timeLog("123", "by timeLog()");
+
+  console.timeEnd("");
+  console.timeEnd("alpha");
+  console.timeEnd("123");
+
+  console.log("Exotic, non-String arguments, which are converted to String.");
+  console.time(0);
+  console.time(123);
+  console.time(1.5);
+  console.time(true);
+  console.time(BigInt(100));
+  console.time({ toString() { return "Label"; } });
+  console.time([1, 2, 3]);
+
+  console.timeLog(0, "by timeLog()");
+  console.timeLog(123, "by timeLog()");
+  console.timeLog(1.5, "by timeLog()");
+  console.timeLog(true, "by timeLog()");
+  console.timeLog(BigInt(100), "by timeLog()");
+  console.timeLog({ toString() { return "Label"; } }, "by timeLog()");
+  console.timeLog([1, 2, 3], "by timeLog()");
+
+  console.timeEnd(0);
+  console.timeEnd(123);
+  console.timeEnd(1.5);
+  console.timeEnd(true);
+  console.timeEnd(BigInt(100));
+  console.timeEnd({ toString() { return "Label"; } });
+  console.timeEnd([1, 2, 3]);
+
+  console.log("Check what happens if error occurs while converting the " +
+              "first argument value to String.");
+  try {
+    console.time({ toString() { throw "Ooops!"; } });
+  } catch (e) {
+    console.error("Exception %s caught while calling time().", e);
+  }
+
+  try {
+    console.timeLog({ toString() { throw "Arghh!"; } });
+  } catch (e) {
+    console.error("Exception %s caught while calling timeLog().", e);
+  }
+
+  try {
+    console.timeEnd({ toString() { throw "Ouch!"; } });
+  } catch (e) {
+    console.error("Exception %s caught while calling timeEnd().", e);
+  }
+$$|
+DELIMITER ;|
+CALL p_time_arg_conv();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_time_arg_conv;
+
+--echo #
+--echo # 5.4) Test how timeLog() handles values of the second and later
+--echo #      arguments of different types.
+--echo #
+--echo # These arguments are converted to String representation useful
+--echo # for debugging purposes and they results are appended to the
+--echo # message about elapsed time. Unlike in assert() format specifiers
+--echo # in the second argument are not processed.
+DELIMITER |;
+CREATE PROCEDURE p_timelog_args() LANGUAGE JS AS $$
+  // Let us check how different condition values are handled.
+  const arg_desc = ["", "null", "undefined", "0", "123", "0.0", "12.5",
+                    "BigInt(0)", "BigInt(123)", "true", "false",
+                    "''", "'alpha'", "'0'", "'0.0'", "'123'",
+                    "[1, 2, 3]", "({ x: 1, y: 'alpha' })",
+                    "({ toString() { return 'Message'; } })",
+                    "({ toString() { throw 'Oops!'; } })",
+                    "(function (a) { return a; })",
+                    "new Uint8Array([0, 1, 2, 3])"];
+
+  console.time('a');
+  for (const a of arg_desc) {
+    console.log("Calling console.timeLog('a', %s) results in :", a);
+    eval("console.timeLog('a', " + a + ")");
+  }
+
+  console.log("Test console.timeLog() with more than 2 arguments:");
+  console.timeLog('a', 1, 2, 3);
+  console.timeLog('a', "four");
+  console.log("Format specifiers should not be processed:");
+  console.timeLog('a', "five %s %d", "six", 7.65, 8);
+
+  console.timeEnd('a');
+$$|
+DELIMITER ;|
+CALL p_timelog_args();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_timelog_args;
+
+--echo #
+--echo # 5.5) Test how labels are compared by time(), timeLog() and
+--echo #      timeEnd() calls.
+--echo #
+--echo # Labels should be compared in the same way as Strings are compared
+--echo # in JS by default (i.e. using binary comparison).
+DELIMITER |;
+CREATE PROCEDURE p_time_label() LANGUAGE JS AS $$
+  console.log("Start timer 'a' and then call timeLog() for labels 'A' and 'â'.");
+  console.time("a");
+  console.timeLog("A");
+  console.timeLog("â");
+
+  console.log("Now try to end the time using labels 'A' and 'â'.");
+  console.timeEnd("A");
+  console.timeEnd("â");
+
+  console.timeEnd("a");
+$$|
+DELIMITER ;|
+CALL p_time_label();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_time_label;
+
+--echo #
+--echo # 5.6) Test that timeLog() and timeEnd() produce messages with 'Info'
+--echo #      log level.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_time_log_level() LANGUAGE JS AS $$
+  console.time("label");
+  console.time();
+
+  console.timeLog("label");
+  console.timeLog("label", "Additional message.");
+  console.timeLog();
+
+  console.timeEnd();
+  console.timeEnd("label");
+$$|
+DELIMITER ;|
+CALL p_time_log_level();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_time_log_level;
+
+--echo #
+--echo # 5.7) Finally, test that time() produces a warning if timer
+--echo #      already has been started for the label, and that
+--echo #      timeLog() and timeEnd() produce warnings if there is
+--echo #      no active timer for the label.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_time_warn() LANGUAGE JS AS $$
+  console.log("Test what happens if we call time() for already used label.");
+  console.time("label");
+  console.time("label");
+
+  console.log("But after timeEnd() calling time() for previously used " +
+              "label should be OK.");
+  console.timeEnd("label");
+  console.time("label");
+
+  console.log("Calling timeLog() and timeEnd() for label without timer " +
+              "started should produce warning.");
+  console.timeLog("no-such-label");
+  console.timeEnd("no-such-label");
+
+  console.log("Even if there was timer for the label in the past.");
+  console.timeEnd("label");
+  console.timeLog("label");
+  console.timeEnd("label");
+$$|
+DELIMITER ;|
+CALL p_time_warn();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_time_warn;
+
+--echo #
+--echo # 6) Tests for console.group(), groupCollapsed() and groupEnd() calls.
+--echo #
+--echo # 6.1) Basic functionality tests for group(), groupCollapsed() and
+--echo #      groupEnd().
+DELIMITER |;
+CREATE PROCEDURE p_group_basic() LANGUAGE JS AS $$
+  console.log("No group at this level..");
+
+  console.group("a");
+  console.log("This should go to group 'a'.");
+
+  console.group("b");
+  console.log("This should go to group 'b' under group 'a'.");
+  console.groupEnd();
+
+  console.log("This should go to group 'a' again.");
+
+  console.group("b");
+  console.log("This should go to a new group 'b' under group 'a'.");
+  console.groupEnd();
+
+  console.group("c");
+  console.log("This should go to group 'c' under group 'a'.");
+
+  console.groupEnd();
+
+  console.log("We should be back at group 'a' once again.");
+
+  console.groupEnd();
+  console.log("We should be back at basic level.");
+$$|
+DELIMITER ;|
+CALL p_group_basic();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_basic;
+
+--echo #
+--echo # 6.2) Test coverage for argument handling in group()/groupCollapsed()
+--echo #      and groupEnd() calls.
+--echo #
+--echo # 6.2.1) group() call without argument creates a group without
+--echo #        a lable (null in JSON represenation). This is different
+--echo #        from empty ("") group label. No group label is logged
+--echo #        in the former case.
+DELIMITER |;
+CREATE PROCEDURE p_group_no_label() LANGUAGE JS AS $$
+  console.log("Group without label:");
+  console.group();
+  console.log("This should go into group without label/null in JSON.");
+  console.groupEnd();
+
+  console.log("Group with empty label:");
+  console.group("");
+  console.log("This should go into group with label name ('').");
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_group_no_label();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_no_label;
+
+--echo #
+--echo # 6.2.2) In case when group() call has arguments they are processed
+--echo #        similarly to arguments of log() call to create group label.
+--echo #
+--echo # - If first argument is not a String, then group label is created by
+--echo #   concatenating representations of each argument useful for debugging
+--echo #   purposes separated by spaces.
+--echo # - In case of single String argument it is used as group label as is.
+--echo # - In case when there are more than one argument and first argument
+--echo #   is String we build label by replacing format specifiers in the
+--echo #   first argument string with by converted values of later arguments,
+--echo #   where conversion procedure for each argument is prescribed by
+--echo #   corresponding specifier.
+DELIMITER |;
+CREATE PROCEDURE p_group_args() LANGUAGE JS AS $$
+  console.group(1);
+  console.log("This goes into group with converted Number as label.");
+  console.groupEnd();
+
+  console.group(true, 1.0, "alpha", [1, 2, 3],
+                { toString() { return "label"; } });
+  console.log("This goes into group with label constructed from debugging " +
+              "representation of arguments.");
+  console.groupEnd();
+
+  console.group("String group label %% %s");
+  console.log("This goes into group with label which is verbatim value of " +
+              "single String argument.");
+  console.groupEnd();
+
+  console.group("String without specifiers.", 1, "One more String.", [1, 2, 3]);
+  console.log("This goes into group with label which is built from the first " +
+              "String argument without specifiers and some more arguments.");
+  console.groupEnd();
+
+  console.group("One %s three %d five", { toString() { return "two"; } }, 4);
+  console.log("This goes into group with label which is built by processing " +
+              "specifiers in the first String argument.");
+  console.groupEnd();
+
+  console.group("One %s", 2, [3, 4, 5]);
+  console.log("This goes into group with label which is built by processing " +
+              "specifiers in the first String argument and there more " +
+              "arguments than specifiers.");
+  console.groupEnd();
+
+  console.group("One %s %d %s End!", "Two", "3");
+  console.log("This goes into group with label which is built by processing " +
+              "specifiers in the first String argument and there too few " +
+              "arguments.");
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_group_args();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_args;
+
+--echo #
+--echo # 6.2.3) Also test what happens when group() gets an error while
+--echo #        converting its arguments.
+DELIMITER |;
+CREATE PROCEDURE p_group_arg_error() LANGUAGE JS AS $$
+  console.group({ toString() { throw "Ooops!!!"; } } );
+  console.log("This should into group with a valid label.");
+  console.groupEnd();
+
+  try {
+    console.group("Message %s", { toString() { throw "Ouch!!!"; } });
+    console.log("This should have gone into group, but we have got error " +
+                 "while building label.");
+    console.groupEnd();
+  } catch (e) {
+    console.error("Error while calling console.group() : ", e);
+  }
+$$|
+DELIMITER ;|
+CALL p_group_arg_error();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           level VARCHAR(10) PATH "$.level",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_arg_error;
+
+--echo #
+--echo # 6.2.4) "Arity" of groupEnd() call.
+--echo #
+--echo # We follow standard JS practice and just ignore all extra (that is all)
+--echo # to this call.
+DELIMITER |;
+CREATE PROCEDURE p_groupend_arity() LANGUAGE JS AS $$
+  console.group("a");
+  console.log("This goes into group 'a'.");
+  console.groupEnd("b");
+
+  console.log("This should be outside any group.");
+
+  console.group("a");
+  console.group("b");
+  console.log("This goes into group 'b' in group 'a'.");
+  console.groupEnd("a");
+  console.log("This still goes into group 'a'.");
+  console.groupEnd();
+
+  console.log("This should be outside any group as well.");
+
+  console.group("c");
+  console.log("This goes into group 'c'.");
+  console.groupEnd("d", "e", 6, 7.1);
+
+  console.log("And this should be outside any group too.");
+$$|
+DELIMITER ;|
+CALL p_groupend_arity();
+SELECT * FROM JSON_TABLE(JS_GET_CONSOLE_LOG_JSON(),
+                         "$[*]" COLUMNS(
+                           gs0 VARCHAR(3) PATH "$.groups[0]",
+                           gs1 VARCHAR(3) PATH "$.groups[1]",
+                           message VARCHAR(100) PATH "$.message")
+                        ) AS jslog;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_groupend_arity;
+
+--echo #
+--echo # 6.3) Test case for groups with the label name on the group stack.
+--echo #
+--echo # Even though it is exotic case, it is perfectly legal to have nested
+--echo # groups with the label. Group labels are mostly for user convinience
+--echo # they do not identify groups.
+DELIMITER |;
+CREATE PROCEDURE p_group_dupname() LANGUAGE JS AS $$
+  console.group("a");
+  console.group("b");
+  console.group("a");
+  console.log("This goes to group 'a' under group 'b' under group 'a' " +
+              "(different one!).");
+  console.groupEnd();
+  console.groupEnd();
+  console.groupEnd();
+
+  console.group();
+  console.group();
+  console.log("Another exotic case. This goes into 2nd level group. " +
+              "Both levels do not have labels (null in JSON).");
+  console.groupEnd();
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_group_dupname();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_dupname;
+
+--echo #
+--echo # 6.4) Test case for groupCollapsed() call.
+--echo #
+--echo # In our implementation groupCollapsed() is an alias for group() call.
+DELIMITER |;
+CREATE PROCEDURE p_groupcollapsed() LANGUAGE JS AS $$
+  console.groupCollapsed("a");
+  console.log("This goes to group 'a'");
+
+  console.groupCollapsed("b %s", "Two", 3);
+  console.log("This goes to group 'b Two 3' under group 'a'");
+  console.groupEnd();
+
+  console.log("This goes to group 'a' again.");
+
+  console.group(123);
+  console.log("This goes to group '123' under group 'a'");
+  console.groupEnd();
+
+  console.groupEnd();
+
+  console.log("This goes outside any group.");
+$$|
+DELIMITER ;|
+CALL p_groupcollapsed();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_groupcollapsed;
+
+--echo #
+--echo # 6.5) Test that console log entries with group labels generated by
+--echo #      group()/groupCollapsed() calls get 'Info' log level.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_group_log_level() LANGUAGE JS AS $$
+  console.group("g1");
+  console.warn("This warning goes to group 'g1'");
+  console.groupEnd();
+
+  console.groupCollapsed("g2");
+  console.error("This error goes to group 'g2'");
+
+  console.group("g3");
+  console.debug("This debug messages goes to group 'g3' under group 'g2'.");
+  console.groupEnd();
+
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_group_log_level();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_log_level;
+
+--echo #
+--echo # 6.6) Test that output of all console calls goes to the group on the
+--echo #      top of the group stack.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_group_top() LANGUAGE JS AS $$
+  console.group("a");
+  console.group("b");
+
+  console.assert(false, "assert() message should go to group 'b' under 'a'");
+  console.debug("debug() message should go to group 'b' under 'a'");
+  console.error("error() message should go to group 'b' under 'a'");
+  console.info("info() message should go to group 'b' under 'a'");
+  console.log("log() message should go to group 'b' under 'a'");
+  console.warn("warn() message should go to group 'b' under 'a'");
+
+  const cnt_label = "count() result should go to to group 'b' under 'a'";
+  console.count(cnt_label);
+  console.countReset(cnt_label);
+
+  const time_label ="timeEnd()/timeLog() result should go to group 'b' too";
+  console.time(time_label);
+  console.timeLog(time_label, "extra");
+  console.timeEnd(time_label);
+
+  console.group("Finally label for nested group should go to 'b' as well");
+  console.log("This goes into the nested group under 'b' under 'a'");
+  console.groupEnd();
+
+  console.groupEnd();
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_group_top();
+--replace_regex /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/ /[0-9]+\.[0-9]{3}/X.XXX/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_top;
+
+--echo #
+--echo # 6.7) Test special semantics of console.clear() for groups,
+--echo #      it should empty group stack as a side-effect.
+--echo #      OTOH JS_CLEAR_CONSOLE_LOG() should not have the same
+--echo #      side-effect.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_group_clear() LANGUAGE JS AS $$
+  console.group("a");
+  console.group("b");
+  console.log("This should go into group 'b' under group 'a'. " +
+              "But we won't see this.");
+
+  console.clear();
+  console.log("console.clear() call resets groups stack, so this " +
+              "should go to the top level.");
+$$|
+CREATE PROCEDURE p_group_clear_udf_begin() LANGUAGE JS AS $$
+  console.group("a");
+  console.group("b");
+  console.log("This should go into group 'b' under group 'a'.");
+$$|
+CREATE PROCEDURE p_group_clear_udf_end() LANGUAGE JS AS $$
+  console.log("This should go into group 'b' under group 'a' as well.");
+  console.groupEnd();
+  console.groupEnd();
+$$|
+DELIMITER ;|
+
+--echo # Test console.clear() call first.
+CALL p_group_clear();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+--echo # Now test how JS_CLEAR_CONSOLE_LOG() UDF behaves.
+CALL p_group_clear_udf_begin();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+CALL p_group_clear_udf_end();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+
+--echo # Clean-up.
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_group_clear_udf_begin;
+DROP PROCEDURE p_group_clear_udf_end;
+DROP PROCEDURE p_group_clear;
+
+--echo #
+--echo # 6.8) Finally, let us test what happens when there is groupEnd()
+--echo #      call without prior group() call.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_groupend_unbalanced() LANGUAGE JS AS $$
+  console.log("This doesn't belong to any group.");
+  console.groupEnd();
+  console.log("Neither this.");
+
+  console.group("a");
+  console.log("This goes to group 'a'.");
+  console.groupEnd();
+  console.groupEnd();
+
+  console.log("This doesn't belong to any group as well.");
+$$|
+DELIMITER ;|
+CALL p_groupend_unbalanced();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_groupend_unbalanced;
+
+--echo #
+--echo # 7) Test coverage for console.clear() call.
+--echo #
+--echo # console.clear() should remove all messages from console log
+--echo # and also reset the group stack.
+DELIMITER |;
+CREATE PROCEDURE p_clear() LANGUAGE JS AS $$
+  console.clear("But first, test that clear()", "ignores its", "args...");
+
+  console.assert(false, "This assert() message should be removed.");
+  console.debug("So this debug() message.");
+  console.error("And this error() message too.");
+  console.info("Ditto this info() message.");
+  console.log("And this log() message.");
+  console.warn("And this warn() message as well.");
+
+  const cnt_label = "count() result should be removed as well.";
+  console.count(cnt_label);
+  console.countReset(cnt_label);
+
+  const time_label ="So the messages from timeEnd()/timeLog().";
+  console.time(time_label);
+  console.timeLog(time_label, "extra");
+  console.timeEnd(time_label);
+
+  console.group("Finally, this label for this group should be removed.");
+  console.log("And the message which goes into this group.");
+
+  console.clear();
+
+  console.log("This message is the only which should be left. " +
+              "Since clear() resets group stack it should go to top level.");
+
+$$|
+DELIMITER ;|
+CALL p_clear();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_clear;
+
+--echo #
+--echo # 8) Test what happens when one invokes console calls which are
+--echo #    present in specification but are not unsupported (yet?).
+--echo #
+--echo # These functions do not do anything at the moment.
+DELIMITER |;
+CREATE PROCEDURE p_unsupported() LANGUAGE JS AS $$
+  console.table(["Output",  "of",  "table()", "is", "ignored"]);
+  console.trace("trace() does nothing too.");
+  console.dir({  a: "So dir() as well." });
+  console.dirxml({  a: "Neither dirxml() does anything." });
+$$|
+DELIMITER ;|
+CALL p_unsupported();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_unsupported;
+
+--echo #
+--echo # 9) Test that we correctly escape strings in JS_GET_CONSOLE_LOG_JSON()
+--echo #    output (at this point only message and group names need this).
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_json_escaping() LANGUAGE JS AS $$
+  console.log("RFC7159 says that the following characters need escaping:");
+  console.log("- All control characters (0x00 - 0x1F), among them:");
+  console.log("  * Bell <\u0007>");
+  console.log("  * Backspace <\b>");
+  console.log("  * Tab <\t>");
+  console.log("  * New line <\n>");
+  console.log('- Quotation mark (")');
+  console.log("- Reverse solidus \\ (aka escape character)");
+
+  console.log("Apostrophe doesn't neeed quoting, and in fact doing this " +
+              "by simply adding reverse solidus before it is against RFC.");
+
+  console.group("Escaping should be also done for group labels <\"example\">");
+  console.log("This goes into group");
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_json_escaping();
+--echo # There should be no escaping in JS_GET_CONSOLE_LOG() output case.
+SELECT JS_GET_CONSOLE_LOG();
+--echo # But there should be when output is JSON!
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_json_escaping;
+
+--echo #
+--echo # 10) Test that one can limit how much console lines are buffered
+--echo #     by using js_lang.max_console_log_size variable.
+--echo #
+--echo # 10.1) First, case when limit is exceeded due to total length of
+--echo #       messages.
+--echo #
+--echo # Set limit to minimal supported value.
+SET GLOBAL js_lang.max_console_log_size = 10240;
+DELIMITER |;
+CREATE PROCEDURE p_log_10240_and_some() LANGUAGE JS AS $$
+  for (let i = 0; i < 1024; i++) {
+    console.log("0123456789");
+  }
+  console.log("And more...");
+$$|
+DELIMITER ;|
+CALL p_log_10240_and_some();
+--echo # Simple console output should be definitely within the limit.
+SELECT LENGTH(JS_GET_CONSOLE_LOG()) <= 1024 * 10;
+--echo # JSON version of console output can easily exceed the limit
+--echo # since it doesn't account for things like timestamps, severity,
+--echo # JSON field names, indentation and quotes. Magic number 130
+--echo # is there to take overhead from these factors into account.
+SELECT LENGTH(JS_GET_CONSOLE_LOG_JSON()) <= 1024 * (130 + 10);
+--echo # As each log messages needs at least 10 bytes total number
+--echo # of messages should be below 1024.
+SELECT JS_CLEAR_CONSOLE_LOG() <= 1024;
+DROP PROCEDURE p_log_10240_and_some;
+
+--echo #
+--echo # 10.2) Then, case when limit is exceeded thanks to group stack info.
+DELIMITER |;
+CREATE PROCEDURE p_log_10240_and_some_group() LANGUAGE JS AS $$
+  console.group("0123456789");
+  for (let i = 0; i < 1024; i++) {
+    console.log("");
+  }
+  console.groupEnd();
+$$|
+DELIMITER ;|
+CALL p_log_10240_and_some_group();
+--echo # Since each message takes at least 10 bytes thanks to group stack,
+--echo # the total number of messages should be below 1024.
+--echo # Simple console output will consist from this number of lines,
+--echo # where each line contains 2 spaces (group indent) + '\n' char.
+SELECT LENGTH(JS_GET_CONSOLE_LOG()) <= 1024 * (2 + 1);
+--echo # Again JSON version of console output can exceed the limit.
+--echo # Same magic number 130 as in case 10.1) to the rescue.
+SELECT LENGTH(JS_GET_CONSOLE_LOG_JSON()) <= 1024 * (130 + 10);
+--echo # Naturally total number of messages should be below 1024.
+SELECT JS_CLEAR_CONSOLE_LOG() <= 1024;
+DROP PROCEDURE p_log_10240_and_some_group;
+
+--echo #
+--echo # 10.3) Finally, extreme case with single huge message which exceeds
+--echo #       the limit.
+DELIMITER |;
+CREATE PROCEDURE p_log_huge() LANGUAGE JS AS $$
+  console.log("0123456789".repeat(1024 + 1));
+$$|
+DELIMITER ;|
+CALL p_log_huge();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_log_huge;
+SET GLOBAL js_lang.max_console_log_size = DEFAULT;
+
+--echo #
+--echo # 11) Now let us test security aspect of console support.
+--echo #
+DELIMITER |;
+CREATE PROCEDURE p_definer() LANGUAGE JS AS $$
+  console.log("Test definer!");
+$$|
+CREATE PROCEDURE p_invoker() SQL SECURITY INVOKER LANGUAGE JS AS $$
+  console.log("Test invoker!");
+$$|
+CREATE FUNCTION f_log() RETURNS VARCHAR(100) RETURN JS_GET_CONSOLE_LOG() |
+DELIMITER ;|
+CREATE USER u_other@localhost;
+GRANT EXECUTE ON test.* TO u_other@localhost;
+
+--connect (con_other, localhost, u_other,,)
+--echo # Test case when user never run any JS at all first.
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+--echo # Execution of SQL SECURITY DEFINER routine doesn't affect
+--echo # current user's JS console log.
+CALL p_definer();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+
+--echo # Log contents should be visible from routine DEFINER context.
+SELECT f_log();
+
+--echo # Execution of SQL SECURITY INVOKER routine affects current user's
+--echo # console log as expected.
+CALL p_invoker();
+SELECT JS_GET_CONSOLE_LOG();
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT JS_GET_CONSOLE_LOG_JSON();
+SELECT JS_CLEAR_CONSOLE_LOG();
+SELECT JS_GET_CONSOLE_LOG();
+SELECT JS_GET_CONSOLE_LOG_JSON();
+
+--echo # Console log associated with root@localhost security context was
+--echo # not affected.
+SELECT f_log();
+
+--echo # Clean-up.
+--disconnect con_other
+--source include/wait_until_disconnected.inc
+--connection default
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP PROCEDURE p_definer;
+DROP PROCEDURE p_invoker;
+DROP FUNCTION f_log;
+DROP USER u_other@localhost;
+
+--echo #
+--echo # 12) Check types, charset and nullability of return values for
+--echo #     JS_GET_CONSOLE_LOG() UDF and friends.
+--echo #
+--echo # 12.1) Test type, charset and nullability.
+DELIMITER |;
+CREATE PROCEDURE p_log_some() LANGUAGE JS AS $$
+  console.log("Log something...");
+  console.error("And then log something as error...");
+$$|
+DELIMITER ;|
+CALL p_log_some();
+CREATE TABLE t_s AS SELECT JS_GET_CONSOLE_LOG();
+CREATE TABLE t_j AS SELECT JS_GET_CONSOLE_LOG_JSON();
+CREATE TABLE t_c AS SELECT JS_CLEAR_CONSOLE_LOG();
+SHOW CREATE TABLE t_s;
+SELECT * FROM t_s;
+SHOW CREATE TABLE t_j;
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/YYYY-MM-DD HH:MM:SS.FFFFFF/
+SELECT * FROM t_j;
+SHOW CREATE TABLE t_c;
+SELECT * FROM t_c;
+DROP TABLES t_s, t_j, t_c;
+DROP PROCEDURE p_log_some;
+
+--echo #
+--echo # 12.2) Let us also check what happens if we return fairly big result
+--echo #       from JS_GET_CONSOLE_LOG() and JS_GET_CONSOLE_LOG_JSON() UDFs.
+SET GLOBAL js_lang.max_console_log_size = 21*1024*1024;
+DELIMITER |;
+CREATE PROCEDURE p_log_more_than_mediumtext() LANGUAGE JS AS $$
+  for (let i = 0; i < 1024; i++) {
+    console.log("01234567890123456789".repeat(1024));
+  }
+$$|
+DELIMITER ;|
+CALL p_log_more_than_mediumtext();
+SELECT LENGTH(JS_GET_CONSOLE_LOG()) > 20*1024*1024;
+SELECT LENGTH(JS_GET_CONSOLE_LOG_JSON()) > 20*1024*1024;
+--echo # Also check that we correctly store returned output
+--echo # when using CREATE TABLE ... SELECT UDF().
+CREATE TABLE t_s AS SELECT JS_GET_CONSOLE_LOG() AS l;
+CREATE TABLE t_j AS SELECT JS_GET_CONSOLE_LOG_JSON() AS l;
+SELECT LENGTH(l) > 20*1024*1024 FROM t_s;
+SELECT LENGTH(l) > 20*1024*1024 FROM t_j;
+SELECT JS_CLEAR_CONSOLE_LOG();
+DROP TABLES t_s, t_j;
+DROP PROCEDURE p_log_more_than_mediumtext;
+SET GLOBAL js_lang.max_console_log_size = DEFAULT;
+
+--echo #
+--echo # Final clean-up.
+REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
+
+--echo # Disconnect of default connection to free the only remaining
+--echo # connection context and isolate, so we can uninstall component.
+--disconnect default
+--source include/wait_until_disconnected.inc
+--connect(default,localhost,root)
+
+UNINSTALL COMPONENT 'file://component_js_lang';
+
+--echo # Restart server to let subsequent tests to do INSTALL COMPONENT freely.
+--source include/restart_mysqld.inc
+
+--disable_connect_log


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9192

Added support for JS Console Log to our implementation of JS Stored Programs.

Users can now use console.log() and other calls described in the JS Console Standard in their JS Stored Programs to log messages to debugging console. And then access to buffered output of the console through UDFs.

The main purpose of this tool is to simplify debugging and profiling of JS routines.

A few things to note:
- Most of calls described in JS Console Standard are supported.
- Each connection and user pair gets its own Console instance (similarly to JS Contexts).
- While JS_GET_CONSOLE_LOG() UDF provides access to simple, plain version of console output (similar to Node.JS), JS_GET_CONSOLE_LOG_JSON() provides access to extended, more structured version of console log in JSON form.
- We also support clearing the console log from SQL session through JS_CLEAR_CONSOLE_LOG() UDF.

Added test coverage for this functionality.