### PR TITLE
PS-9757 [8.4]: Azure Pipelines: Ubuntu 20.04 LTS runner will be removed on 2025-04-15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ pr:
 jobs:
 - job: BiDiScan
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
 
   steps:
   - checkout: self
@@ -62,7 +62,7 @@ jobs:
     vmImage: $(imageName)
 
   variables:
-    UBUNTU_CODE_NAME: focal
+    UBUNTU_CODE_NAME: jammy
     USE_CCACHE: 1
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     CCACHE_COMPRESS: 1
@@ -87,50 +87,67 @@ jobs:
           Compiler: clang
           BuildType: Debug
 
-      # clang-12 and newer compilers
-      clang-19 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        UBUNTU_CODE_NAME: jammy
+
+      # clang-14 and newer compilers
+      clang-20 RelWithDebInfo [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        UBUNTU_CODE_NAME: noble
         Compiler: clang
-        CompilerVer: 19
+        CompilerVer: 20
         BuildType: RelWithDebInfo
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-19 RelWithDebInfo INVERTED [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
+        clang-20 RelWithDebInfo INVERTED [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
           Compiler: clang
-          CompilerVer: 19
+          CompilerVer: 20
           BuildType: RelWithDebInfo
           BUILD_PARAMS_TYPE: inverted
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-19 Debug [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
+        clang-20 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
           Compiler: clang
-          CompilerVer: 19
+          CompilerVer: 20
           BuildType: Debug
 
-      clang-19 Debug INVERTED [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        UBUNTU_CODE_NAME: jammy
+      clang-20 Debug INVERTED [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        UBUNTU_CODE_NAME: noble
         Compiler: clang
-        CompilerVer: 19
+        CompilerVer: 20
         BuildType: Debug
         BUILD_PARAMS_TYPE: inverted
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-18 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
+        clang-19 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 19
+          BuildType: RelWithDebInfo
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-19 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 19
+          BuildType: Debug
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-18 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
           Compiler: clang
           CompilerVer: 18
           BuildType: RelWithDebInfo
 
-      clang-18 Debug [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        UBUNTU_CODE_NAME: jammy
+      clang-18 Debug [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        UBUNTU_CODE_NAME: noble
         Compiler: clang
         CompilerVer: 18
         BuildType: Debug
@@ -138,7 +155,6 @@ jobs:
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-17 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
           Compiler: clang
           CompilerVer: 17
           BuildType: RelWithDebInfo
@@ -146,7 +162,6 @@ jobs:
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-17 Debug [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
           Compiler: clang
           CompilerVer: 17
           BuildType: Debug
@@ -154,14 +169,12 @@ jobs:
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-16 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
           Compiler: clang
           CompilerVer: 16
           BuildType: RelWithDebInfo
 
       clang-16 Debug [Ubuntu 22.04 Jammy]:
         imageName: 'ubuntu-22.04'
-        UBUNTU_CODE_NAME: jammy
         Compiler: clang
         CompilerVer: 16
         BuildType: Debug
@@ -169,7 +182,6 @@ jobs:
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-15 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
           Compiler: clang
           CompilerVer: 15
           BuildType: RelWithDebInfo
@@ -177,49 +189,22 @@ jobs:
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-15 Debug [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
-          UBUNTU_CODE_NAME: jammy
           Compiler: clang
           CompilerVer: 15
           BuildType: Debug
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-14 RelWithDebInfo [Ubuntu 20.04 Focal]:
-          imageName: 'ubuntu-20.04'
-          Compiler: clang
-          CompilerVer: 14
-          BuildType: RelWithDebInfo
+      clang-14 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+        imageName: 'ubuntu-22.04'
+        Compiler: clang
+        CompilerVer: 14
+        BuildType: RelWithDebInfo
 
-      clang-14 Debug [Ubuntu 20.04 Focal]:
-        imageName: 'ubuntu-20.04'
+      clang-14 Debug [Ubuntu 22.04 Jammy]:
+        imageName: 'ubuntu-22.04'
         Compiler: clang
         CompilerVer: 14
         BuildType: Debug
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-13 RelWithDebInfo [Ubuntu 20.04 Focal]:
-          imageName: 'ubuntu-20.04'
-          Compiler: clang
-          CompilerVer: 13
-          BuildType: RelWithDebInfo
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-13 Debug [Ubuntu 20.04 Focal]:
-          imageName: 'ubuntu-20.04'
-          Compiler: clang
-          CompilerVer: 13
-          BuildType: Debug
-
-      clang-12 RelWithDebInfo [Ubuntu 20.04 Focal]:
-        imageName: 'ubuntu-20.04'
-        Compiler: clang
-        CompilerVer: 12
-        BuildType: RelWithDebInfo
-
-      clang-12 Debug [Ubuntu 20.04 Focal]:
-        imageName: 'ubuntu-20.04'
-        Compiler: clang
-        CompilerVer: 12
-        BuildType: Debug
 
       # gcc-10 and newer compilers
       gcc-14 RelWithDebInfo [Ubuntu 24.04 Noble]:
@@ -261,27 +246,27 @@ jobs:
         BuildType: Debug
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        gcc-11 RelWithDebInfo [Ubuntu 20.04 Focal]:
-          imageName: 'ubuntu-20.04'
+        gcc-11 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 11
           BuildType: RelWithDebInfo
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        gcc-11 Debug [Ubuntu 20.04 Focal]:
-          imageName: 'ubuntu-20.04'
+        gcc-11 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 11
           BuildType: Debug
 
-      gcc-10 RelWithDebInfo [Ubuntu 20.04 Focal]:
-        imageName: 'ubuntu-20.04'
+      gcc-10 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+        imageName: 'ubuntu-22.04'
         Compiler: gcc
         CompilerVer: 10
         BuildType: RelWithDebInfo
 
-      gcc-10 Debug [Ubuntu 20.04 Focal]:
-        imageName: 'ubuntu-20.04'
+      gcc-10 Debug [Ubuntu 22.04 Jammy]:
+        imageName: 'ubuntu-22.04'
         Compiler: gcc
         CompilerVer: 10
         BuildType: Debug


### PR DESCRIPTION
1. Switch to ubuntu-22.04.
2. Remove clang-6.0 to clang-13.
3. Add clang-20.