### PR TITLE
gcc-15 compilation fix ( uintXX_t types)

### DIFF
--- a/plugin/x/tests/driver/connector/warning.h
+++ b/plugin/x/tests/driver/connector/warning.h
@@ -26,6 +26,7 @@
 #ifndef PLUGIN_X_TESTS_DRIVER_CONNECTOR_WARNING_H_
 #define PLUGIN_X_TESTS_DRIVER_CONNECTOR_WARNING_H_
 
+#include <cstdint>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/router/src/harness/include/mysql/harness/stdx/io/file_handle.h
+++ b/router/src/harness/include/mysql/harness/stdx/io/file_handle.h
@@ -25,6 +25,7 @@
 #ifndef MYSQL_HARNESS_STDX_FILE_HANDLE_INCLUDED
 #define MYSQL_HARNESS_STDX_FILE_HANDLE_INCLUDED
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 #include <utility>  // exchange

--- a/router/src/harness/src/keyring/keyring_file.cc
+++ b/router/src/harness/src/keyring/keyring_file.cc
@@ -26,6 +26,7 @@
 #include "keyring/keyring_file.h"
 
 #include <array>
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <stdexcept>

--- a/router/src/http/include/mysqlrouter/http_request.h
+++ b/router/src/http/include/mysqlrouter/http_request.h
@@ -29,6 +29,7 @@
 #include "mysqlrouter/http_common_export.h"
 
 #include <bitset>
+#include <cstdint>
 #include <ctime>
 #include <functional>  // std::function
 #include <memory>

--- a/router/src/router/include/mysqlrouter/cluster_metadata_dynamic_state.h
+++ b/router/src/router/include/mysqlrouter/cluster_metadata_dynamic_state.h
@@ -26,6 +26,7 @@
 #ifndef CLUSTER_METADATA_DYNAMIC_STATE_INCLUDED
 #define CLUSTER_METADATA_DYNAMIC_STATE_INCLUDED
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
GCC-15 requires "#include <cstdint>" in order to use uint32_t, uint64_t, etc. Required inckude statements added.