### PR TITLE
PS-9681: boolean value true/false returned by JS stored function is i…

### DIFF
--- a/components/js_lang/js_lang_param.cc
+++ b/components/js_lang/js_lang_param.cc
@@ -849,7 +849,8 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
       assert(false);
       [[fallthrough]];
     }
-    // We treat YEAR type similarly to integer types.
+    // We treat YEAR type similarly to integer types
+    // (except case of Boolean JS values).
     case MYSQL_SP_ARG_TYPE_YEAR: {
       [[fallthrough]];
     }
@@ -867,6 +868,9 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
       H::get_param_signedness(m_sql_sp, param_idx, &is_signed);
 
       if (is_signed) {
+        // YEAR is always unsigned, so we don't have to handle it
+        // especially in this branch.
+        assert(sql_type != MYSQL_SP_ARG_TYPE_YEAR);
         return [](v8::Local<v8::Context> context, size_t idx,
                   v8::Local<v8::Value> result) -> bool {
           if (result->IsUndefined() || result->IsNull()) {
@@ -884,6 +888,15 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
             }
             // If direct conversion to int64_t is lossy, resort to
             // converting through string.
+          } else if (result->IsBoolean()) {
+            // Converting JS Boolean values to SQL integers through strngs,
+            // results in error, which is not what users expect (especially,
+            // since BOOL type is mapped to TINYINT).
+            // So we convert JS Boolean to 0/1 first. This is well aligned
+            // with what SQL-layer does when value of logical experssion is
+            // stored in integer field.
+            return H::set_param_int(
+                idx, result->BooleanValue(context->GetIsolate()));
           }
           // A natural thing would be to have alternative for JS Number as well
           // (i.e. get it as double and pass as double to SQL core).
@@ -911,8 +924,9 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
           return H::set_param_string(idx, *utf8, utf8.length());
         };
       } else {
-        return [](v8::Local<v8::Context> context, size_t idx,
-                  v8::Local<v8::Value> result) -> bool {
+        const bool is_year = (sql_type == MYSQL_SP_ARG_TYPE_YEAR);
+        return [is_year](v8::Local<v8::Context> context, size_t idx,
+                         v8::Local<v8::Value> result) -> bool {
           if (result->IsUndefined() || result->IsNull()) {
             return H::set_param_null(idx);
           } else if (result->IsUint32()) {
@@ -928,6 +942,15 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
             }
             // If direct conversion to uint64_t is lossy, resort to
             // converting through string.
+          } else if (!is_year && result->IsBoolean()) {
+            // Converting JS Boolean values to SQL integers through strngs,
+            // results in error, which is not what users expect.
+            // So we convert JS Boolean to 0/1 first. This is well aligned
+            // with what SQL-layer does when value of logical experssion is
+            // stored in integer field.
+            // Doing this for YEAR type doesn't make sense though.
+            return H::set_param_uint(
+                idx, result->BooleanValue(context->GetIsolate()));
           }
           // Convert JS value to JS string and get it as UTF-8.
           v8::String::Utf8Value utf8(context->GetIsolate(), result);
@@ -1015,6 +1038,10 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
     //
     // To avoid confusion we decided not to allow storing string JS
     // values which are not convertible to Number in BIT parameters.
+    //
+    // This works nicely even when Boolean JS values are converted to
+    // BIT (i.e. such values are converted to 0/1 and stored in SQL
+    // parameter without causing errors).
     case MYSQL_SP_ARG_TYPE_BIT: {
       return [](v8::Local<v8::Context> context, size_t idx,
                 v8::Local<v8::Value> result) -> bool {
@@ -1061,6 +1088,11 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
           // Number already, so no real conversion that can fail.
           double float_result = result->NumberValue(context).ToChecked();
           return H::set_param_float(idx, float_result);
+        } else if (result->IsBoolean()) {
+          // Convert JS Boolean values to floating-point SQL values
+          // similarly to how it is done for integers.
+          int int_result = result->BooleanValue(context->GetIsolate());
+          return H::set_param_float(idx, int_result);
         } else {
           // Convert JS value to JS string and get it as UTF-8.
           v8::String::Utf8Value utf8(context->GetIsolate(), result);
@@ -1162,6 +1194,39 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
         }
       };
     }
+    // In most cases we handle DECIMAL SQL-type by converting JS value to
+    // string and then letting SQL core to extract fixed point value.
+    //
+    // Unlike for integer or floating-point values it doesn't make sense
+    // to optimize conversion from Number type, as SQL core handles double
+    // -> DECIMAL conversions through strings.
+    //
+    // For Boolean JS values we convert to 0/1 first, and then store result
+    // as integer, to avoid unwanted errors.
+    case MYSQL_SP_ARG_TYPE_NEWDECIMAL: {
+      return [](v8::Local<v8::Context> context, size_t idx,
+                v8::Local<v8::Value> result) -> bool {
+        if (result->IsUndefined() || result->IsNull()) {
+          return H::set_param_null(idx);
+        } else if (result->IsBoolean()) {
+          // Convert JS Boolean values to DECIMAL SQL values
+          // similarly to how it is done for integers.
+          return H::set_param_int(idx,
+                                  result->BooleanValue(context->GetIsolate()));
+        } else {
+          // Convert JS value to JS string and get it as UTF-8.
+          v8::String::Utf8Value utf8(context->GetIsolate(), result);
+          if (!*utf8) {
+            // Conversion of JS value to JS string can fail (e.g. throw).
+            my_error_js_value_to_string_param();
+            return true;
+          }
+          // Implementation of datetime types in SQL core accepts input
+          // in UTF-8 without requiring conversion.
+          return H::set_param_string(idx, *utf8, utf8.length());
+        }
+      };
+    }
     // Obsolete types which shold not be possible to use as return
     // value for newly created routine.
     case MYSQL_SP_ARG_TYPE_DECIMAL:
@@ -1182,24 +1247,6 @@ Js_sp::set_param_func_t Js_sp::prepare_set_param_func(size_t param_idx) {
     // New SQL-types need analysis to be handled correctly.
     default: {
       assert(false);
-      [[fallthrough]];
-    }
-    // We handle DECIMAL SQL-type by converting JS value to string and
-    // then letting SQL core to extract fixed point value.
-    //
-    // Unlike for integer or floating-point values it doesn't make sense
-    // to optimize conversion from Number type, as SQL core handles int/
-    // double -> DECIMAL conversions through strings.
-    case MYSQL_SP_ARG_TYPE_NEWDECIMAL: {
-#ifndef NDEBUG
-      // It is important to avoid unnecessary work in the generic string
-      // handling code below and not to do charset conversions.
-      // Code which does parsing of decimal values only cares about latin1
-      // digits and spaces, so no conversion from UTF8 should be required.
-      const char *cs_name;
-      H::get_param_charset(m_sql_sp, param_idx, &cs_name);
-      assert(strcmp(cs_name, UTF8_CS_NAME) == 0);
-#endif
       [[fallthrough]];
     }
     // We handle ENUMs similarly to strings.

--- a/mysql-test/suite/component_js_lang/r/js_lang_basic.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_basic.result
@@ -1222,6 +1222,8 @@ DROP FUNCTION f_object_serr;
 # - JS 'null' and 'undefined' values which are mapped to SQL NULL.
 # - If JS numeric or BigInt value can be safely converted to SQL-type
 #   we use direct conversion (for performance reasons).
+# - JS Boolean values are converted to 0 or 1 directly as well
+#   (as conversion through string causes error).
 # - Otherwise, as well as for all other types of JS values conversion
 #   is done through strings (i.e. by doing JS toString() conversion
 #   and trying to store resulting string as SQL integer value).
@@ -1256,6 +1258,7 @@ CREATE FUNCTION f_bigint_u() RETURNS TINYINT UNSIGNED LANGUAGE JS AS $$ return B
 CREATE FUNCTION f_bigint_un() RETURNS TINYINT UNSIGNED LANGUAGE JS AS $$ return BigInt(-42); $$;
 CREATE FUNCTION f_bigint_tb() RETURNS TINYINT LANGUAGE JS AS $$ return BigInt(1e+25); $$;
 CREATE FUNCTION f_bool() RETURNS TINYINT LANGUAGE JS AS $$ return true; $$;
+CREATE FUNCTION f_bool_u() RETURNS TINYINT UNSIGNED LANGUAGE JS AS $$ return true; $$;
 CREATE FUNCTION f_str_e() RETURNS TINYINT LANGUAGE JS AS $$ return ""; $$;
 CREATE FUNCTION f_str_a() RETURNS TINYINT LANGUAGE JS AS $$ return "alpha"; $$;
 CREATE FUNCTION f_str_n1() RETURNS TINYINT LANGUAGE JS AS $$ return "123"; $$;
@@ -1315,7 +1318,11 @@ ERROR 22003: Out of range value for column 'f_bigint_un()' at row 1
 SELECT f_bigint_tb();
 ERROR 22003: Out of range value for column 'f_bigint_tb()' at row 1
 SELECT f_bool() AS bo;
-ERROR HY000: Incorrect integer value: 'true' for column 'bo' at row 1
+bo
+1
+SELECT f_bool_u() AS bu;
+bu
+1
 SELECT f_str_e() AS se;
 ERROR HY000: Incorrect integer value: '' for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -1373,6 +1380,7 @@ DROP FUNCTION f_bigint_u;
 DROP FUNCTION f_bigint_un;
 DROP FUNCTION f_bigint_tb;
 DROP FUNCTION f_bool;
+DROP FUNCTION f_bool_u;
 DROP FUNCTION f_str_e;
 DROP FUNCTION f_str_a;
 DROP FUNCTION f_str_n1;
@@ -1417,6 +1425,7 @@ CREATE FUNCTION f_bigint_u() RETURNS SMALLINT UNSIGNED LANGUAGE JS AS $$ return 
 CREATE FUNCTION f_bigint_un() RETURNS SMALLINT UNSIGNED LANGUAGE JS AS $$ return BigInt(-42); $$;
 CREATE FUNCTION f_bigint_tb() RETURNS SMALLINT LANGUAGE JS AS $$ return BigInt(1e+25); $$;
 CREATE FUNCTION f_bool() RETURNS SMALLINT LANGUAGE JS AS $$ return true; $$;
+CREATE FUNCTION f_bool_u() RETURNS SMALLINT UNSIGNED LANGUAGE JS AS $$ return true; $$;
 CREATE FUNCTION f_str_e() RETURNS SMALLINT LANGUAGE JS AS $$ return ""; $$;
 CREATE FUNCTION f_str_a() RETURNS SMALLINT LANGUAGE JS AS $$ return "alpha"; $$;
 CREATE FUNCTION f_str_n1() RETURNS SMALLINT LANGUAGE JS AS $$ return "123"; $$;
@@ -1476,7 +1485,11 @@ ERROR 22003: Out of range value for column 'f_bigint_un()' at row 1
 SELECT f_bigint_tb();
 ERROR 22003: Out of range value for column 'f_bigint_tb()' at row 1
 SELECT f_bool() AS bo;
-ERROR HY000: Incorrect integer value: 'true' for column 'bo' at row 1
+bo
+1
+SELECT f_bool_u() AS bu;
+bu
+1
 SELECT f_str_e() AS se;
 ERROR HY000: Incorrect integer value: '' for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -1534,6 +1547,7 @@ DROP FUNCTION f_bigint_u;
 DROP FUNCTION f_bigint_un;
 DROP FUNCTION f_bigint_tb;
 DROP FUNCTION f_bool;
+DROP FUNCTION f_bool_u;
 DROP FUNCTION f_str_e;
 DROP FUNCTION f_str_a;
 DROP FUNCTION f_str_n1;
@@ -1578,6 +1592,7 @@ CREATE FUNCTION f_bigint_u() RETURNS MEDIUMINT UNSIGNED LANGUAGE JS AS $$ return
 CREATE FUNCTION f_bigint_un() RETURNS MEDIUMINT UNSIGNED LANGUAGE JS AS $$ return BigInt(-42); $$;
 CREATE FUNCTION f_bigint_tb() RETURNS MEDIUMINT LANGUAGE JS AS $$ return BigInt(1e+25); $$;
 CREATE FUNCTION f_bool() RETURNS MEDIUMINT LANGUAGE JS AS $$ return true; $$;
+CREATE FUNCTION f_bool_u() RETURNS MEDIUMINT UNSIGNED LANGUAGE JS AS $$ return true; $$;
 CREATE FUNCTION f_str_e() RETURNS MEDIUMINT LANGUAGE JS AS $$ return ""; $$;
 CREATE FUNCTION f_str_a() RETURNS MEDIUMINT LANGUAGE JS AS $$ return "alpha"; $$;
 CREATE FUNCTION f_str_n1() RETURNS MEDIUMINT LANGUAGE JS AS $$ return "123"; $$;
@@ -1637,7 +1652,11 @@ ERROR 22003: Out of range value for column 'f_bigint_un()' at row 1
 SELECT f_bigint_tb();
 ERROR 22003: Out of range value for column 'f_bigint_tb()' at row 1
 SELECT f_bool() AS bo;
-ERROR HY000: Incorrect integer value: 'true' for column 'bo' at row 1
+bo
+1
+SELECT f_bool_u() AS bu;
+bu
+1
 SELECT f_str_e() AS se;
 ERROR HY000: Incorrect integer value: '' for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -1695,6 +1714,7 @@ DROP FUNCTION f_bigint_u;
 DROP FUNCTION f_bigint_un;
 DROP FUNCTION f_bigint_tb;
 DROP FUNCTION f_bool;
+DROP FUNCTION f_bool_u;
 DROP FUNCTION f_str_e;
 DROP FUNCTION f_str_a;
 DROP FUNCTION f_str_n1;
@@ -1739,6 +1759,7 @@ CREATE FUNCTION f_bigint_u() RETURNS INT UNSIGNED LANGUAGE JS AS $$ return BigIn
 CREATE FUNCTION f_bigint_un() RETURNS INT UNSIGNED LANGUAGE JS AS $$ return BigInt(-42); $$;
 CREATE FUNCTION f_bigint_tb() RETURNS INT LANGUAGE JS AS $$ return BigInt(1e+25); $$;
 CREATE FUNCTION f_bool() RETURNS INT LANGUAGE JS AS $$ return true; $$;
+CREATE FUNCTION f_bool_u() RETURNS INT UNSIGNED LANGUAGE JS AS $$ return true; $$;
 CREATE FUNCTION f_str_e() RETURNS INT LANGUAGE JS AS $$ return ""; $$;
 CREATE FUNCTION f_str_a() RETURNS INT LANGUAGE JS AS $$ return "alpha"; $$;
 CREATE FUNCTION f_str_n1() RETURNS INT LANGUAGE JS AS $$ return "123"; $$;
@@ -1798,7 +1819,11 @@ ERROR 22003: Out of range value for column 'f_bigint_un()' at row 1
 SELECT f_bigint_tb();
 ERROR 22003: Out of range value for column 'f_bigint_tb()' at row 1
 SELECT f_bool() AS bo;
-ERROR HY000: Incorrect integer value: 'true' for column 'bo' at row 1
+bo
+1
+SELECT f_bool_u() AS bu;
+bu
+1
 SELECT f_str_e() AS se;
 ERROR HY000: Incorrect integer value: '' for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -1856,6 +1881,7 @@ DROP FUNCTION f_bigint_u;
 DROP FUNCTION f_bigint_un;
 DROP FUNCTION f_bigint_tb;
 DROP FUNCTION f_bool;
+DROP FUNCTION f_bool_u;
 DROP FUNCTION f_str_e;
 DROP FUNCTION f_str_a;
 DROP FUNCTION f_str_n1;
@@ -1900,6 +1926,7 @@ CREATE FUNCTION f_bigint_u() RETURNS BIGINT UNSIGNED LANGUAGE JS AS $$ return Bi
 CREATE FUNCTION f_bigint_un() RETURNS BIGINT UNSIGNED LANGUAGE JS AS $$ return BigInt(-42); $$;
 CREATE FUNCTION f_bigint_tb() RETURNS BIGINT LANGUAGE JS AS $$ return BigInt(1e+25); $$;
 CREATE FUNCTION f_bool() RETURNS BIGINT LANGUAGE JS AS $$ return true; $$;
+CREATE FUNCTION f_bool_u() RETURNS BIGINT UNSIGNED LANGUAGE JS AS $$ return true; $$;
 CREATE FUNCTION f_str_e() RETURNS BIGINT LANGUAGE JS AS $$ return ""; $$;
 CREATE FUNCTION f_str_a() RETURNS BIGINT LANGUAGE JS AS $$ return "alpha"; $$;
 CREATE FUNCTION f_str_n1() RETURNS BIGINT LANGUAGE JS AS $$ return "123"; $$;
@@ -1956,7 +1983,11 @@ ERROR 22003: Out of range value for column 'f_bigint_un()' at row 1
 SELECT f_bigint_tb();
 ERROR 22003: Out of range value for column 'f_bigint_tb()' at row 1
 SELECT f_bool() AS bo;
-ERROR HY000: Incorrect integer value: 'true' for column 'bo' at row 1
+bo
+1
+SELECT f_bool_u() AS bu;
+bu
+1
 SELECT f_str_e() AS se;
 ERROR HY000: Incorrect integer value: '' for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -2014,6 +2045,7 @@ DROP FUNCTION f_bigint_u;
 DROP FUNCTION f_bigint_un;
 DROP FUNCTION f_bigint_tb;
 DROP FUNCTION f_bool;
+DROP FUNCTION f_bool_u;
 DROP FUNCTION f_str_e;
 DROP FUNCTION f_str_a;
 DROP FUNCTION f_str_n1;
@@ -2036,6 +2068,8 @@ DROP FUNCTION f_object_userr;
 # - JS 'null' and 'undefined' values which are mapped to SQL NULL.
 # - If JS numeric value can be safely converted to SQL-type we use
 #   direct conversion (for performance reasons).
+# - JS Boolean values are converted to 0 or 1 directly as well
+#   (as conversion through string causes error).
 # - Otherwise, as well as for all other types of JS values conversion
 #   is done through strings (i.e. by doing JS toString() conversion
 #   and trying to store resulting string as SQL floating-point value).
@@ -2076,7 +2110,8 @@ SELECT f_bigint_pl() AS bipl;
 bipl
 3.60288e16
 SELECT f_bool() AS bo;
-ERROR 01000: Data truncated for column 'bo' at row 1
+bo
+1
 SELECT f_str_e() AS se;
 ERROR 01000: Data truncated for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -2162,7 +2197,8 @@ SELECT f_bigint_pl() AS bipl;
 bipl
 3.602879701896397e16
 SELECT f_bool() AS bo;
-ERROR 01000: Data truncated for column 'bo' at row 1
+bo
+1
 SELECT f_str_e() AS se;
 ERROR 01000: Data truncated for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -2212,12 +2248,17 @@ DROP FUNCTION f_typed_arr;
 DROP FUNCTION f_data_view;
 DROP FUNCTION f_object_serr;
 #
-# For DECIMAL SQL-type conversion is done through strings (by doing JS
-# toString() conversion and trying to store resulting string as SQL
-# type value). There is no point in optimizing conversion from Number
-# type, like it is done for floating point SQL-types, as SQL core does
-# double -> DECIMAL conversions through strings. As usual JS 'null'
-# and 'undefined' values are mapped to SQL NULL.
+# For DECIMAL SQL-type conversion is almost always done through strings
+# (by doing JS toString() conversion and trying to store resulting string
+# as SQL type value). There is no point in optimizing conversion from
+# Number type, like it is done for floating point SQL-types, as SQL core
+# does double -> DECIMAL conversions through strings.
+#
+# The exception to the above are JS Boolean values which are directly
+# converted to 0/1, as converting them through strings would cause
+# errors.
+#
+# As usual JS 'null' and 'undefined' values are mapped to SQL NULL.
 #
 CREATE FUNCTION f_undefined() RETURNS DECIMAL(4,2) LANGUAGE JS AS $$ return $$;
 CREATE FUNCTION f_null() RETURNS DECIMAL(4,2) LANGUAGE JS AS $$ return null $$;
@@ -2271,7 +2312,8 @@ bi1	bi2
 SELECT f_bigint_tb() AS bitb;
 ERROR 22003: Out of range value for column 'bitb' at row 1
 SELECT f_bool() AS bo;
-ERROR HY000: Incorrect decimal value: 'true' for column 'bo' at row 1
+bo
+1.00
 SELECT f_str_e() AS se;
 ERROR HY000: Incorrect decimal value: '' for column 'se' at row 1
 SELECT f_str_a() AS sa;
@@ -4789,6 +4831,7 @@ CREATE PROCEDURE p_bigint_u(OUT r TINYINT UNSIGNED) LANGUAGE JS AS $$ r = BigInt
 CREATE PROCEDURE p_bigint_un(OUT r TINYINT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(-42); $$;
 CREATE PROCEDURE p_bigint_tb(OUT r TINYINT) LANGUAGE JS AS $$ r = BigInt(1e+25); $$;
 CREATE PROCEDURE p_bool(OUT r TINYINT) LANGUAGE JS AS $$ r = true; $$;
+CREATE PROCEDURE p_bool_u(OUT r TINYINT UNSIGNED) LANGUAGE JS AS $$ r = true; $$;
 CREATE PROCEDURE p_str_e(OUT r TINYINT) LANGUAGE JS AS $$ r = ""; $$;
 CREATE PROCEDURE p_str_a(OUT r TINYINT) LANGUAGE JS AS $$ r = "alpha"; $$;
 CREATE PROCEDURE p_str_n1(OUT r TINYINT) LANGUAGE JS AS $$ r = "123"; $$;
@@ -4901,7 +4944,13 @@ ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bigint_tb(@r);
 ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bool(@r);
-ERROR HY000: Incorrect integer value: 'true' for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
+CALL p_bool_u(@r);
+SELECT @r AS bu;
+bu
+1
 CALL p_str_e(@r);
 ERROR HY000: Incorrect integer value: '' for column 'r' at row 1
 CALL p_str_a(@r);
@@ -4973,6 +5022,7 @@ DROP PROCEDURE p_bigint_u;
 DROP PROCEDURE p_bigint_un;
 DROP PROCEDURE p_bigint_tb;
 DROP PROCEDURE p_bool;
+DROP PROCEDURE p_bool_u;
 DROP PROCEDURE p_str_e;
 DROP PROCEDURE p_str_a;
 DROP PROCEDURE p_str_n1;
@@ -5017,6 +5067,7 @@ CREATE PROCEDURE p_bigint_u(OUT r SMALLINT UNSIGNED) LANGUAGE JS AS $$ r = BigIn
 CREATE PROCEDURE p_bigint_un(OUT r SMALLINT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(-42); $$;
 CREATE PROCEDURE p_bigint_tb(OUT r SMALLINT) LANGUAGE JS AS $$ r = BigInt(1e+25); $$;
 CREATE PROCEDURE p_bool(OUT r SMALLINT) LANGUAGE JS AS $$ r = true; $$;
+CREATE PROCEDURE p_bool_u(OUT r SMALLINT UNSIGNED) LANGUAGE JS AS $$ r = true; $$;
 CREATE PROCEDURE p_str_e(OUT r SMALLINT) LANGUAGE JS AS $$ r = ""; $$;
 CREATE PROCEDURE p_str_a(OUT r SMALLINT) LANGUAGE JS AS $$ r = "alpha"; $$;
 CREATE PROCEDURE p_str_n1(OUT r SMALLINT) LANGUAGE JS AS $$ r = "123"; $$;
@@ -5129,7 +5180,13 @@ ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bigint_tb(@r);
 ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bool(@r);
-ERROR HY000: Incorrect integer value: 'true' for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
+CALL p_bool_u(@r);
+SELECT @r AS bu;
+bu
+1
 CALL p_str_e(@r);
 ERROR HY000: Incorrect integer value: '' for column 'r' at row 1
 CALL p_str_a(@r);
@@ -5201,6 +5258,7 @@ DROP PROCEDURE p_bigint_u;
 DROP PROCEDURE p_bigint_un;
 DROP PROCEDURE p_bigint_tb;
 DROP PROCEDURE p_bool;
+DROP PROCEDURE p_bool_u;
 DROP PROCEDURE p_str_e;
 DROP PROCEDURE p_str_a;
 DROP PROCEDURE p_str_n1;
@@ -5245,6 +5303,7 @@ CREATE PROCEDURE p_bigint_u(OUT r MEDIUMINT UNSIGNED) LANGUAGE JS AS $$ r = BigI
 CREATE PROCEDURE p_bigint_un(OUT r MEDIUMINT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(-42); $$;
 CREATE PROCEDURE p_bigint_tb(OUT r MEDIUMINT) LANGUAGE JS AS $$ r = BigInt(1e+25); $$;
 CREATE PROCEDURE p_bool(OUT r MEDIUMINT) LANGUAGE JS AS $$ r = true; $$;
+CREATE PROCEDURE p_bool_u(OUT r MEDIUMINT UNSIGNED) LANGUAGE JS AS $$ r = true; $$;
 CREATE PROCEDURE p_str_e(OUT r MEDIUMINT) LANGUAGE JS AS $$ r = ""; $$;
 CREATE PROCEDURE p_str_a(OUT r MEDIUMINT) LANGUAGE JS AS $$ r = "alpha"; $$;
 CREATE PROCEDURE p_str_n1(OUT r MEDIUMINT) LANGUAGE JS AS $$ r = "123"; $$;
@@ -5357,7 +5416,13 @@ ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bigint_tb(@r);
 ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bool(@r);
-ERROR HY000: Incorrect integer value: 'true' for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
+CALL p_bool_u(@r);
+SELECT @r AS bu;
+bu
+1
 CALL p_str_e(@r);
 ERROR HY000: Incorrect integer value: '' for column 'r' at row 1
 CALL p_str_a(@r);
@@ -5429,6 +5494,7 @@ DROP PROCEDURE p_bigint_u;
 DROP PROCEDURE p_bigint_un;
 DROP PROCEDURE p_bigint_tb;
 DROP PROCEDURE p_bool;
+DROP PROCEDURE p_bool_u;
 DROP PROCEDURE p_str_e;
 DROP PROCEDURE p_str_a;
 DROP PROCEDURE p_str_n1;
@@ -5473,6 +5539,7 @@ CREATE PROCEDURE p_bigint_u(OUT r INT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(900
 CREATE PROCEDURE p_bigint_un(OUT r INT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(-42); $$;
 CREATE PROCEDURE p_bigint_tb(OUT r INT) LANGUAGE JS AS $$ r = BigInt(1e+25); $$;
 CREATE PROCEDURE p_bool(OUT r INT) LANGUAGE JS AS $$ r = true; $$;
+CREATE PROCEDURE p_bool_u(OUT r INT UNSIGNED) LANGUAGE JS AS $$ r = true; $$;
 CREATE PROCEDURE p_str_e(OUT r INT) LANGUAGE JS AS $$ r = ""; $$;
 CREATE PROCEDURE p_str_a(OUT r INT) LANGUAGE JS AS $$ r = "alpha"; $$;
 CREATE PROCEDURE p_str_n1(OUT r INT) LANGUAGE JS AS $$ r = "123"; $$;
@@ -5585,7 +5652,13 @@ ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bigint_tb(@r);
 ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bool(@r);
-ERROR HY000: Incorrect integer value: 'true' for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
+CALL p_bool_u(@r);
+SELECT @r AS bu;
+bu
+1
 CALL p_str_e(@r);
 ERROR HY000: Incorrect integer value: '' for column 'r' at row 1
 CALL p_str_a(@r);
@@ -5657,6 +5730,7 @@ DROP PROCEDURE p_bigint_u;
 DROP PROCEDURE p_bigint_un;
 DROP PROCEDURE p_bigint_tb;
 DROP PROCEDURE p_bool;
+DROP PROCEDURE p_bool_u;
 DROP PROCEDURE p_str_e;
 DROP PROCEDURE p_str_a;
 DROP PROCEDURE p_str_n1;
@@ -5701,6 +5775,7 @@ CREATE PROCEDURE p_bigint_u(OUT r BIGINT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(
 CREATE PROCEDURE p_bigint_un(OUT r BIGINT UNSIGNED) LANGUAGE JS AS $$ r = BigInt(-42); $$;
 CREATE PROCEDURE p_bigint_tb(OUT r BIGINT) LANGUAGE JS AS $$ r = BigInt(1e+25); $$;
 CREATE PROCEDURE p_bool(OUT r BIGINT) LANGUAGE JS AS $$ r = true; $$;
+CREATE PROCEDURE p_bool_u(OUT r BIGINT UNSIGNED) LANGUAGE JS AS $$ r = true; $$;
 CREATE PROCEDURE p_str_e(OUT r BIGINT) LANGUAGE JS AS $$ r = ""; $$;
 CREATE PROCEDURE p_str_a(OUT r BIGINT) LANGUAGE JS AS $$ r = "alpha"; $$;
 CREATE PROCEDURE p_str_n1(OUT r BIGINT) LANGUAGE JS AS $$ r = "123"; $$;
@@ -5811,7 +5886,13 @@ ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bigint_tb(@r);
 ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bool(@r);
-ERROR HY000: Incorrect integer value: 'true' for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
+CALL p_bool_u(@r);
+SELECT @r AS bu;
+bu
+1
 CALL p_str_e(@r);
 ERROR HY000: Incorrect integer value: '' for column 'r' at row 1
 CALL p_str_a(@r);
@@ -5883,6 +5964,7 @@ DROP PROCEDURE p_bigint_u;
 DROP PROCEDURE p_bigint_un;
 DROP PROCEDURE p_bigint_tb;
 DROP PROCEDURE p_bool;
+DROP PROCEDURE p_bool_u;
 DROP PROCEDURE p_str_e;
 DROP PROCEDURE p_str_a;
 DROP PROCEDURE p_str_n1;
@@ -5975,7 +6057,9 @@ SELECT @r AS bipl;
 bipl
 3.602879701896397e16
 CALL p_bool(@r);
-ERROR 01000: Data truncated for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
 CALL p_str_e(@r);
 ERROR 01000: Data truncated for column 'r' at row 1
 CALL p_str_a(@r);
@@ -6102,7 +6186,9 @@ SELECT @r AS bipl;
 bipl
 3.602879701896397e16
 CALL p_bool(@r);
-ERROR 01000: Data truncated for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1
 CALL p_str_e(@r);
 ERROR 01000: Data truncated for column 'r' at row 1
 CALL p_str_a(@r);
@@ -6245,7 +6331,9 @@ bi2
 CALL p_bigint_tb(@r);
 ERROR 22003: Out of range value for column 'r' at row 1
 CALL p_bool(@r);
-ERROR HY000: Incorrect decimal value: 'true' for column 'r' at row 1
+SELECT @r AS bo;
+bo
+1.00
 CALL p_str_e(@r);
 ERROR HY000: Incorrect decimal value: '' for column 'r' at row 1
 CALL p_str_a(@r);

--- a/mysql-test/suite/component_js_lang/r/js_lang_bugs.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_bugs.result
@@ -1,0 +1,29 @@
+# Global prepare of playground.
+INSTALL COMPONENT 'file://component_js_lang';
+GRANT CREATE_JS_ROUTINE ON *.* TO root@localhost;
+#
+# PS-9681: "boolean value true/false returned by JS stored function
+#           is interpreted as a string value."
+#
+# Original test case reported. See additional coverage for conversion
+# of JS Boolean values to numeric SQL parameters/returns values in
+# js_lang_basic test.
+CREATE FUNCTION f_ps9681_0() RETURNS BOOL LANGUAGE JS AS $$ return false $$;
+CREATE FUNCTION f_ps9681_1() RETURNS BOOL LANGUAGE JS AS $$ return true $$;
+SELECT f_ps9681_0() AS f;
+f
+0
+SELECT f_ps9681_1() AS t;
+t
+1
+DROP FUNCTION f_ps9681_0;
+DROP FUNCTION f_ps9681_1;
+# Global clean-up.
+REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
+# Disconnect of default connection to free the only remaining
+# connection context and isolate, so we can uninstall component.
+disconnect default;
+connect default,localhost,root;
+UNINSTALL COMPONENT 'file://component_js_lang';
+# Restart server to let subsequent tests to do INSTALL COMPONENT freely.
+# restart

--- a/mysql-test/suite/component_js_lang/t/js_lang_basic.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_basic.test
@@ -530,6 +530,8 @@ while($i <= 6)
 --echo # - JS 'null' and 'undefined' values which are mapped to SQL NULL.
 --echo # - If JS numeric or BigInt value can be safely converted to SQL-type
 --echo #   we use direct conversion (for performance reasons).
+--echo # - JS Boolean values are converted to 0 or 1 directly as well
+--echo #   (as conversion through string causes error).
 --echo # - Otherwise, as well as for all other types of JS values conversion
 --echo #   is done through strings (i.e. by doing JS toString() conversion
 --echo #   and trying to store resulting string as SQL integer value).
@@ -578,6 +580,8 @@ while($i <= 5)
   --eval CREATE FUNCTION f_bigint_tb() RETURNS $type LANGUAGE JS AS \$\$ return BigInt(1e+25); \$\$
 
   --eval CREATE FUNCTION f_bool() RETURNS $type LANGUAGE JS AS \$\$ return true; \$\$
+
+  --eval CREATE FUNCTION f_bool_u() RETURNS $type UNSIGNED LANGUAGE JS AS \$\$ return true; \$\$
 
   --eval CREATE FUNCTION f_str_e() RETURNS $type LANGUAGE JS AS \$\$ return ""; \$\$
   --eval CREATE FUNCTION f_str_a() RETURNS $type LANGUAGE JS AS \$\$ return "alpha"; \$\$
@@ -641,8 +645,9 @@ while($i <= 5)
   --error ER_WARN_DATA_OUT_OF_RANGE
   SELECT f_bigint_tb();
 
-  --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
   SELECT f_bool() AS bo;
+
+  SELECT f_bool_u() AS bu;
 
   --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
   SELECT f_str_e() AS se;
@@ -701,6 +706,7 @@ while($i <= 5)
   DROP FUNCTION f_bigint_un;
   DROP FUNCTION f_bigint_tb;
   DROP FUNCTION f_bool;
+  DROP FUNCTION f_bool_u;
   DROP FUNCTION f_str_e;
   DROP FUNCTION f_str_a;
   DROP FUNCTION f_str_n1;
@@ -728,6 +734,8 @@ while($i <= 5)
 --echo # - JS 'null' and 'undefined' values which are mapped to SQL NULL.
 --echo # - If JS numeric value can be safely converted to SQL-type we use
 --echo #   direct conversion (for performance reasons).
+--echo # - JS Boolean values are converted to 0 or 1 directly as well
+--echo #   (as conversion through string causes error).
 --echo # - Otherwise, as well as for all other types of JS values conversion
 --echo #   is done through strings (i.e. by doing JS toString() conversion
 --echo #   and trying to store resulting string as SQL floating-point value).
@@ -782,7 +790,6 @@ while($i <= 2)
   SELECT f_bigint() AS bi;
   SELECT f_bigint_pl() AS bipl;
 
-  --error 1265
   SELECT f_bool() AS bo;
 
   --error 1265
@@ -837,12 +844,17 @@ while($i <= 2)
 }
 
 --echo #
---echo # For DECIMAL SQL-type conversion is done through strings (by doing JS
---echo # toString() conversion and trying to store resulting string as SQL
---echo # type value). There is no point in optimizing conversion from Number
---echo # type, like it is done for floating point SQL-types, as SQL core does
---echo # double -> DECIMAL conversions through strings. As usual JS 'null'
---echo # and 'undefined' values are mapped to SQL NULL.
+--echo # For DECIMAL SQL-type conversion is almost always done through strings
+--echo # (by doing JS toString() conversion and trying to store resulting string
+--echo # as SQL type value). There is no point in optimizing conversion from
+--echo # Number type, like it is done for floating point SQL-types, as SQL core
+--echo # does double -> DECIMAL conversions through strings.
+--echo #
+--echo # The exception to the above are JS Boolean values which are directly
+--echo # converted to 0/1, as converting them through strings would cause
+--echo # errors.
+--echo #
+--echo # As usual JS 'null' and 'undefined' values are mapped to SQL NULL.
 --echo #
 
 CREATE FUNCTION f_undefined() RETURNS DECIMAL(4,2) LANGUAGE JS AS $$ return $$;
@@ -900,7 +912,6 @@ SELECT f_bigint_1() AS bi1, f_bigint_2() AS bi2;
 --error ER_WARN_DATA_OUT_OF_RANGE
 SELECT f_bigint_tb() AS bitb;
 
---error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
 SELECT f_bool() AS bo;
 
 --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
@@ -1917,6 +1928,8 @@ while($i <= 5)
 
   --eval CREATE PROCEDURE p_bool(OUT r $type) LANGUAGE JS AS \$\$ r = true; \$\$
 
+  --eval CREATE PROCEDURE p_bool_u(OUT r $type UNSIGNED) LANGUAGE JS AS \$\$ r = true; \$\$
+
   --eval CREATE PROCEDURE p_str_e(OUT r $type) LANGUAGE JS AS \$\$ r = ""; \$\$
   --eval CREATE PROCEDURE p_str_a(OUT r $type) LANGUAGE JS AS \$\$ r = "alpha"; \$\$
   --eval CREATE PROCEDURE p_str_n1(OUT r $type) LANGUAGE JS AS \$\$ r = "123"; \$\$
@@ -2010,8 +2023,11 @@ while($i <= 5)
   --error ER_WARN_DATA_OUT_OF_RANGE
   CALL p_bigint_tb(@r);
 
-  --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
   CALL p_bool(@r);
+  SELECT @r AS bo;
+
+  CALL p_bool_u(@r);
+  SELECT @r AS bu;
 
   --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
   CALL p_str_e(@r);
@@ -2077,6 +2093,7 @@ while($i <= 5)
   DROP PROCEDURE p_bigint_un;
   DROP PROCEDURE p_bigint_tb;
   DROP PROCEDURE p_bool;
+  DROP PROCEDURE p_bool_u;
   DROP PROCEDURE p_str_e;
   DROP PROCEDURE p_str_a;
   DROP PROCEDURE p_str_n1;
@@ -2173,8 +2190,8 @@ while($i <= 2)
   CALL p_bigint_pl(@r);
   SELECT @r AS bipl;
 
-  --error 1265
   CALL p_bool(@r);
+  SELECT @r AS bo;
 
   --error 1265
   CALL p_str_e(@r);
@@ -2310,8 +2327,8 @@ SELECT @r AS bi2;
 --error ER_WARN_DATA_OUT_OF_RANGE
 CALL p_bigint_tb(@r);
 
---error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
 CALL p_bool(@r);
+SELECT @r AS bo;
 
 --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
 CALL p_str_e(@r);

--- a/mysql-test/suite/component_js_lang/t/js_lang_bugs.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_bugs.test
@@ -1,0 +1,41 @@
+#
+# Test coverage for various bugs in JS stored routines.
+#
+--source include/have_js_lang_component.inc
+
+--echo # Global prepare of playground.
+--enable_connect_log
+
+INSTALL COMPONENT 'file://component_js_lang';
+
+GRANT CREATE_JS_ROUTINE ON *.* TO root@localhost;
+
+--echo #
+--echo # PS-9681: "boolean value true/false returned by JS stored function
+--echo #           is interpreted as a string value."
+--echo #
+--echo # Original test case reported. See additional coverage for conversion
+--echo # of JS Boolean values to numeric SQL parameters/returns values in
+--echo # js_lang_basic test.
+CREATE FUNCTION f_ps9681_0() RETURNS BOOL LANGUAGE JS AS $$ return false $$;
+CREATE FUNCTION f_ps9681_1() RETURNS BOOL LANGUAGE JS AS $$ return true $$;
+SELECT f_ps9681_0() AS f;
+SELECT f_ps9681_1() AS t;
+DROP FUNCTION f_ps9681_0;
+DROP FUNCTION f_ps9681_1;
+
+--echo # Global clean-up.
+REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
+
+--echo # Disconnect of default connection to free the only remaining
+--echo # connection context and isolate, so we can uninstall component.
+--disconnect default
+--source include/wait_until_disconnected.inc
+--connect(default,localhost,root)
+
+UNINSTALL COMPONENT 'file://component_js_lang';
+
+--echo # Restart server to let subsequent tests to do INSTALL COMPONENT freely.
+--source include/restart_mysqld.inc
+
+--disable_connect_log


### PR DESCRIPTION
…nterpreted as a string value.

https://perconadev.atlassian.net/browse/PS-9681

Problem:
--------
Trying to return Boolean JS value from JS stored routine with numeric SQL type of return value (including BOOL type!) or as OUT parameter resulted in error. This was not in line with how conversions from logical to numeric values work in MySQL, and how JS converts Boolean to Numeric values. So it broke user's expectations.

Analysis:
---------
The error occurred because in all these cases we converted JS Boolean values to JS Strings (i.e. "false" or "true") and tried to store this as SQL numeric values.

Fix:
----
We fix problem by changing conversion rules for return values and OUT parameters of integer, floating-point and DECIMAL SQL types. We no longer go through strings for them now. Instead we convert JS Boolean values to integer or floating-point values directly.

Adjusted test coverage for these kind of conversions in js_lang_basic test accordingly.