### PR TITLE
(8.0) PS-9647: MySQL Perf Improvements (deque)

### DIFF
--- a/include/mem_root_deque.h
+++ b/include/mem_root_deque.h
@@ -110,9 +110,15 @@ class mem_root_deque {
 
   size_t size() const { return list_.size(); }
 
-  void push_back(const T &value) { list_.push_back(value); }
+  bool push_back(const T &value) {
+    list_.push_back(value);
+    return false;
+  }
 
-  void push_front(const T &value) { list_.push_front(value); }
+  bool push_front(const T &value) {
+    list_.push_front(value);
+    return false;
+  }
 
   void pop_back() {
     if (!list_.empty()) {

--- a/sql/sql_derived.cc
+++ b/sql/sql_derived.cc
@@ -545,9 +545,10 @@ bool copy_field_info(THD *thd, Item *orig_expr, Item *cloned_expr) {
                  }
                  if (inner_item->type() == Item::FIELD_ITEM) {
                    Item_field *field = down_cast<Item_field *>(inner_item);
-                   field_info.push_back(
-                       Field_info(context, field->table_ref, depended_from,
-                                  field->cached_table, field->field));
+                   if (field_info.push_back(
+                           Field_info(context, field->table_ref, depended_from,
+                                      field->cached_table, field->field)))
+                     return true;
                  }
                  return false;
                }))

--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -4344,7 +4344,7 @@ bool change_to_use_tmp_fields(mem_root_deque<Item *> *fields, THD *thd,
         Item_field *new_field = new Item_field(field);
         if (!suv || !new_field) return true;  // Fatal error
         mem_root_deque<Item *> list(thd->mem_root);
-        list.push_back(new_field);
+        if (list.push_back(new_field)) return true;
         if (suv->set_arguments(&list, true)) return true;
         new_item = suv;
       } else

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -2126,8 +2126,7 @@ static bool AddRowIdAsTempTableField(THD *thd, TABLE *table,
   Item_field *ifield = new (thd->mem_root) Item_field(field);
   if (ifield == nullptr) return true;
   ifield->set_nullable(false);
-  fields->push_back(ifield);
-  return false;
+  return fields->push_back(ifield);
 }
 
 /// Stores the current row ID of "table" in the specified field of "tmp_table".


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9647

Post push fix.

Commit 1ada447f changed mem_root_deque interface. It changed push_back and push_front methods return value from bool to void, because underlying list.push_back/list.push_front is a void type. However, it forces changes on caller side. Caller can not check the return code. These changes can be avoided by keeping the original interface and returning 'false' always.
Compiler will optimize such 'if' branches anyway after detection that push_back/push_front return 'false' always.