### PR TITLE
PS-9825: Add telemetry counters for JS Stored Routines (part 1)

### DIFF
--- a/components/js_lang/js_lang_core.cc
+++ b/components/js_lang/js_lang_core.cc
@@ -308,6 +308,15 @@ Js_isolate *Js_isolate::create() {
         type == v8::GCType::kGCTypeMarkSweepCompact) {
       Js_isolate *js_isolate = static_cast<Js_isolate *>(data);
       js_isolate->m_memory_manager.check_mem_limit_at_GC();
+
+      // Piggy-back on GC to refresh global call counter.
+      //
+      // This allows to keep counter more up-to-date in situations when
+      // we have a long-living connection that executes a lot of JS calls.
+      //
+      // TODO: This needs to be changed if we are to change relationship
+      //       between isolates and connections.
+      Js_thd::get_current_js_thd()->aggregate_call_count();
     }
     return;
   };
@@ -489,6 +498,9 @@ SHOW_VAR *Js_isolate::get_status_vars_defs() {
       // TODO: In future we might introduce Js_lang_isolates as well.
       {"Js_lang_contexts", reinterpret_cast<char *>(&show_contexts), SHOW_FUNC,
        SHOW_SCOPE_GLOBAL},
+      {"Js_lang_stored_program_call_count",
+       reinterpret_cast<char *>(&Js_thd::show_call_count), SHOW_FUNC,
+       SHOW_SCOPE_GLOBAL},
       {nullptr, nullptr, SHOW_UNDEF, SHOW_SCOPE_UNDEF}};
 
   return status_vars;
@@ -600,6 +612,8 @@ bool Js_isolate::check_if_heap_alloc_will_exceed_mem_limit(size_t length) {
 }
 
 mysql_thd_store_slot Js_thd::s_thd_slot = nullptr;
+
+std::atomic<size_t> Js_thd::s_call_count = 0;
 
 void Js_thd::register_slot() {
   auto free_fn_lambda = [](void *resource) {
@@ -815,6 +829,14 @@ bool Js_thd::Auth_id_context::process_unhandled_rejected_promises() {
 
   m_unhandled_rejected_promises.clear();
   return true;
+}
+
+int Js_thd::show_call_count(MYSQL_THD, SHOW_VAR *var, char *buff) {
+  var->type = SHOW_LONGLONG;
+  var->value = buff;
+  auto *value = reinterpret_cast<ulonglong *>(buff);
+  *value = s_call_count.load(std::memory_order_relaxed);
+  return 0;
 }
 
 Js_sp::Js_sp(stored_program_handle sp, uint16_t sql_sp_type) : m_sql_sp(sp) {
@@ -1144,6 +1166,8 @@ bool Js_sp::parse() {
 
 bool Js_sp::execute() {
   Js_thd *js_thd = Js_thd::get_or_create_current_js_thd();
+
+  js_thd->inc_call_count();
 
   /*
     Get Isolate and JS context for current connection and active user.

--- a/components/js_lang/js_lang_core.h
+++ b/components/js_lang/js_lang_core.h
@@ -429,7 +429,11 @@ class Js_isolate {
 class Js_thd {
  public:
   explicit Js_thd(MYSQL_THD thd) : m_thd(thd) {}
-  ~Js_thd() {}
+  ~Js_thd() {
+    // Add not-yet agreggated number of calls for this connection into
+    // global calls counter.
+    s_call_count += m_call_count;
+  }
 
   // Block default copy/move semantics.
   Js_thd(Js_thd const &rhs) = delete;
@@ -868,6 +872,17 @@ class Js_thd {
     m_auth_id_contexts.erase(auth_id);
   }
 
+  void inc_call_count() { ++m_call_count; }
+
+  // Connection's call counter into global one, reset the former.
+  void aggregate_call_count() {
+    s_call_count += m_call_count;
+    m_call_count = 0;
+  }
+
+  /* Helper implementing call count status variable. */
+  static int show_call_count(MYSQL_THD, SHOW_VAR *var, char *buff);
+
  private:
   // Opaque handle for corresponding THD object.
   MYSQL_THD m_thd;
@@ -877,6 +892,13 @@ class Js_thd {
 
   // Map with per user-account contexts for the connection.
   std::unordered_map<std::string, Auth_id_context> m_auth_id_contexts;
+
+  // Number of JS stored programs calls that happened in this connection
+  // which are not yet aggregated into global call counter.
+  size_t m_call_count{0};
+
+  // Global counter of JS stored programs calls.
+  static std::atomic<size_t> s_call_count;
 };
 
 /**

--- a/mysql-test/suite/component_js_lang/r/js_lang_big.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_big.result
@@ -53,6 +53,29 @@ disconnect con_big_packet;
 connection default;
 SET @@global.max_allowed_packet = @save_max_allowed_packet;
 SET @@global.js_lang.max_mem_size = @save_js_lang_max_mem_size;
+#
+# Test JS stored program call count global status variable.
+#
+
+# Run trivial JS function in a new connection plenty of times
+# to ensure that the status variable increment is clearly visible.
+connect  con_call_count, localhost, root,,;
+CREATE FUNCTION f_trivial() RETURNS INT LANGUAGE JS AS $$ return 2*2 $$;
+SELECT BENCHMARK(100000, f_trivial());
+BENCHMARK(100000, f_trivial())
+0
+DROP FUNCTION f_trivial;
+# Disconnect the connection to ensure that call count is aggregated
+# into global status variable value.
+disconnect con_call_count;
+connection default;
+# Check that 'Js_lang_stored_program_call_count' global status variable
+# got updated accordingly.
+#
+# Use wait_condition.inc for this check to ensure that it is not affected
+# by the fact that release of connection of resources (and hence call
+# count aggregation) happens after its close and thus asynchronously
+# from test's point of view.
 # Global clean-up.
 REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
 # Disconnect of default connection to free the only remaining

--- a/mysql-test/suite/component_js_lang/r/js_lang_mem_limit.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_mem_limit.result
@@ -117,6 +117,7 @@ SHOW STATUS LIKE 'js_lang%';
 Variable_name	Value
 Js_lang_contexts	#
 Js_lang_external_memory_size	#
+Js_lang_stored_program_call_count	#
 Js_lang_total_heap_size	#
 Js_lang_used_heap_size	#
 # But at least number of contexts is stable.

--- a/mysql-test/suite/component_js_lang/t/js_lang_big.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_big.test
@@ -87,6 +87,34 @@ DROP FUNCTION f_longblob;
 SET @@global.max_allowed_packet = @save_max_allowed_packet;
 SET @@global.js_lang.max_mem_size = @save_js_lang_max_mem_size;
 
+--echo #
+--echo # Test JS stored program call count global status variable.
+--echo #
+
+--echo
+--echo # Run trivial JS function in a new connection plenty of times
+--echo # to ensure that the status variable increment is clearly visible.
+--connect (con_call_count, localhost, root,,)
+CREATE FUNCTION f_trivial() RETURNS INT LANGUAGE JS AS $$ return 2*2 $$;
+SELECT BENCHMARK(100000, f_trivial());
+DROP FUNCTION f_trivial;
+
+--echo # Disconnect the connection to ensure that call count is aggregated
+--echo # into global status variable value.
+--disconnect con_call_count
+--source include/wait_until_disconnected.inc
+
+--connection default
+--echo # Check that 'Js_lang_stored_program_call_count' global status variable
+--echo # got updated accordingly.
+--echo #
+--echo # Use wait_condition.inc for this check to ensure that it is not affected
+--echo # by the fact that release of connection of resources (and hence call
+--echo # count aggregation) happens after its close and thus asynchronously
+--echo # from test's point of view.
+--let $wait_condition= SELECT variable_value >= 100000 FROM performance_schema.global_status WHERE variable_name = "Js_lang_stored_program_call_count"
+--source include/wait_condition.inc
+
 --echo # Global clean-up.
 REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9825

Added 'Js_lang_stored_program_call_count' global status variable which allows to track number of calls to stored programs in JS.

Added test coverage for this variable.

Note that tho avoid making this counter performance bottleneck we do not update this global status variable on each JS stored program call. Instead we accumulate number of such calls in connection-specific counter and aggregate per-connection counter values into global one on connection close (similarly how it works for some other global status variables) and during JS Garbage Collection.