### PR TITLE
PS-9956 fix: PS 8.4.4-4 Group replication crashes with audit log filter component enabled (8.4)

### DIFF
--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -130,20 +130,28 @@ uint64_t LogRecordFormatterBase::make_record_id() const noexcept {
 }
 
 std::string LogRecordFormatterBase::make_escaped_string(
-    const std::string &in) const noexcept {
+    const char *in) const noexcept {
   std::string out;
-  const auto &escape_rules = get_escape_rules();
+  if (in != nullptr) {
+    const auto &escape_rules = get_escape_rules();
 
-  for (const char &c : in) {
-    const auto it = escape_rules.find(c);
-    if (it == escape_rules.end()) {
-      out.append(&c, 1);
-    } else {
-      out.append(it->second);
+    for (const char *ptr = in; *ptr != '\0'; ++ptr) {
+      const auto it = escape_rules.find(*ptr);
+      if (it == escape_rules.end()) {
+        out.append(ptr, 1);
+      } else {
+        out.append(it->second);
+      }
     }
   }
 
   return out;
+}
+
+std::string LogRecordFormatterBase::make_escaped_string(
+    const std::string &in) const noexcept {
+  const mysql_cstring_with_length wrapper{in.data(), in.size()};
+  return make_escaped_string(&wrapper);
 }
 
 std::string LogRecordFormatterBase::make_escaped_string(
@@ -153,10 +161,11 @@ std::string LogRecordFormatterBase::make_escaped_string(
   if (in != nullptr && in->str != nullptr && in->length != 0) {
     const auto &escape_rules = get_escape_rules();
 
-    for (size_t i = 0; i < in->length; ++i) {
-      const auto it = escape_rules.find(in->str[i]);
+    for (const char *ptr = in->str, *en = in->str + in->length; ptr < en;
+         ++ptr) {
+      const auto it = escape_rules.find(*ptr);
       if (it == escape_rules.end()) {
-        out.append(&in->str[i], 1);
+        out.append(ptr, 1);
       } else {
         out.append(it->second);
       }

--- a/components/audit_log_filter/log_record_formatter/base.h
+++ b/components/audit_log_filter/log_record_formatter/base.h
@@ -264,6 +264,14 @@ class LogRecordFormatterBase {
    * @brief Apply escaping rules to provided string.
    *
    * @param in String to be escaped
+   * @return Escaped string (an empty string if 'in' is nullptr)
+   */
+  [[nodiscard]] std::string make_escaped_string(const char *in) const noexcept;
+
+  /**
+   * @brief Apply escaping rules to provided string.
+   *
+   * @param in String to be escaped
    * @return Escaped string
    */
   [[nodiscard]] std::string make_escaped_string(


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9956

Fixed problem with 'LogReccordFormatter(s)' ('OLD', 'NEW' and 'JSON') sometimes passing nullptr strings into 'make_escaped_string()'  function which was performing implicit conversion into 'std::string'. In c++20 this operation is considered UB although most STL implementations just throw an exception in this case. Fixed by adding another overload `make_escaped_string(const char *)` which handles nullptrs properly.