### PR TITLE
[8.0] PS-9159 : crash due to SELECT GLOBAL_TEMPORARY_TABLES when there is running DDL

### DIFF
--- a/mysql-test/include/percona_global_temp_table_alter.inc
+++ b/mysql-test/include/percona_global_temp_table_alter.inc
@@ -1,0 +1,33 @@
+--source include/count_sessions.inc
+
+if (!$create_table_query) {
+  --die "please set the variable $create_table_query to a valid query"
+}
+
+if (!$alter_table_query) {
+  --die "please set the variable $alter_table_query to a valid query"
+}
+
+if (!$drop_table_query) {
+  --die "please set the variable $alter_table_query to a valid query"
+}
+
+connect (con1, localhost, root,,);
+--connection default
+--eval $create_table_query
+
+
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+--send_eval $alter_table_query
+
+--connection con1
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+--replace_column 1 SESSION_ID 3 TABLE_NAME 5 NAME
+SELECT * FROM information_schema.global_temporary_tables;
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+--connection default
+--reap
+--eval $drop_table_query
+--disconnect con1
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/r/percona_global_temp_tables_debug.result
+++ b/mysql-test/r/percona_global_temp_tables_debug.result
@@ -1,0 +1,68 @@
+create table b(id int primary key) PARTITION BY HASH(id) PARTITIONS 8;
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+alter table b rebuild partition p0,p1,p2,p3;
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+drop table b;
+create table t1(id int primary key);
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+optimize table t1;
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+drop table t1;
+create table t1(id int primary key,b INT);
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+alter table t1 add index k1(b);
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+drop table t1;
+create table t1(id int primary key,b INT);
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+alter table t1 add column c INT;
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+drop table t1;
+create table t1(partition_id tinyint NOT NULL , cal_date date NOT NULL, value CHAR(100), PRIMARY KEY(partition_id, cal_date)) ENGINE=InnoDB PARTITION BY LIST COLUMNS(partition_id, cal_date) (PARTITION p0 VALUES IN ((0,'2024-06-01'), (0, '2024-07-01')) ENGINE=InnoDB, PARTITION p1 VALUES IN ((1, '2024-08-01'),(1, '2024-09-01')) ENGINE=InnoDB);
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+ALTER TABLE t1 ADD PARTITION (PARTITION p3 VALUES IN ((3, '2024-10-01')));
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+DROP TABLE t1;
+create table t1(partition_id tinyint NOT NULL , cal_date date NOT NULL, value CHAR(100), PRIMARY KEY(partition_id, cal_date)) ENGINE=InnoDB PARTITION BY LIST COLUMNS(partition_id, cal_date) (PARTITION p0 VALUES IN ((0,'2024-06-01'), (0, '2024-07-01')) ENGINE=InnoDB, PARTITION p1 VALUES IN ((1, '2024-08-01'),(1, '2024-09-01')) ENGINE=InnoDB);
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+ALTER TABLE t1 DROP PARTITION p0;
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+DROP TABLE t1;
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY, title VARCHAR(255), body TEXT) ENGINE=InnoDB;
+SET DEBUG_SYNC="alter_before_close_temp_tables SIGNAL enter_alter_table_before_close_temp_tables WAIT_FOR continue_commit_alter_ddl";
+ALTER TABLE t1 ADD FULLTEXT(title, body);
+SET DEBUG_SYNC="now WAIT_FOR enter_alter_table_before_close_temp_tables";
+SELECT * FROM information_schema.global_temporary_tables;
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+SESSION_ID	test	TABLE_NAME	InnoDB	NAME	0	0	0	0	NULL	NULL
+SET DEBUG_SYNC="now SIGNAL continue_commit_alter_ddl";
+Warnings:
+Warning	124	InnoDB rebuilding table to add column FTS_DOC_ID
+DROP TABLE t1;

--- a/mysql-test/t/percona_global_temp_tables_debug.test
+++ b/mysql-test/t/percona_global_temp_tables_debug.test
@@ -1,0 +1,37 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--let $create_table_query=create table b(id int primary key) PARTITION BY HASH(id) PARTITIONS 8
+--let $alter_table_query=alter table b rebuild partition p0,p1,p2,p3
+--let $drop_table_query=drop table b
+--source include/percona_global_temp_table_alter.inc
+
+--let $create_table_query=create table t1(id int primary key)
+--let $alter_table_query=optimize table t1
+--let $drop_table_query=drop table t1
+--source include/percona_global_temp_table_alter.inc
+
+--let $create_table_query=create table t1(id int primary key,b INT)
+--let $alter_table_query=alter table t1 add index k1(b)
+--let $drop_table_query=drop table t1
+--source include/percona_global_temp_table_alter.inc
+
+--let $create_table_query=create table t1(id int primary key,b INT)
+--let $alter_table_query=alter table t1 add column c INT
+--let $drop_table_query=drop table t1
+--source include/percona_global_temp_table_alter.inc
+
+--let $create_table_query=create table t1(partition_id tinyint NOT NULL , cal_date date NOT NULL, value CHAR(100), PRIMARY KEY(partition_id, cal_date)) ENGINE=InnoDB PARTITION BY LIST COLUMNS(partition_id, cal_date) (PARTITION p0 VALUES IN ((0,'2024-06-01'), (0, '2024-07-01')) ENGINE=InnoDB, PARTITION p1 VALUES IN ((1, '2024-08-01'),(1, '2024-09-01')) ENGINE=InnoDB)
+--let $alter_table_query= ALTER TABLE t1 ADD PARTITION (PARTITION p3 VALUES IN ((3, '2024-10-01')))
+--let $drop_table_query=DROP TABLE t1
+--source include/percona_global_temp_table_alter.inc
+
+--let $create_table_query=create table t1(partition_id tinyint NOT NULL , cal_date date NOT NULL, value CHAR(100), PRIMARY KEY(partition_id, cal_date)) ENGINE=InnoDB PARTITION BY LIST COLUMNS(partition_id, cal_date) (PARTITION p0 VALUES IN ((0,'2024-06-01'), (0, '2024-07-01')) ENGINE=InnoDB, PARTITION p1 VALUES IN ((1, '2024-08-01'),(1, '2024-09-01')) ENGINE=InnoDB)
+--let $alter_table_query= ALTER TABLE t1 DROP PARTITION p0
+--let $drop_table_query=DROP TABLE t1
+--source include/percona_global_temp_table_alter.inc
+
+--let $create_table_query=CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY, title VARCHAR(255), body TEXT) ENGINE=InnoDB
+--let $alter_table_query=ALTER TABLE t1 ADD FULLTEXT(title, body)
+--let $drop_table_query=DROP TABLE t1
+--source include/percona_global_temp_table_alter.inc

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -4468,12 +4468,13 @@ static int store_temporary_table_record(THD *thd, TABLE *table,
 
   /* We have only one handler object for a temp table globally and it might
   be in use by other thread.  Do not trash it by invoking handler methods on
-  it but rather clone it. */
-  if (file) {
+  it but rather clone it. if db_stat is 0, the table is not opened in SE,
+  do not clone it */
+  if (file && tmp_table->db_stat != 0) {
     file = file->clone(tmp_table->s->normalized_path.str, mem_root);
   }
 
-  if (file) {
+  if (file && tmp_table->db_stat != 0) {
     MYSQL_TIME time;
 
     /**

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -13809,6 +13809,9 @@ static bool mysql_inplace_alter_table(
     close_all_tables_for_name(thd, table->s, false, nullptr);
     table_list->table = table = nullptr;
     reopen_tables = true;
+
+    DEBUG_SYNC(thd, "alter_before_close_temp_tables");
+
     close_temporary_table(thd, altered_table, true, false);
     rollback_needs_dict_cache_reset = true;
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9159
Problem:
--------
When there are temporary tables created by ALTER, a concurrent
SELECT * FROM information_schema.global_temporary_tables causes a crash.

The temporary table object from ALTER is created using an intermediate name (#sql-ib* or *#P#p0#tmp)

Later I_S query tries to clone the handler object of the temporary table to avoid concurrent
usage of handler object by two threads (THDs). Handler::clone()/ha_innobase::clone() opens the cloned 
object again using handler::open()/ha_innobase::open().

This time, it tries to open with the temp table name. The corresponding dd::Table object is valid. So it tries
to load the object from DD and load to cache. A table object with 
different name (already exists in cache) but with same table_id. This causes the crash.

Example data from core/rr:
rr) p table->id
$21 = 1075
(rr) p table->name
$22 = {m_name = 0x7f575ec556c0 "test/#sql-3147d6_8#p#p0"}
(rr) p table2->name
$23 = {m_name = 0x7f575428f5d0 "test/b#p#p0#tmp"}
(rr) p table2->id
$24 = 1075

Fix:
----
Since commit 4480f97 (8.0.1), handler::clone()'s behaviour changed. It now assigns the TABLE*
object to handler. This changes the behaviour of the handler::clone(). If TABLE* exists in the handler,
it will do handler::open().

From the I_S query path, we can identify the tables that are never opened in SE from the TABLE*->db_stat property. If we have a temp table that is not opened in SE, do not try to clone the handler. Actually, handler::clone() is useless for temp tables from ALTERs anyway. We always return NULL index stats for tmp tables from DDLs (5.7 behaviour) anyway.