### PR TITLE
PS-9956 fix: PS 8.4.4-4 Group replication crashes with audit log filter component enabled (9.x)

### DIFF
--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -130,20 +130,28 @@ uint64_t LogRecordFormatterBase::make_record_id() const noexcept {
 }
 
 std::string LogRecordFormatterBase::make_escaped_string(
-    const std::string &in) const noexcept {
+    const char *in) const noexcept {
   std::string out;
-  const auto &escape_rules = get_escape_rules();
+  if (in != nullptr) {
+    const auto &escape_rules = get_escape_rules();
 
-  for (const char &c : in) {
-    const auto it = escape_rules.find(c);
-    if (it == escape_rules.end()) {
-      out.append(&c, 1);
-    } else {
-      out.append(it->second);
+    for (const char *ptr = in; *ptr != '\0'; ++ptr) {
+      const auto it = escape_rules.find(*ptr);
+      if (it == escape_rules.end()) {
+        out.append(ptr, 1);
+      } else {
+        out.append(it->second);
+      }
     }
   }
 
   return out;
+}
+
+std::string LogRecordFormatterBase::make_escaped_string(
+    const std::string &in) const noexcept {
+  const mysql_cstring_with_length wrapper{in.data(), in.size()};
+  return make_escaped_string(&wrapper);
 }
 
 std::string LogRecordFormatterBase::make_escaped_string(
@@ -153,10 +161,11 @@ std::string LogRecordFormatterBase::make_escaped_string(
   if (in != nullptr && in->str != nullptr && in->length != 0) {
     const auto &escape_rules = get_escape_rules();
 
-    for (size_t i = 0; i < in->length; ++i) {
-      const auto it = escape_rules.find(in->str[i]);
+    for (const char *ptr = in->str, *en = in->str + in->length; ptr < en;
+         ++ptr) {
+      const auto it = escape_rules.find(*ptr);
       if (it == escape_rules.end()) {
-        out.append(&in->str[i], 1);
+        out.append(ptr, 1);
       } else {
         out.append(it->second);
       }

--- a/components/audit_log_filter/log_record_formatter/base.h
+++ b/components/audit_log_filter/log_record_formatter/base.h
@@ -264,6 +264,14 @@ class LogRecordFormatterBase {
    * @brief Apply escaping rules to provided string.
    *
    * @param in String to be escaped
+   * @return Escaped string (an empty string if 'in' is nullptr)
+   */
+  [[nodiscard]] std::string make_escaped_string(const char *in) const noexcept;
+
+  /**
+   * @brief Apply escaping rules to provided string.
+   *
+   * @param in String to be escaped
    * @return Escaped string
    */
   [[nodiscard]] std::string make_escaped_string(

--- a/mysql-test/suite/group_replication/r/percona_gr_audit_log_filter.result
+++ b/mysql-test/suite/group_replication/r/percona_gr_audit_log_filter.result
@@ -1,0 +1,21 @@
+include/group_replication.inc [rpl_server_count=2]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
+[connection server1]
+SET sql_log_bin = 0;
+SET sql_log_bin = 1;
+
+# Starting GR on server1
+
+[connection server1]
+include/start_and_bootstrap_group_replication.inc
+
+# Starting GR on server2
+
+[connection server2]
+include/start_group_replication.inc
+include/group_replication_end.inc
+# restart
+SET sql_log_bin = 0;
+SET sql_log_bin = 1;

--- a/mysql-test/suite/group_replication/t/percona_gr_audit_log_filter.test
+++ b/mysql-test/suite/group_replication/t/percona_gr_audit_log_filter.test
@@ -1,0 +1,38 @@
+--source include/have_group_replication_plugin.inc
+--source include/have_component_audit_log.inc
+
+--let $rpl_skip_group_replication_start = 1
+--let $rpl_server_count = 2
+--let $rpl_group_replication_single_primary_mode = 1
+--source include/group_replication.inc
+
+SET sql_log_bin = 0;
+--source suite/component_audit_log_filter/inc/audit_tables_init.inc
+--source suite/component_audit_log_filter/inc/audit_comp_install.inc
+SET sql_log_bin = 1;
+
+--echo
+--echo # Starting GR on server1
+--echo
+# Boostrap start GR on server1 (Primary)
+--let $rpl_connection_name = server1
+--source include/connection.inc
+--source include/start_and_bootstrap_group_replication.inc
+
+--echo
+--echo # Starting GR on server2
+--echo
+# Start GR on server2 (Secondary)
+--let $rpl_connection_name = server2
+--source include/connection.inc
+--source include/start_group_replication.inc
+
+--source include/group_replication_end.inc
+
+# restart is needed to be able to uninstall the audit_log_filter component
+--source include/restart_mysqld.inc
+
+SET sql_log_bin = 0;
+--source suite/component_audit_log_filter/inc/audit_comp_uninstall.inc
+--source suite/component_audit_log_filter/inc/audit_tables_cleanup.inc
+SET sql_log_bin = 1;

--- a/sql/command_mapping.cc
+++ b/sql/command_mapping.cc
@@ -248,5 +248,17 @@ enum_server_command get_server_command(const char *server_command) {
 const char *get_sql_command_string(enum_sql_command sql_command) {
   static_assert(((size_t)(SQLCOM_END - SQLCOM_SELECT) + 2) ==
                 (sizeof(Command_maps::sql_commands) / sizeof(char *)));
-  return Command_maps::sql_commands[sql_command];
+  /* As this function is called with the 'sql_command' extracted from the
+     THD's 'lex' subobject ('thd->lex->sql_command'), in some cases (for
+     instance, when one of the group replication threads changes the value
+     of the 'read_only' / 'super_read_only' system variables) the THD object
+     associated with the current thread is not a real one fully initialized
+     by the connection handler and may have 'lex' subobject initialized with
+     default values where 'lex->sql_command' will be 'SQLCOM_END'. In other
+     words, 'SQLCOM_END' is a valid value for this function and we should
+     handle this case properly.
+  */
+  assert(sql_command <= SQLCOM_END);
+  return sql_command < SQLCOM_END ? Command_maps::sql_commands[sql_command]
+                                  : "<unknown>";
 }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9956

Fixed problem with 'get_sql_command_string()' function accessing out-of-bound array element when called with 'SQLCOM_END'. In some cases, for instance, when one of the group replication threads changes the value of the 'read_only' / 'super_read_only' system variables, the 'THD' object associated with the executing thread is not a real one fully initialized by the connection handler and may have default-constructed 'lex' subobject with 'lex->sql_command' equal to 'SQLCOM_END'. In other words, 'SQLCOM_END' is a valid value for this function and we should handle this case properly.

As an additional safety measure inside the 'audit_log_filter' code added another overload of the 'make_escaped_string()' function that accepts 'const char *' which guarantees that all
'make_escaped_string(audit_record.event->sql_command)' calls comming from 'LogReccordFormatter(s)' ('OLD', 'NEW' and 'JSON') will handle null values (that may come from 'thd->lex->sql_command') properly.

Added 'group_replication.percona_gr_audit_log_filter' MTR test case that helped to reproduce original issue under Address Sanitizer.