### PR TITLE
PS-9836 [8.4]: Performance regression with audit_log_filter vs audit_log plugins

### DIFF
--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -28,6 +28,8 @@
 #include <mysql/components/services/defs/event_tracking_stored_program_defs.h>
 #include <mysql/components/services/defs/event_tracking_table_access_defs.h>
 
+#include <boost/date_time/c_time.hpp>
+
 #include <cassert>
 #include <iomanip>
 #include <iostream>
@@ -480,10 +482,16 @@ const EscapeRulesContainer &LogRecordFormatterBaseXml::get_escape_rules()
 std::string LogRecordFormatterBaseXml::make_timestamp(
     const std::chrono::system_clock::time_point time_point) const noexcept {
   std::time_t t = std::chrono::system_clock::to_time_t(time_point);
-  std::stringstream timestamp;
-  timestamp << std::put_time(std::localtime(&t), "%FT%T");
+  std::tm tm;
+  static constexpr std::size_t max_buffer_size{32};
+  std::string result(max_buffer_size, '\0');
 
-  return timestamp.str();
+  boost::date_time::c_time::localtime(&t, &tm);
+  const std::size_t len =
+      std::strftime(result.data(), result.size(), "%FT%T", &tm);
+  result.resize(len);
+
+  return result;
 }
 
 }  // namespace audit_log_filter::log_record_formatter

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -29,6 +29,8 @@
 #include <mysql/components/services/defs/event_tracking_stored_program_defs.h>
 #include <mysql/components/services/defs/event_tracking_table_access_defs.h>
 
+#include <boost/date_time/c_time.hpp>
+
 #include <cassert>
 #include <chrono>
 #include <iomanip>
@@ -824,10 +826,16 @@ std::string LogRecordFormatterJson::make_timestamp(
         SysVars::get_debug_time_point_for_rotation());
   });
 
-  std::stringstream timestamp;
-  timestamp << std::put_time(std::localtime(&tp), "%F %T");
+  std::tm tm;
+  static constexpr std::size_t max_buffer_size{32};
+  std::string result(max_buffer_size, '\0');
 
-  return timestamp.str();
+  boost::date_time::c_time::localtime(&tp, &tm);
+  const std::size_t len =
+      std::strftime(result.data(), result.size(), "%F %T", &tm);
+  result.resize(len);
+
+  return result;
 }
 
 void LogRecordFormatterJson::apply_debug_info(

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -86,8 +86,11 @@ void FileHandle::write_file(const char *record, const size_t size) noexcept {
 
 uint64_t FileHandle::get_file_size() const noexcept {
   assert(m_file.is_open());
-  return std::filesystem::exists(m_path) ? std::filesystem::file_size(m_path)
-                                         : 0;
+  try {
+    return std::filesystem::file_size(m_path);
+  } catch (const std::filesystem::filesystem_error &) {
+    return 0;
+  }
 }
 
 std::filesystem::path FileHandle::get_file_path() const noexcept {


### PR DESCRIPTION
Optimize a number of system calls for  `LogRecordFormatterBaseXml::make_timestamp`, `LogRecordFormatterJson::make_timestamp`, and `FileHandle::get_file_size`.

```
OLD VERSION: audit_log_filter_format=JSON, 8 sysbench threads
8 records/query; queries:  562911 (18762.63 per sec.); output_log: 1500M; {"filter": { "log": true } }
5 records/query; queries:  804338 (26809.53 per sec.); output_log: 1500M; {"filter": { "class": [ { "name": "general" }, { "name": "query" } ] } }');
3 records/query; queries: 1126845 (37559.33 per sec.)  output_log: 1500M; {"filter": { "class": [ { "name": "general" } ] } }
1 records/query; queries: 1616769 (53889.32 per sec.); output_log: 727M;  {"filter": { "class": [ { "name": "general", "event": {"name": "log"}, "general_data": { "sql_command": "select" } } ] } }
```

```
OPTIMIZED VERSION: audit_log_filter_format=JSON, 8 sysbench threads
8 records/query; queries:  786834 (26226.32 per sec.); output_log: 2100M; {"filter": { "log": true } }
5 records/query; queries: 1036192 (34537.80 per sec.); output_log: 1900M; {"filter": { "class": [ { "name": "general" }, { "name": "query" } ] } }');
3 records/query; queries: 1365392 (45510.27 per sec.); output_log: 1800M; {"filter": { "class": [ { "name": "general" } ] } }
1 records/query; queries: 1713596 (57116.59 per sec.); output_log: 771M;  {"filter": { "class": [ { "name": "general", "event": {"name": "log"}, "general_data": { "sql_command": "select" } } ] } }
```