### PR TITLE
PS-9825: Add telemetry counters for JS Stored Routines (part 2)

### DIFF
--- a/components/js_lang/js_lang_core.cc
+++ b/components/js_lang/js_lang_core.cc
@@ -52,6 +52,8 @@ std::unique_ptr<v8::Platform> Js_v8::s_platform;
 
 std::atomic<int> Js_v8::s_ref_count = 0;
 
+std::atomic<size_t> Js_v8::s_peak_ref_count = 0;
+
 void Js_v8::init() {
   // We would like to enforce strict mode for code of JS routines right
   // from the start.
@@ -81,6 +83,35 @@ void Js_v8::shutdown() {
   v8::V8::Dispose();
   v8::V8::DisposePlatform();
   s_platform.reset();
+}
+
+/**
+  Helper which atomically updates peak status variable if new value of
+  global status variable exceeds current peak value.
+*/
+static void update_peak_value(std::atomic<size_t> &peak_var, size_t new_val) {
+  size_t old_peak_val = peak_var.load();
+  while (new_val > old_peak_val &&
+         !peak_var.compare_exchange_weak(old_peak_val, new_val)) {
+    // CAS failed because peak value was concurrently updated under our feet.
+    // The new peak value was stored in old_peak_val as a side-effect of
+    // failed CAS. Let us check if new_val still exceeds peak and retry
+    // update if yes.
+    //
+    // Note that at this point new_val might not match the current value
+    // of global status variable which peak value we are tracking. This
+    // is OK. If new_val is bigger than current value of status variable
+    // we can still update peak. If new_val is smaller than current value
+    // of status variable then peak values has been already updated (so
+    // the above condition will fail) or will be updated soon (in which
+    // case updating peak value won't harm either).
+  }
+}
+
+void Js_v8::inc_ref_count() {
+  assert(s_ref_count.load() >= 0);
+  size_t new_isolate_count = (++s_ref_count);
+  update_peak_value(s_peak_ref_count, new_isolate_count);
 }
 
 bool Js_isolate::Memory_manager::check_mem_limit_at_arr_buff_alloc(
@@ -351,14 +382,25 @@ void Js_isolate::Memory_manager::update_global_mem_stats(
   // global memory usage counters. To get actual global values, deduct values
   // which were added to global counters on previous call of this method for
   // the isolate.
-  s_total_heap_size += (stats.total_heap_size() - m_old_stats.total_heap_size);
-  s_used_heap_size += (stats.used_heap_size() - m_old_stats.used_heap_size);
+  size_t new_ths = (s_total_heap_size +=
+                    (stats.total_heap_size() - m_old_stats.total_heap_size));
+  size_t new_uhs = (s_used_heap_size +=
+                    (stats.used_heap_size() - m_old_stats.used_heap_size));
   // Using value from v8::HeapStatistics rather than directly from
   // Memory_manager sounds more future-proof. For example, in future we might
   // add size of SQL result objects to the amount of externally allocated
   // memory (by reporting it to V8 using appropriate API).
-  s_external_memory_size +=
+  size_t new_ems = s_external_memory_size +=
       (stats.external_memory() - m_old_stats.external_memory_size);
+
+  // Also update corresponding global peak usage counters if necessary.
+  //
+  // Note that since update of peak usage counters is not atomic with update
+  // global usage counters, users might sometimes see their values not in
+  // sync. This should not be big deal for statistics.
+  update_peak_value(s_peak_total_heap_size, new_ths);
+  update_peak_value(s_peak_used_heap_size, new_uhs);
+  update_peak_value(s_peak_external_memory_size, new_ems);
 
   // Save added counter values so they can be deducted on future calls or
   // isolate destruction.
@@ -422,15 +464,31 @@ std::string Js_isolate::Memory_manager::get_mem_stats_json(
   json_writer.Key(STRING_WITH_LEN("totalHeapSize"));
   json_writer.Uint64(s_total_heap_size.load(std::memory_order_relaxed));
 
+  // TODO: In future if number of counters reported grows we might consider
+  //       splitting global object into two sub-objects, one for current and
+  //       one for peak values.
+  json_writer.Key(STRING_WITH_LEN("peakTotalHeapSize"));
+  json_writer.Uint64(s_peak_total_heap_size.load(std::memory_order_relaxed));
+
   json_writer.Key(STRING_WITH_LEN("usedHeapSize"));
   json_writer.Uint64(s_used_heap_size.load(std::memory_order_relaxed));
+
+  json_writer.Key(STRING_WITH_LEN("peakUsedHeapSize"));
+  json_writer.Uint64(s_peak_used_heap_size.load(std::memory_order_relaxed));
 
   json_writer.Key(STRING_WITH_LEN("externalMemorySize"));
   json_writer.Uint64(s_external_memory_size.load(std::memory_order_relaxed));
 
+  json_writer.Key(STRING_WITH_LEN("peakExternalMemorySize"));
+  json_writer.Uint64(
+      s_peak_external_memory_size.load(std::memory_order_relaxed));
+
   // Number of contexts is the same as number isolates at this point.
   json_writer.Key(STRING_WITH_LEN("contexts"));
   json_writer.Uint(Js_v8::get_isolate_count());
+
+  json_writer.Key(STRING_WITH_LEN("peakContexts"));
+  json_writer.Uint(Js_v8::get_peak_isolate_count());
 
   json_writer.EndObject();
 
@@ -440,34 +498,20 @@ std::string Js_isolate::Memory_manager::get_mem_stats_json(
 }
 
 std::atomic<size_t> Js_isolate::Memory_manager::s_total_heap_size = 0;
+std::atomic<size_t> Js_isolate::Memory_manager::s_peak_total_heap_size = 0;
 std::atomic<size_t> Js_isolate::Memory_manager::s_used_heap_size = 0;
+std::atomic<size_t> Js_isolate::Memory_manager::s_peak_used_heap_size = 0;
 std::atomic<size_t> Js_isolate::Memory_manager::s_external_memory_size = 0;
+std::atomic<size_t> Js_isolate::Memory_manager::s_peak_external_memory_size = 0;
 
-int Js_isolate::Memory_manager::show_total_heap_size(MYSQL_THD, SHOW_VAR *var,
-                                                     char *buff) {
+// Helper template to show value of status variable represented
+// by C++ static class member with atomic<size_t> type.
+template <std::atomic<size_t> *atomic_var>
+int show_atomic_status_var(MYSQL_THD, SHOW_VAR *var, char *buff) {
   var->type = SHOW_LONGLONG;
   var->value = buff;
   auto *value = reinterpret_cast<ulonglong *>(buff);
-  *value = s_total_heap_size.load(std::memory_order_relaxed);
-  return 0;
-}
-
-int Js_isolate::Memory_manager::show_used_heap_size(MYSQL_THD, SHOW_VAR *var,
-                                                    char *buff) {
-  var->type = SHOW_LONGLONG;
-  var->value = buff;
-  auto *value = reinterpret_cast<ulonglong *>(buff);
-  *value = s_used_heap_size.load(std::memory_order_relaxed);
-  return 0;
-}
-
-int Js_isolate::Memory_manager::show_external_memory_size(MYSQL_THD,
-                                                          SHOW_VAR *var,
-                                                          char *buff) {
-  var->type = SHOW_LONGLONG;
-  var->value = buff;
-  auto *value = reinterpret_cast<ulonglong *>(buff);
-  *value = s_external_memory_size.load(std::memory_order_relaxed);
+  *value = atomic_var->load(std::memory_order_relaxed);
   return 0;
 }
 
@@ -487,17 +531,36 @@ SHOW_VAR *Js_isolate::get_status_vars_defs() {
   //       to fight with information leakage more easily).
   static SHOW_VAR status_vars[] = {
       {"Js_lang_total_heap_size",
-       reinterpret_cast<char *>(&Memory_manager::show_total_heap_size),
+       reinterpret_cast<char *>(
+           &show_atomic_status_var<&Memory_manager::s_total_heap_size>),
+       SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+      {"Js_lang_peak_total_heap_size",
+       reinterpret_cast<char *>(
+           &show_atomic_status_var<&Memory_manager::s_peak_total_heap_size>),
        SHOW_FUNC, SHOW_SCOPE_GLOBAL},
       {"Js_lang_used_heap_size",
-       reinterpret_cast<char *>(&Memory_manager::show_used_heap_size),
+       reinterpret_cast<char *>(
+           &show_atomic_status_var<&Memory_manager::s_used_heap_size>),
+       SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+      {"Js_lang_peak_used_heap_size",
+       reinterpret_cast<char *>(
+           &show_atomic_status_var<&Memory_manager::s_peak_used_heap_size>),
        SHOW_FUNC, SHOW_SCOPE_GLOBAL},
       {"Js_lang_external_memory_size",
-       reinterpret_cast<char *>(&Memory_manager::show_external_memory_size),
+       reinterpret_cast<char *>(
+           &show_atomic_status_var<&Memory_manager::s_external_memory_size>),
+       SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+      {"Js_lang_peak_external_memory_size",
+       reinterpret_cast<char *>(&show_atomic_status_var<
+                                &Memory_manager::s_peak_external_memory_size>),
        SHOW_FUNC, SHOW_SCOPE_GLOBAL},
       // TODO: In future we might introduce Js_lang_isolates as well.
       {"Js_lang_contexts", reinterpret_cast<char *>(&show_contexts), SHOW_FUNC,
        SHOW_SCOPE_GLOBAL},
+      {"Js_lang_peak_contexts",
+       reinterpret_cast<char *>(
+           &show_atomic_status_var<&Js_v8::s_peak_ref_count>),
+       SHOW_FUNC, SHOW_SCOPE_GLOBAL},
       {"Js_lang_stored_program_call_count",
        reinterpret_cast<char *>(&Js_thd::show_call_count), SHOW_FUNC,
        SHOW_SCOPE_GLOBAL},

--- a/components/js_lang/js_lang_core.h
+++ b/components/js_lang/js_lang_core.h
@@ -69,6 +69,11 @@ class Js_v8 {
     return (ref_count >= 0) ? ref_count : 0;
   }
 
+  /** Get peak number of v8::Isolate objects which was reached. */
+  static size_t get_peak_isolate_count() {
+    return s_peak_ref_count.load(std::memory_order_relaxed);
+  }
+
   /**
     Pump isolate's foreground message loop, i.e. process tasks posted to
     isolate's foreground task queue (for example, some GC steps, which
@@ -91,10 +96,7 @@ class Js_v8 {
 
  private:
   // Increment/decrement V8 usage/isolate global reference counter.
-  static void inc_ref_count() {
-    assert(s_ref_count.load() >= 0);
-    ++s_ref_count;
-  }
+  static void inc_ref_count();
   static void dec_ref_count() { --s_ref_count; }
 
   // Js_isolate methods need access to inc/dec_ref_count;
@@ -110,6 +112,8 @@ class Js_v8 {
   // (used for debug purposes) or completed (we rely on this to block
   // UNINSTALL -> INSTALL scenario).
   static std::atomic<int> s_ref_count;
+  // Peak number of V8 Isolates which was reached.
+  static std::atomic<size_t> s_peak_ref_count;
 };
 
 /**
@@ -335,11 +339,6 @@ class Js_isolate {
     */
     static std::string get_mem_stats_json(Memory_manager *mem_mgr);
 
-    /* Helpers implementing memory usage status variables. */
-    static int show_total_heap_size(MYSQL_THD, SHOW_VAR *var, char *buff);
-    static int show_used_heap_size(MYSQL_THD, SHOW_VAR *var, char *buff);
-    static int show_external_memory_size(MYSQL_THD, SHOW_VAR *var, char *buff);
-
     /** Pointer to isolate to which this memory manager belongs. */
     Js_isolate *m_js_isolate;
 
@@ -410,14 +409,18 @@ class Js_isolate {
     } m_old_stats{0, 0, 0};
 
     /**
-      Global counters of memory usage to be shown as status variables.
+      Global counters of current and peak memory usage to be shown as status
+      variables.
 
       TODO: Consider partitioning these counters if updating them ever
             becomes performance bottleneck (though it is unlikely).
     */
     static std::atomic<size_t> s_total_heap_size;
+    static std::atomic<size_t> s_peak_total_heap_size;
     static std::atomic<size_t> s_used_heap_size;
+    static std::atomic<size_t> s_peak_used_heap_size;
     static std::atomic<size_t> s_external_memory_size;
+    static std::atomic<size_t> s_peak_external_memory_size;
   } m_memory_manager;
 };
 

--- a/mysql-test/suite/component_js_lang/r/js_lang_mem_limit.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_mem_limit.result
@@ -117,13 +117,20 @@ SHOW STATUS LIKE 'js_lang%';
 Variable_name	Value
 Js_lang_contexts	#
 Js_lang_external_memory_size	#
+Js_lang_peak_contexts	#
+Js_lang_peak_external_memory_size	#
+Js_lang_peak_total_heap_size	#
+Js_lang_peak_used_heap_size	#
 Js_lang_stored_program_call_count	#
 Js_lang_total_heap_size	#
 Js_lang_used_heap_size	#
-# But at least number of contexts is stable.
+# But at least current and peak numbers of contexts are stable.
 SHOW STATUS LIKE 'js_lang_contexts';
 Variable_name	Value
 Js_lang_contexts	1
+SHOW STATUS LIKE 'js_lang_peak_contexts';
+Variable_name	Value
+Js_lang_peak_contexts	1
 #
 # 6) Test coverage for JS_GET_MEMORY_USAGE_JSON() UDF.
 #
@@ -150,9 +157,13 @@ JS_GET_MEMORY_USAGE_JSON()
     },
     "global": {
         "totalHeapSize": <number>,
+        "peakTotalHeapSize": <number>,
         "usedHeapSize": <number>,
+        "peakUsedHeapSize": <number>,
         "externalMemorySize": <number>,
-        "contexts": <number>
+        "peakExternalMemorySize": <number>,
+        "contexts": <number>,
+        "peakContexts": <number>
     }
 }
 # Since some phases of GC are concurrent even checking that memory
@@ -160,15 +171,18 @@ JS_GET_MEMORY_USAGE_JSON()
 # is racy.
 #
 # Let us at least check that heap usage is non-zero.
-# Also number of active contexts should be stable.
+# Also current and peak numbers of active contexts should be stable.
 SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
 SELECT JSON_EXTRACT(@mem_usage, "$.local.totalHeapSize") > 0 AS loc_ths,
 JSON_EXTRACT(@mem_usage, "$.local.usedHeapSize") > 0  AS loc_uhs,
 JSON_EXTRACT(@mem_usage, "$.global.totalHeapSize") > 0 AS glob_ths,
 JSON_EXTRACT(@mem_usage, "$.global.usedHeapSize") > 0  AS glob_uhs,
-JSON_EXTRACT(@mem_usage, "$.global.contexts") AS glob_c;
-loc_ths	loc_uhs	glob_ths	glob_uhs	glob_c
-1	1	1	1	1
+JSON_EXTRACT(@mem_usage, "$.global.peakTotalHeapSize") > 0 AS peak_ths,
+JSON_EXTRACT(@mem_usage, "$.global.peakUsedHeapSize") > 0  AS peak_uhs,
+JSON_EXTRACT(@mem_usage, "$.global.contexts") AS glob_c,
+JSON_EXTRACT(@mem_usage, "$.global.peakContexts") AS peak_c;
+loc_ths	loc_uhs	glob_ths	glob_uhs	peak_ths	peak_uhs	glob_c	peak_c
+1	1	1	1	1	1	1	1
 #
 # 6.2) Test what happens when UDF is called for connection which
 #      never run JS before.
@@ -181,9 +195,13 @@ JS_GET_MEMORY_USAGE_JSON()
     "local": null,
     "global": {
         "totalHeapSize": <number>,
+        "peakTotalHeapSize": <number>,
         "usedHeapSize": <number>,
+        "peakUsedHeapSize": <number>,
         "externalMemorySize": <number>,
-        "contexts": <number>
+        "peakExternalMemorySize": <number>,
+        "contexts": <number>,
+        "peakContexts": <number>
     }
 }
 #
@@ -203,28 +221,73 @@ JS_GET_MEMORY_USAGE_JSON()
     },
     "global": {
         "totalHeapSize": <number>,
+        "peakTotalHeapSize": <number>,
         "usedHeapSize": <number>,
+        "peakUsedHeapSize": <number>,
         "externalMemorySize": <number>,
-        "contexts": <number>
+        "peakExternalMemorySize": <number>,
+        "contexts": <number>,
+        "peakContexts": <number>
     }
 }
-# Number of active contexts should increase!
-SELECT JSON_EXTRACT(JS_GET_MEMORY_USAGE_JSON(), "$.global.contexts") AS c;
-c
-2
+# Current and peak numbers of active contexts should increase!
+SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
+SELECT JSON_EXTRACT(@mem_usage, "$.global.contexts") AS c,
+JSON_EXTRACT(@mem_usage, "$.global.peakContexts") AS peak_c;
+c	peak_c
+2	2
 #
-# 6.4) Finally, let us test that "external"/off-heap allocations
+# 6.4) Now, let us test that "external"/off-heap allocations
 #      are also tracked.
 CREATE PROCEDURE p1() LANGUAGE JS AS $$ globalThis.a = new ArrayBuffer(1024) $$;
 CALL p1();
 SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
 SELECT JSON_EXTRACT(@mem_usage, "$.local.externalMemorySize") >= 1024 AS loc_ems,
-JSON_EXTRACT(@mem_usage, "$.global.externalMemorySize") >= 1024  AS glob_ems;
-loc_ems	glob_ems
-1	1
-# Local clean-up.
+JSON_EXTRACT(@mem_usage, "$.global.externalMemorySize") >= 1024  AS glob_ems,
+JSON_EXTRACT(@mem_usage, "$.global.peakExternalMemorySize") >= 1024  AS peak_ems;
+loc_ems	glob_ems	peak_ems
+1	1	1
+#
+# 6.5) Finally, check what happens to current and peak usage counters
+#      after connection close.
+#
 disconnect con_add;
 connection default;
+#
+# Number of currently active contexts should return back to 1.
+#
+# Use wait_condition.inc for this check to ensure that it is not affected
+# by the fact that release of connection of resources (and hence call
+# count aggregation) happens after its close and thus asynchronously
+# from test's point of view.
+SHOW STATUS LIKE 'js_lang_contexts';
+Variable_name	Value
+Js_lang_contexts	1
+#
+# However peak number of contexts should stay the same.
+SHOW STATUS LIKE 'js_lang_peak_contexts';
+Variable_name	Value
+Js_lang_peak_contexts	2
+# Same check for JS_GET_MEMORY_USAGE_JSON() UDF.
+SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
+SELECT JSON_EXTRACT(@mem_usage, "$.global.contexts") AS c,
+JSON_EXTRACT(@mem_usage, "$.global.peakContexts") AS peak_c;
+c	peak_c
+1	2
+#
+# We can't do similar check for heap usage counters due to
+# unpredicatibility of such allocations and point at which they
+# will be updated.
+#
+# But at least we can check values of "external"/off-heap allocation
+# counters. For them, peak counter value should stay the same and
+# current usage should decrease.
+SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
+SELECT JSON_EXTRACT(@mem_usage, "$.global.externalMemorySize") < 1024  AS glob_ems,
+JSON_EXTRACT(@mem_usage, "$.global.peakExternalMemorySize") >= 1024  AS peak_ems;
+glob_ems	peak_ems
+1	1
+# Local clean-up.
 DROP PROCEDURE p1;
 DROP FUNCTION f1;
 # Global clean-up.

--- a/mysql-test/suite/component_js_lang/t/js_lang_mem_limit.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_mem_limit.test
@@ -136,8 +136,9 @@ DROP FUNCTION f_json_hog;
 --echo # due to garbage collection.
 --replace_column 2 #
 SHOW STATUS LIKE 'js_lang%';
---echo # But at least number of contexts is stable.
+--echo # But at least current and peak numbers of contexts are stable.
 SHOW STATUS LIKE 'js_lang_contexts';
+SHOW STATUS LIKE 'js_lang_peak_contexts';
 
 --echo #
 --echo # 6) Test coverage for JS_GET_MEMORY_USAGE_JSON() UDF.
@@ -162,14 +163,17 @@ SELECT JS_GET_MEMORY_USAGE_JSON();
 --echo # is racy.
 --echo #
 --echo # Let us at least check that heap usage is non-zero.
---echo # Also number of active contexts should be stable.
+--echo # Also current and peak numbers of active contexts should be stable.
 SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
 
 SELECT JSON_EXTRACT(@mem_usage, "$.local.totalHeapSize") > 0 AS loc_ths,
        JSON_EXTRACT(@mem_usage, "$.local.usedHeapSize") > 0  AS loc_uhs,
        JSON_EXTRACT(@mem_usage, "$.global.totalHeapSize") > 0 AS glob_ths,
        JSON_EXTRACT(@mem_usage, "$.global.usedHeapSize") > 0  AS glob_uhs,
-       JSON_EXTRACT(@mem_usage, "$.global.contexts") AS glob_c;
+       JSON_EXTRACT(@mem_usage, "$.global.peakTotalHeapSize") > 0 AS peak_ths,
+       JSON_EXTRACT(@mem_usage, "$.global.peakUsedHeapSize") > 0  AS peak_uhs,
+       JSON_EXTRACT(@mem_usage, "$.global.contexts") AS glob_c,
+       JSON_EXTRACT(@mem_usage, "$.global.peakContexts") AS peak_c;
 
 --echo #
 --echo # 6.2) Test what happens when UDF is called for connection which
@@ -188,23 +192,64 @@ SELECT f1();
 --replace_regex /[0-9]+/<number>/
 SELECT JS_GET_MEMORY_USAGE_JSON();
 
---echo # Number of active contexts should increase!
-SELECT JSON_EXTRACT(JS_GET_MEMORY_USAGE_JSON(), "$.global.contexts") AS c;
+--echo # Current and peak numbers of active contexts should increase!
+SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
+SELECT JSON_EXTRACT(@mem_usage, "$.global.contexts") AS c,
+       JSON_EXTRACT(@mem_usage, "$.global.peakContexts") AS peak_c;
 
 --echo #
---echo # 6.4) Finally, let us test that "external"/off-heap allocations
+--echo # 6.4) Now, let us test that "external"/off-heap allocations
 --echo #      are also tracked.
 CREATE PROCEDURE p1() LANGUAGE JS AS $$ globalThis.a = new ArrayBuffer(1024) $$;
 CALL p1();
 
 SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
 SELECT JSON_EXTRACT(@mem_usage, "$.local.externalMemorySize") >= 1024 AS loc_ems,
-       JSON_EXTRACT(@mem_usage, "$.global.externalMemorySize") >= 1024  AS glob_ems;
+       JSON_EXTRACT(@mem_usage, "$.global.externalMemorySize") >= 1024  AS glob_ems,
+       JSON_EXTRACT(@mem_usage, "$.global.peakExternalMemorySize") >= 1024  AS peak_ems;
 
---echo # Local clean-up.
+--echo #
+--echo # 6.5) Finally, check what happens to current and peak usage counters
+--echo #      after connection close.
+--echo #
+
 --disconnect con_add
 --source include/wait_until_disconnected.inc
 --connection default
+
+--echo #
+--echo # Number of currently active contexts should return back to 1.
+--echo #
+--echo # Use wait_condition.inc for this check to ensure that it is not affected
+--echo # by the fact that release of connection of resources (and hence call
+--echo # count aggregation) happens after its close and thus asynchronously
+--echo # from test's point of view.
+--let $wait_condition= SELECT variable_value = 1 FROM performance_schema.global_status WHERE variable_name = "Js_lang_contexts"
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'js_lang_contexts';
+
+--echo #
+--echo # However peak number of contexts should stay the same.
+SHOW STATUS LIKE 'js_lang_peak_contexts';
+
+--echo # Same check for JS_GET_MEMORY_USAGE_JSON() UDF.
+SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
+SELECT JSON_EXTRACT(@mem_usage, "$.global.contexts") AS c,
+       JSON_EXTRACT(@mem_usage, "$.global.peakContexts") AS peak_c;
+
+--echo #
+--echo # We can't do similar check for heap usage counters due to
+--echo # unpredicatibility of such allocations and point at which they
+--echo # will be updated.
+--echo #
+--echo # But at least we can check values of "external"/off-heap allocation
+--echo # counters. For them, peak counter value should stay the same and
+--echo # current usage should decrease.
+SET @mem_usage := JS_GET_MEMORY_USAGE_JSON();
+SELECT JSON_EXTRACT(@mem_usage, "$.global.externalMemorySize") < 1024  AS glob_ems,
+       JSON_EXTRACT(@mem_usage, "$.global.peakExternalMemorySize") >= 1024  AS peak_ems;
+
+--echo # Local clean-up.
 DROP PROCEDURE p1;
 DROP FUNCTION f1;
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9825

Added status variables/counters for global peak memory usage and peak number of active JS contexts.

These status variables are named:
  1) 'Js_lang_peak_used_heap_size'
  2) 'Js_lang_peak_total_heap_size'
  3) 'Js_lang_peak_external_memory_size'
  4) 'Js_lang_peak_contexts'
and correspond to their non-peak versions.

Added this information to JS_GET_MEMORY_USAGE_JSON() output as well.

Extended test coverage accordingly.