### PR TITLE
PS-9834 [8.4] Fix integer overflow in audit log filter FILE rotation …

### DIFF
--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -257,7 +257,7 @@ void LogWriterFile::prune() noexcept {
                                                      SysVars::get_file_name());
 
     ulonglong current_logs_size = std::accumulate(
-        log_file_list.begin(), log_file_list.end(), 0,
+        log_file_list.begin(), log_file_list.end(), ulonglong{0},
         [](const ulonglong &a, const PruneFileInfo &b) { return a + b.size; });
     current_logs_size += get_log_size();
 


### PR DESCRIPTION
…leading to data loss

Problem: When using audit_log_filter.handler=FILE and audit_log_filter.max_size that exceeds 2GiB, the previous prune logic would incorrectly compute an enormous existing log footprint. This was caused by an integer overflow in std::accumulate, which was initialized with a signed 32-bit integer literal. The overflow resulted in an incorrect total size calculation, leading to the premature deletion of all existing audit log files and potential data loss.

Solution: Initialize std::accumulate with an unsigned long long. This explicitly sets the accumulation type to `unsigned long long`, preventing integer overflow and ensuring accurate audit log size calculations and correct pruning behavior.