### PR TITLE
PS-10131 [8.4] Fix audit log rotation stall in buffered strategies

### DIFF
--- a/components/audit_log_filter/log_writer/file_writer_buffering.cc
+++ b/components/audit_log_filter/log_writer/file_writer_buffering.cc
@@ -104,6 +104,9 @@ bool FileWriterBuffering::open() noexcept {
 
 void FileWriterBuffering::close() noexcept {
   mysql_mutex_lock(&m_mutex);
+  if (m_flush_pos != m_write_pos) {
+    mysql_cond_signal(&m_written_cond);
+  }
   while (m_flush_pos != m_write_pos) {
     mysql_cond_wait(&m_flushed_cond, &m_mutex);
   }


### PR DESCRIPTION
Fix stall during audit log rotation when using ASYNCHRONOUS or PERFORMANCE buffering strategies. The rotation process could be delayed by up to one second while holding the m_write_lock mutex.

```
mysql> do audit_log_rotate();
Query OK, 0 rows affected (0.99 sec)
```

The issue occurs when log rotation calls FileWriterBuffering::close() and the flush worker thread was sleeping in mysql_cond_timedwait. The close method waits for the flush worker to clear the buffer, but that worker thread might not wake up for up to one second causing unnecessary delay.

Signal the flush worker thread immediately before waiting in close to ensure prompt processing of any remaining buffered data and prevent rotation stalls.