### PR TITLE
PS-10132: Uninitialized buf_page_t::is_corrupt member found by Valgrind

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -4830,7 +4830,12 @@ static void buf_page_init_low(buf_page_t *bpage) noexcept {
 
   bpage->flush_type = BUF_FLUSH_LRU;
   bpage->reinit_io_fix();
+#ifndef HAVE_VALGRIND
+  /* This is to check if we call buf_page_init_low() on buf_page_t that is not
+   buf-fixed. buf_page_alloc_descriptor() does not init buf_fix_count in release
+   version, so Valgrind would complain here */
   ut_a(bpage->buf_fix_count == 0);
+#endif
   bpage->buf_fix_count.store(0);
   bpage->freed_page_clock = 0;
   bpage->access_time = {};

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1169,7 +1169,8 @@ class buf_page_t {
         m_version(other.m_version),
         access_time(other.access_time),
         m_dblwr_id(other.m_dblwr_id),
-        old(other.old)
+        old(other.old),
+        is_corrupt(other.is_corrupt)
 #ifdef UNIV_DEBUG
         ,
         file_page_was_freed(other.file_page_was_freed),


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10132

Detected by Valgrind.
Fixed the copy constructor of buf_page_t. 'is_corrupt' member is not initialized in copy constructor. buf_LRU_free_page() uses this constructor (placement 'new' in memory allocated by buf_page_alloc_descriptor()) and does not call buf_page_init_low() where 'is_corrupt' is initialized in other cases.
Then we have several places in code when decision is made basing on 'is_corrupt' value. This is where Valgrind complained.

Note that buf_page_alloc_descriptor() initializes 'is_corrupt', but only in debug build, so the problem is visible only in release.