### PR TITLE
(8.0) PS-10132: Uninitialized buf_page_t::is_corrupt member found by Valgrind

### DIFF
--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1169,7 +1169,8 @@ class buf_page_t {
         m_version(other.m_version),
         access_time(other.access_time),
         m_dblwr_id(other.m_dblwr_id),
-        old(other.old)
+        old(other.old),
+        is_corrupt(other.is_corrupt)
 #ifdef UNIV_DEBUG
         ,
         file_page_was_freed(other.file_page_was_freed),

--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -681,9 +681,12 @@ static inline buf_page_t *buf_page_alloc_descriptor(void) {
   UNIV_MEM_ALLOC(bpage, sizeof *bpage);
   /* This is required for valgrind to work correctly. */
   bpage->m_space = nullptr;
-#ifdef UNIV_DEBUG
+#ifdef UNIV_DEBUG_VALGRIND
+  /* There is a counterpart assertion of the following assignment in
+   buf_page_init_low(). The assertion is to check if we call buf_page_init_low()
+   on buf_page_t that is not buf-fixed. buf_page_alloc_descriptor() does not
+   init buf_fix_count explicitly, so Valgrind would complain there. */
   bpage->buf_fix_count.store(0);
-  bpage->is_corrupt = false;
 #endif
 
   return (bpage);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10132

Fixed issue detected by Valgrind for release build. This is the improvement of fix for the same issue introduced in commit 2e1b2b5c.

Commit 4ad1d0cc introduced buf_page_t::is_corrupt flag; however, it omitted including it in the copy constructor of buf_page_t.

Not including it in the copy constructor seems safe at the moment, but it is error-prone in general. The copy constructor is used in several places as a placement new. It is assumed that the memory used by it is zeroed upfront. But nothing forces the copy constructor to use such zeroed memory, so in general, a newly copied object can contain garbage in the 'is_corrupt' member.

1. Fixed the copy constructor of buf_page_t
2. Adjusted fix from commit 4ad1d0cc to work always if we do Valgrind, not only in the debug build.

Why did Valgrind complain?
'is_corrupt' member was not initialized in the copy constructor. buf_LRU_free_page() uses this constructor (placement 'new' in memory allocated by buf_page_alloc_descriptor()) and does not call buf_page_init_low(), where 'is_corrupt' is initialized in other cases. Then we have several places in code where a decision is made based on the 'is_corrupt' value. This is where Valgrind complained.

Note that after commi 2e1b2b5c buf_page_alloc_descriptor() initialized 'is_corrupt' only in the debug build, so the problem was visible only in the release.

We also use a copy constructor of buf_page_t in buf_page_realloc(), buf_relocate(), and rtr_copy_buf(). This is after getting a block/page from the LRU free list. In such a case, there is no mechanism that guarantees that 'is_corrupt' is false. Having a proper copy constructor guarantees that the copy is what we expect it to be.