### PR TITLE
PS-10131 [8.4] Fix Audit Log file rotation stall

### DIFF
--- a/components/audit_log_filter/CMakeLists.txt
+++ b/components/audit_log_filter/CMakeLists.txt
@@ -37,6 +37,7 @@ IF(WITH_COMPONENT_AUDIT_LOG_FILTER)
       audit_table/base.cc
       audit_table/audit_log_filter.cc
       audit_table/audit_log_user.cc
+      log_file_timestamp.cc
       log_record_formatter.cc
       log_record_formatter/base.cc
       log_record_formatter/new.cc

--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -42,8 +42,9 @@ void AuditLogReader::set_files_to_read_list(
 
   std::vector<std::string> tp_list;
 
-  for (const auto &item : m_first_timestamp_to_file_map) {
-    if (item.first >= reader_context->next_event_bookmark.timestamp) {
+  for (const auto &item : m_timestamp_to_file_map) {
+    if (item.second->first_timestamp >=
+        reader_context->next_event_bookmark.timestamp) {
       auto *file_info = item.second.get();
 
       if (file_info->is_encrypted && file_info->encryption_options == nullptr) {
@@ -108,19 +109,19 @@ bool AuditLogReader::init() noexcept {
     }
   }
 
-  std::copy_if(all_files.cbegin(), all_files.cend(),
+  std::copy_if(std::cbegin(all_files), std::cend(all_files),
                std::back_inserter(new_files), [this](const auto &name) {
-                 return !std::any_of(m_first_timestamp_to_file_map.cbegin(),
-                                     m_first_timestamp_to_file_map.cend(),
+                 return !std::any_of(std::cbegin(m_timestamp_to_file_map),
+                                     std::cend(m_timestamp_to_file_map),
                                      [&name](const auto &entry) {
                                        return entry.second->name == name;
                                      });
                });
 
-  std::for_each(m_first_timestamp_to_file_map.cbegin(),
-                m_first_timestamp_to_file_map.cend(),
+  std::for_each(std::cbegin(m_timestamp_to_file_map),
+                std::cend(m_timestamp_to_file_map),
                 [&all_files, &removed_files](const auto &pair) {
-                  if (!std::any_of(all_files.cbegin(), all_files.cend(),
+                  if (!std::any_of(std::cbegin(all_files), std::cend(all_files),
                                    [&pair](const auto &name) {
                                      return name == pair.second->name;
                                    })) {
@@ -178,19 +179,21 @@ bool AuditLogReader::init() noexcept {
       continue;
     }
 
-    m_first_timestamp_to_file_map.emplace(
-        first_event->GetObject()["timestamp"].GetString(),
-        std::move(file_info));
+    file_info->first_timestamp =
+        first_event->GetObject()["timestamp"].GetString();
+
+    m_timestamp_to_file_map.emplace(LogFileTimestamp(log_name),
+                                    std::move(file_info));
   }
 
   for (const auto &log_name : removed_files) {
     auto it = std::find_if(
-        m_first_timestamp_to_file_map.cbegin(),
-        m_first_timestamp_to_file_map.cend(),
+        std::cbegin(m_timestamp_to_file_map),
+        std::cend(m_timestamp_to_file_map),
         [log_name](const auto &pair) { return pair.second->name == log_name; });
 
-    if (it != m_first_timestamp_to_file_map.cend()) {
-      m_first_timestamp_to_file_map.erase(it);
+    if (it != std::cend(m_timestamp_to_file_map)) {
+      m_timestamp_to_file_map.erase(it);
     }
   }
 

--- a/components/audit_log_filter/audit_log_reader.h
+++ b/components/audit_log_filter/audit_log_reader.h
@@ -19,6 +19,7 @@
 #include "components/audit_log_filter/audit_encryption.h"
 #include "components/audit_log_filter/json_reader/audit_json_handler.h"
 #include "components/audit_log_filter/json_reader/audit_json_read_stream.h"
+#include "components/audit_log_filter/log_file_timestamp.h"
 #include "components/audit_log_filter/sys_vars.h"
 
 #include <atomic>
@@ -59,6 +60,7 @@ struct FileInfo {
         is_encrypted{is_encrypted_},
         encryption_options{nullptr} {}
   std::string name;
+  std::string first_timestamp;
   std::string encryption_options_id;
   bool is_compressed;
   bool is_encrypted;
@@ -84,8 +86,7 @@ class AuditLogReader {
   void set_files_to_read_list(AuditLogReaderContext *reader_context) noexcept;
 
  private:
-  std::map<std::string, std::unique_ptr<FileInfo>>
-      m_first_timestamp_to_file_map;
+  std::map<LogFileTimestamp, std::unique_ptr<FileInfo>> m_timestamp_to_file_map;
   std::shared_mutex m_reader_mutex;
   std::atomic<bool> m_reload_requested;
 };

--- a/components/audit_log_filter/log_file_timestamp.cc
+++ b/components/audit_log_filter/log_file_timestamp.cc
@@ -1,0 +1,63 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "components/audit_log_filter/log_file_timestamp.h"
+#include <ctime>
+#include <regex>
+#include <tuple>
+
+namespace audit_log_filter {
+
+LogFileTimestamp::LogFileTimestamp(const std::filesystem::path &path) {
+  // 1. Finds the first timestamp ("YYYYMMDDTHHMMSS").
+  // 2. Optionally, looks for a sequence number ("-seq").
+  // 3. Optionally, matches ".enc", which is used to check if we're dealing
+  //    with rotation or encryption key timestamp.
+  static const std::regex pattern(
+      R"(^.*?\.(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(-(\d+))?(\.enc)?.*)");
+
+  auto filename = path.filename().string();
+  std::smatch match;
+  if (!std::regex_match(filename, match, pattern) || match[9].length() != 0) {
+    // If we weren't able to find any timestamp, or we were able to find
+    // only timestamp of an encryption key, we create empty (non-rotated)
+    // timestamp.
+    return;
+  }
+
+  std::tm tm = {};
+  tm.tm_year = std::stoi(match[1]) - 1900;
+  tm.tm_mon = std::stoi(match[2]) - 1;
+  tm.tm_mday = std::stoi(match[3]);
+  tm.tm_hour = std::stoi(match[4]);
+  tm.tm_min = std::stoi(match[5]);
+  tm.tm_sec = std::stoi(match[6]);
+  tm.tm_isdst = -1;
+
+  timestamp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+  seq = match[8].length() != 0 ? std::stoul(match[8]) : 0;
+}
+
+bool operator<(const LogFileTimestamp &lhs,
+               const LogFileTimestamp &rhs) noexcept {
+  if (!lhs.timestamp && !rhs.timestamp) return false;
+  if (!lhs.timestamp) return false;
+  if (!rhs.timestamp) return true;
+
+  return std::tie(lhs.timestamp.value(), lhs.seq) <
+         std::tie(rhs.timestamp.value(), rhs.seq);
+}
+
+}  // namespace audit_log_filter

--- a/components/audit_log_filter/log_file_timestamp.h
+++ b/components/audit_log_filter/log_file_timestamp.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef AUDIT_LOG_FILTER_LOG_FILE_TIMESTAMP_H_INCLUDED
+#define AUDIT_LOG_FILTER_LOG_FILE_TIMESTAMP_H_INCLUDED
+
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+
+namespace audit_log_filter {
+
+/**
+ * @brief Combines a timestamp and a sequence number in a sortable object.
+ *
+ * It orders log file names, considering the following scenarios:
+ * - non-rotated files (timestamp is empty)
+ * - rotated files without timestamp collisions (seq == 0)
+ * - rotated files with timestamp collisions (seq != 0)
+ */
+struct LogFileTimestamp {
+  LogFileTimestamp(const std::filesystem::path &path);
+
+  friend bool operator<(const LogFileTimestamp &lhs,
+                        const LogFileTimestamp &rhs) noexcept;
+
+  std::optional<std::chrono::system_clock::time_point> timestamp;
+  std::size_t seq = 0;
+};
+
+}  // namespace audit_log_filter
+
+#endif  // AUDIT_LOG_FILTER_LOG_FILE_TIMESTAMP_H_INCLUDED

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -288,7 +288,7 @@ void LogWriterFile::prune() noexcept {
                                                      SysVars::get_file_name());
 
     for (const auto &entry : log_file_list) {
-      if (entry.age > prune_seconds) {
+      if (entry.age > std::chrono::seconds(prune_seconds)) {
         FileHandle::remove_file(entry.path);
       }
     }

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -219,22 +219,35 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
     extensions_str = filename_str.substr(first_ext_pos);
   }
 
-  std::stringstream new_file_name;
-  new_file_name << base_file_name_str << "."
-                << std::put_time(std::localtime(&t),
-                                 kRotationTimeFormat.c_str())
-                << extensions_str;
-
-  std::filesystem::path new_file_path{current_file_path};
-  new_file_path.replace_filename(new_file_name.str());
   std::error_code ec;
+  std::filesystem::path new_file_path;
+  std::string new_file_name_str;
+  std::size_t seq = 0;
+
+  do {
+    std::string seq_str;
+    if (seq != 0) {
+      seq_str = "-" + std::to_string(seq);
+    }
+    seq++;
+
+    std::stringstream new_file_name;
+    new_file_name << base_file_name_str << "."
+                  << std::put_time(std::localtime(&t),
+                                   kRotationTimeFormat.c_str())
+                  << seq_str << extensions_str;
+    new_file_name_str = new_file_name.str();
+
+    new_file_path = current_file_path;
+    new_file_path.replace_filename(new_file_name_str);
+  } while (std::filesystem::exists(new_file_path, ec));
 
   std::filesystem::rename(current_file_path, new_file_path, ec);
 
   result->error_code = ec.value();
 
   if (result->error_code == 0) {
-    result->status_string = new_file_name.str();
+    result->status_string = new_file_name_str;
   } else {
     result->status_string = ec.message();
   }
@@ -245,14 +258,13 @@ PruneFilesList FileHandle::get_prune_files(
     const std::string &file_name) noexcept {
   PruneFilesList prune_files;
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
-  auto time_now = std::time(nullptr);
+  auto time_now = std::chrono::system_clock::now();
 
   DBUG_EXECUTE_IF("audit_log_filter_debug_timestamp", {
     // This will return the time of the newest rotated log + 1 minute so
     // file age will be calculated properly for files which are subject
     // for age based pruning.
-    time_now = std::chrono::system_clock::to_time_t(
-        SysVars::get_debug_time_point_for_rotation());
+    time_now = SysVars::get_debug_time_point_for_rotation();
   });
 
   for (const auto &entry :
@@ -262,15 +274,9 @@ PruneFilesList FileHandle::get_prune_files(
       auto parsed_file_name = FileName::from_path(entry.path().filename());
 
       if (parsed_file_name.is_rotated()) {
-        std::tm tm{};
-        std::istringstream ss(parsed_file_name.get_rotation_time());
-        ss >> std::get_time(&tm, kRotationTimeFormat.c_str());
-        tm.tm_isdst = -1;
-        auto time_rotated = timelocal(&tm);
-
+        auto timestamp = parsed_file_name.get_rotation_time().timestamp.value();
         prune_files.push_back(
-            {entry.path(), entry.file_size(),
-             static_cast<ulonglong>(time_now - time_rotated)});
+            {entry.path(), entry.file_size(), time_now - timestamp});
       }
     }
   }

--- a/components/audit_log_filter/log_writer/file_handle.h
+++ b/components/audit_log_filter/log_writer/file_handle.h
@@ -18,6 +18,7 @@
 
 #include "mysql/plugin_audit.h"
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -28,7 +29,7 @@ namespace audit_log_filter::log_writer {
 struct PruneFileInfo {
   std::filesystem::path path;
   ulonglong size;
-  ulonglong age;
+  std::chrono::system_clock::duration age;
 };
 
 struct FileRotationResult {

--- a/components/audit_log_filter/log_writer/file_name.cc
+++ b/components/audit_log_filter/log_writer/file_name.cc
@@ -22,10 +22,8 @@ namespace audit_log_filter::log_writer {
 FileName FileName::from_path(std::filesystem::path filename) noexcept {
   bool is_compressed{false};
   bool is_encrypted{false};
-  bool is_rotated{false};
 
   std::string key_id_str;
-  std::string rotation_time_str;
 
   if (filename.has_extension() && filename.extension().compare(".enc") == 0) {
     is_encrypted = true;
@@ -39,34 +37,29 @@ FileName FileName::from_path(std::filesystem::path filename) noexcept {
     filename.replace_extension();
   }
 
-  static const std::regex rotation_time_regex(R"(\.(\d{8}T\d{6}))");
-  std::smatch pieces_match;
+  auto timestamp = LogFileTimestamp(filename);
 
   while (filename.has_extension()) {
-    auto extension_str = filename.extension().string();
-
-    if (std::regex_match(extension_str, pieces_match, rotation_time_regex)) {
-      is_rotated = true;
-      rotation_time_str = pieces_match[1].str();
-    }
-
     filename.replace_extension();
   }
 
-  return FileName{
-      is_compressed,     is_encrypted,          is_rotated,
-      filename.string(), std::move(key_id_str), std::move(rotation_time_str)};
+  return FileName{is_compressed, is_encrypted, filename.string(),
+                  std::move(key_id_str), std::move(timestamp)};
 }
 
 bool FileName::is_compressed() const noexcept { return m_is_compressed; }
 
 bool FileName::is_encrypted() const noexcept { return m_is_encrypted; }
 
-bool FileName::is_rotated() const noexcept { return m_is_rotated; }
+bool FileName::is_rotated() const noexcept {
+  return m_rotation_time.timestamp.has_value();
+}
 
-std::string FileName::get_base_name() const noexcept { return m_base_name; }
+const std::string &FileName::get_base_name() const noexcept {
+  return m_base_name;
+}
 
-std::string FileName::get_rotation_time() const noexcept {
+const LogFileTimestamp &FileName::get_rotation_time() const noexcept {
   return m_rotation_time;
 }
 

--- a/components/audit_log_filter/log_writer/file_name.h
+++ b/components/audit_log_filter/log_writer/file_name.h
@@ -18,20 +18,20 @@
 
 #include <filesystem>
 #include <string>
+#include "components/audit_log_filter/log_file_timestamp.h"
 
 namespace audit_log_filter::log_writer {
 
 class FileName {
  private:
-  FileName(bool is_compressed, bool is_encrypted, bool is_rotated,
+  FileName(bool is_compressed, bool is_encrypted,
            std::string base_file_name_str, std::string key_id_str,
-           std::string rotation_time_str)
+           const LogFileTimestamp &rotation_time)
       : m_is_compressed{is_compressed},
         m_is_encrypted{is_encrypted},
-        m_is_rotated{is_rotated},
         m_base_name{std::move(base_file_name_str)},
         m_keyring_key_id{std::move(key_id_str)},
-        m_rotation_time{std::move(rotation_time_str)} {}
+        m_rotation_time{rotation_time} {}
 
  public:
   static FileName from_path(std::filesystem::path filename) noexcept;
@@ -40,16 +40,15 @@ class FileName {
   [[nodiscard]] bool is_encrypted() const noexcept;
   [[nodiscard]] bool is_rotated() const noexcept;
 
-  [[nodiscard]] std::string get_base_name() const noexcept;
-  [[nodiscard]] std::string get_rotation_time() const noexcept;
+  [[nodiscard]] const std::string &get_base_name() const noexcept;
+  [[nodiscard]] const LogFileTimestamp &get_rotation_time() const noexcept;
 
  private:
-  const bool m_is_compressed;
-  const bool m_is_encrypted;
-  const bool m_is_rotated;
-  const std::string m_base_name;
-  const std::string m_keyring_key_id;
-  const std::string m_rotation_time;
+  bool m_is_compressed;
+  bool m_is_encrypted;
+  std::string m_base_name;
+  std::string m_keyring_key_id;
+  LogFileTimestamp m_rotation_time;
 };
 
 }  // namespace audit_log_filter::log_writer

--- a/components/audit_log_filter/log_writer/file_writer_buffering.cc
+++ b/components/audit_log_filter/log_writer/file_writer_buffering.cc
@@ -105,6 +105,7 @@ bool FileWriterBuffering::open() noexcept {
 void FileWriterBuffering::close() noexcept {
   mysql_mutex_lock(&m_mutex);
   while (m_flush_pos != m_write_pos) {
+    mysql_cond_signal(&m_written_cond);
     mysql_cond_wait(&m_flushed_cond, &m_mutex);
   }
   mysql_mutex_unlock(&m_mutex);

--- a/mysql-test/suite/component_audit_log_filter/t/check_logs_age.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/check_logs_age.inc
@@ -37,7 +37,8 @@ perl;
   opendir(my $dh, $ENV{'log_path'}) || die "Can't opendir $ENV{'log_path'}: $!";
 
   while ((my $filename = readdir($dh))) {
-    if ($filename =~ /^$log_base_name/ && $filename =~ /\.(\d{8}T\d{6})\./) {
+    if ($filename =~ /^$log_base_name/ &&
+        $filename =~ /\.(\d{8}T\d{6})(-\d+)?\./) {
       push(@$timestamps, str2time($1));
     }
   }

--- a/mysql-test/suite/component_audit_log_filter/t/check_logs_name_format.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/check_logs_name_format.inc
@@ -56,22 +56,22 @@ perl;
       if ($with_compression && $with_encryption) {
         die "Bad log name format: $filename"
             if ($filename !~ /^$audit_filter_log_name\.gz\.(\d{8}T\d{6})-\d\.enc$/ &&
-                $filename !~ /^$log_base_name\.(\d{8}T\d{6})$log_extensions\.gz\.(\d{8}T\d{6})-\d\.enc/);
+                $filename !~ /^$log_base_name\.(\d{8}T\d{6})(-\d+)?$log_extensions\.gz\.(\d{8}T\d{6})-\d\.enc/);
       }
       elsif ($with_compression) {
         die "Bad log name format: $filename"
             if ($filename !~ /^$audit_filter_log_name\.gz$/ &&
-                $filename !~ /^$log_base_name\.(\d{8}T\d{6})$log_extensions\.gz/);
+                $filename !~ /^$log_base_name\.(\d{8}T\d{6})(-\d+)?$log_extensions\.gz/);
       }
       elsif ($with_encryption) {
         die "Bad log name format: $filename"
             if ($filename !~ /^$audit_filter_log_name\.(\d{8}T\d{6})-\d\.enc$/ &&
-                $filename !~ /^$log_base_name\.(\d{8}T\d{6})$log_extensions\.(\d{8}T\d{6})-\d\.enc/);
+                $filename !~ /^$log_base_name\.(\d{8}T\d{6})(-\d+)?$log_extensions\.(\d{8}T\d{6})-\d\.enc/);
       }
       else {
         die "Bad log name format: $filename"
             if ($filename !~ /^$audit_filter_log_name$/ &&
-                $filename !~ /^$log_base_name\.(\d{8}T\d{6})$log_extensions/);
+                $filename !~ /^$log_base_name\.(\d{8}T\d{6})(-\d+)?$log_extensions/);
       }
     }
   }

--- a/mysql-test/suite/component_audit_log_filter/t/log_format_unix_timestamp.test
+++ b/mysql-test/suite/component_audit_log_filter/t/log_format_unix_timestamp.test
@@ -9,7 +9,7 @@
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
 
 # Delete rotated xml formatted logs
---remove_files_wildcard $audit_filter_log_path audit_filter.????????T??????.log
+--remove_files_wildcard $audit_filter_log_path audit_filter.????????T??????*.log
 
 SELECT audit_log_filter_set_filter('log_all', '{"filter": {"log": true}}');
 SELECT audit_log_filter_set_user('%', 'log_all');

--- a/mysql-test/suite/component_audit_log_filter/t/log_prune_seconds.test
+++ b/mysql-test/suite/component_audit_log_filter/t/log_prune_seconds.test
@@ -3,6 +3,11 @@
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
 
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+
+# remove old rotated log files
+--remove_files_wildcard $audit_filter_log_path audit_filter.????????T??????*.log
+
 SET GLOBAL DEBUG='+d,audit_log_filter_debug_timestamp';
 
 SET @old_prune_seconds = @@global.audit_log_filter.prune_seconds;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10131

When using Audit Log in memory-buffered mode (ASYNCHRONOUS or PERFORMANCE), rotating a log file could be stalled for up to 1 second because file flushing thread wasn't being signaled properly. This patch fixes that, and causes log files to be rotated immediately upon request. However, since audit log file names contain rotation timestamp with resolution of 1 second, it introduces a possibility of log files being overwritten when rotated multiple times a second. To avoid potential loss of audit log information, timestamp used in names of newly rotated log files will be appended with a sequence number, whenever a file name collision was to occur.