### PR TITLE
PS-10210 [8.0]: Accepted ranges for some MyRocks variables don't match definition of variables

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1723,7 +1723,7 @@ static MYSQL_SYSVAR_INT(max_file_opening_threads,
                         "DBOptions::max_file_opening_threads for RocksDB",
                         nullptr, nullptr,
                         rocksdb_db_options->max_file_opening_threads,
-                        /* min */ 1, /* max */ INT_MAX, 0);
+                        /* min */ 1, /* max */ 1 << 18, 0);
 
 static MYSQL_SYSVAR_UINT64_T(max_total_wal_size,
                              rocksdb_db_options->max_total_wal_size,
@@ -1847,7 +1847,7 @@ static MYSQL_SYSVAR_ULONG(keep_log_file_num,
                           PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                           "DBOptions::keep_log_file_num for RocksDB", nullptr,
                           nullptr, rocksdb_db_options->keep_log_file_num,
-                          /* min */ 0L, /* max */ LONG_MAX, 0);
+                          /* min */ 1L, /* max */ LONG_MAX, 0);
 
 static MYSQL_SYSVAR_UINT64_T(max_manifest_file_size,
                              rocksdb_db_options->max_manifest_file_size,
@@ -2070,7 +2070,7 @@ static MYSQL_SYSVAR_UINT64_T(block_size, rocksdb_tbl_options->block_size,
                              PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                              "BlockBasedTableOptions::block_size for RocksDB",
                              nullptr, nullptr, rocksdb_tbl_options->block_size,
-                             /* min */ 1024L, /* max */ UINT64_MAX, 0);
+                             /* min */ 1024L, /* max */ std::numeric_limits<uint32_t>::max(), 0);
 
 static MYSQL_SYSVAR_BOOL(charge_memory, rocksdb_charge_memory,
                          PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -6830,7 +6830,7 @@ static int rocksdb_init_internal(void *const p) {
     }
     if (!strlen(rocksdb_persistent_cache_path)) {
       LogPluginErrMsg(ERROR_LEVEL, 0,
-                      "Specify rocksdb_persistent_cache_size_path");
+                      "Specify rocksdb_persistent_cache_path");
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Align min/max values to internal RocksDB limits:
1. Set max value of `rocksdb_block_size` to 4GiB.
2. Set min value of `rocksdb_keep_log_file_num` to 1.
3. Set max value of `rocksdb_max_file_opening_threads` to 262,144.

This patch fixes the following issues:
```
--loose-rocksdb_block_size=1125899906842624
2025-09-29T12:12:03.958604Z 0 [ERROR] [MY-000000] [Server] Plugin rocksdb reported: 'Error opening instance, Status Code: 4, Status: Invalid argument: block size exceeds maximum number (4GiB) allowed'

--loose-rocksdb_keep_log_file_num=0
2025-09-29T13:05:52.058572Z 0 [ERROR] [MY-000000] [Server] Plugin rocksdb reported: 'Error opening instance, Status Code: 4, Status: Invalid argument: keep_log_file_num must be greater than 0'
```