### PR TITLE
PS-10210 [9.x]: Accepted ranges for some MyRocks variables don't match definition of variables

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1716,7 +1716,7 @@ static MYSQL_SYSVAR_INT(max_file_opening_threads,
                         "DBOptions::max_file_opening_threads for RocksDB",
                         nullptr, nullptr,
                         rocksdb_db_options->max_file_opening_threads,
-                        /* min */ 1, /* max */ INT_MAX, 0);
+                        /* min */ 1, /* max */ 1 << 18, 0);
 
 static MYSQL_SYSVAR_UINT64_T(max_total_wal_size,
                              rocksdb_db_options->max_total_wal_size,
@@ -1840,7 +1840,7 @@ static MYSQL_SYSVAR_ULONG(keep_log_file_num,
                           PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                           "DBOptions::keep_log_file_num for RocksDB", nullptr,
                           nullptr, rocksdb_db_options->keep_log_file_num,
-                          /* min */ 0L, /* max */ LONG_MAX, 0);
+                          /* min */ 1L, /* max */ LONG_MAX, 0);
 
 static MYSQL_SYSVAR_UINT64_T(max_manifest_file_size,
                              rocksdb_db_options->max_manifest_file_size,
@@ -2063,7 +2063,7 @@ static MYSQL_SYSVAR_UINT64_T(block_size, rocksdb_tbl_options->block_size,
                              PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                              "BlockBasedTableOptions::block_size for RocksDB",
                              nullptr, nullptr, rocksdb_tbl_options->block_size,
-                             /* min */ 1024L, /* max */ UINT64_MAX, 0);
+                             /* min */ 1024L, /* max */ std::numeric_limits<uint32_t>::max(), 0);
 
 static MYSQL_SYSVAR_BOOL(charge_memory, rocksdb_charge_memory,
                          PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -6806,7 +6806,7 @@ static int rocksdb_init_internal(void *const p) {
     }
     if (!strlen(rocksdb_persistent_cache_path)) {
       LogPluginErrMsg(ERROR_LEVEL, 0,
-                      "Specify rocksdb_persistent_cache_size_path");
+                      "Specify rocksdb_persistent_cache_path");
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Align min/max values to internal RocksDB limits:
1. Set max value of `rocksdb_block_size` to 4GiB.
2. Set min value of `rocksdb_keep_log_file_num` to 1.
3. Set max value of `rocksdb_max_file_opening_threads` to 262,144.