### PR TITLE
PS-10215 [9.x]: Fix failing Azure Pipelines platforms (macOS-14)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -283,9 +283,9 @@ jobs:
           REAL_COMPILER_VER=`$SELECTED_CC --version | head -1 | awk '{print $4}'`
         fi
       else
-         brew update
-         brew install ccache protobuf@21 lz4 openssl@1.1 bison
-         brew link protobuf@21
+        brew update
+        brew install ccache protobuf@21 lz4 openssl@3 bison
+        brew link --force protobuf@21
       fi
 
       UPDATE_TIME=$SECONDS
@@ -352,12 +352,13 @@ jobs:
       "
 
       if [[ "$OS_NAME" == "Darwin" ]]; then
+        OPENSSL_PREFIX=$(brew --prefix openssl@3)
         CMAKE_OPT+="
           -DMYSQL_MAINTAINER_MODE=OFF
           -DWITH_PROTOBUF=system
           -DWITH_SYSTEM_LIBS=ON
           -DWITH_ICU=bundled
-          -DWITH_SSL=/usr/local/opt/openssl@1.1
+          -DWITH_SSL=$OPENSSL_PREFIX
           -DWITH_FIDO=bundled
           -DWITH_ZLIB=bundled
           -DWITH_PERCONA_AUTHENTICATION_LDAP=OFF


### PR DESCRIPTION
Switch from `openssl@1.1` to `openssl@3` to fix macOS-14 issues with OpenSSL on Azure:

```
Undefined symbols for architecture x86_64:
  "_ERR_new", referenced from:
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_ERR_set_debug", referenced from:
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_ERR_set_error", referenced from:
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_EVP_PKEY_CTX_new_from_name", referenced from:
      TlsClientContext::TlsClientContext(TlsVerify, bool, unsigned long, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>) in tls_client_context.cc.o
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_EVP_PKEY_CTX_set_params", referenced from:
      TlsClientContext::TlsClientContext(TlsVerify, bool, unsigned long, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>) in tls_client_context.cc.o
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_EVP_PKEY_generate", referenced from:
      TlsClientContext::TlsClientContext(TlsVerify, bool, unsigned long, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>) in tls_client_context.cc.o
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_EVP_PKEY_get_base_id", referenced from:
      TlsContext::load_key_and_cert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_context.cc.o
  "_EVP_PKEY_get_int_param", referenced from:
      TlsContext::load_key_and_cert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_context.cc.o
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_OSSL_DECODER_CTX_free", referenced from:
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_OSSL_DECODER_CTX_new_for_pkey", referenced from:
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_OSSL_DECODER_from_bio", referenced from:
      TlsServerContext::init_tmp_dh(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in tls_server_context.cc.o
  "_OSSL_PARAM_construct_end", referenced from:
```