### PR TITLE
PS-9834 [8.0] Fixed Audit Log file size counter overflow

### DIFF
--- a/plugin/audit_log_filter/log_writer/file.cc
+++ b/plugin/audit_log_filter/log_writer/file.cc
@@ -257,7 +257,7 @@ void LogWriterFile::prune() noexcept {
                                                      SysVars::get_file_name());
 
     ulonglong current_logs_size = std::accumulate(
-        log_file_list.begin(), log_file_list.end(), 0,
+        log_file_list.begin(), log_file_list.end(), ulonglong{0},
         [](const ulonglong &a, const PruneFileInfo &b) { return a + b.size; });
     current_logs_size += get_log_size();
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9834

Calculation of the combined size of Audit Log files used an incorrect data type for the accumulator (int). This resulted in an overflow and removal of all rotated Audit Log files, after their combined size reached 2GB.

The type of the accumulator has been changed to unsigned long long to correctly handle large log sets.