### PR TITLE
PS-9840 [8.4]: Assertion when a DD table exists for table T that is not registered in RocksDB

### DIFF
--- a/mysql-test/suite/rocksdb/r/validate_datadic.result
+++ b/mysql-test/suite/rocksdb/r/validate_datadic.result
@@ -1,10 +1,21 @@
 CALL mtr.add_suppression("Schema mismatch - Table test\.t.+ is registered in RocksDB but does not have a corresponding DD table");
 CALL mtr.add_suppression("Schema mismatch - A DD table exists for table test\.t1, but that table is not registered in RocksDB");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'RocksDB: Problems validating data dictionary against DD tables, exiting\. Use \"rocksdb_validate_tables=2\" to ignore this error\.'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Failed to initialize DDL manager\.'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the background thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the index thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the index stats calculation thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the manual compaction thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin 'ROCKSDB' init function returned error");
+CALL mtr.add_suppression("Plugin 'ROCKSDB' registration as a STORAGE ENGINE failed");
 # restart
 CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
 CREATE TABLE t2 (pk int primary key) ENGINE=ROCKSDB PARTITION BY KEY(pk) PARTITIONS 4;
+# restart:--rocksdb_validate_tables=1
+include/assert.inc [Check that RocksDB plugin is NOT ACTIVE]
 # restart:--rocksdb_validate_tables=2
-include/assert_grep.inc [Expect 2 warnings that we are missing two DD tables]
+include/assert.inc [Check that RocksDB plugin is ACTIVE]
+include/assert_grep.inc [Expect 2*2 warnings that we are missing two DD tables]
 # restart:--rocksdb_validate_tables=2
 DROP TABLE t1;
 # restart:--rocksdb_validate_tables=2

--- a/mysql-test/suite/rocksdb/t/validate_datadic.test
+++ b/mysql-test/suite/rocksdb/t/validate_datadic.test
@@ -13,6 +13,16 @@
 CALL mtr.add_suppression("Schema mismatch - Table test\.t.+ is registered in RocksDB but does not have a corresponding DD table");
 CALL mtr.add_suppression("Schema mismatch - A DD table exists for table test\.t1, but that table is not registered in RocksDB");
 
+# Suppress expected RocksDB plugin errors during validation fail with --rocksdb_validate_tables=1
+CALL mtr.add_suppression("Plugin rocksdb reported: 'RocksDB: Problems validating data dictionary against DD tables, exiting\. Use \"rocksdb_validate_tables=2\" to ignore this error\.'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Failed to initialize DDL manager\.'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the background thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the index thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the index stats calculation thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin rocksdb reported: 'Couldn't stop the manual compaction thread: \\(errno=22\\)'");
+CALL mtr.add_suppression("Plugin 'ROCKSDB' init function returned error");
+CALL mtr.add_suppression("Plugin 'ROCKSDB' registration as a STORAGE ENGINE failed");
+
 --let $MYSQLD_DATADIR= `select @@datadir`
 
 # Shut down and save MySQL DD without tables
@@ -31,15 +41,26 @@ CREATE TABLE t2 (pk int primary key) ENGINE=ROCKSDB PARTITION BY KEY(pk) PARTITI
 --copy_file $MYSQLD_DATADIR/mysql.ibd $MYSQL_TMP_DIR/mysql.ibd.t1_t2
 --move_file $MYSQL_TMP_DIR/mysql.ibd.no_tables $MYSQLD_DATADIR/mysql.ibd
 
+# PS-9840: Assertion/crash when a DD table exists for table T that is not registered in RocksDB
+--let $restart_parameters=restart:--rocksdb_validate_tables=1
+--source include/start_mysqld.inc
+--let $assert_text = Check that RocksDB plugin is NOT ACTIVE
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME="rocksdb" AND PLUGIN_STATUS="ACTIVE"] = 0
+--source include/assert.inc
+--source include/shutdown_mysqld.inc
+
 # Restart the server
 --let $restart_parameters=restart:--rocksdb_validate_tables=2
 --source include/start_mysqld.inc
+--let $assert_text = Check that RocksDB plugin is ACTIVE
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME="rocksdb" AND PLUGIN_STATUS="ACTIVE"] = 1
+--source include/assert.inc
 
 --let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST: rocksdb.validate_datadic
---let $assert_count = 2
+--let $assert_count = 4
 --let $assert_select = Schema mismatch - Table test\.t.+ is registered in RocksDB but does not have a corresponding DD table
---let $assert_text = Expect 2 warnings that we are missing two DD tables
+--let $assert_text = Expect 2*2 warnings that we are missing two DD tables
 --source include/assert_grep.inc
 
 # Shut down and replace MySQL DD with t1 and t2 tables

--- a/storage/rocksdb/ChangeLog.md
+++ b/storage/rocksdb/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## MyRocks 9.3.1-3
 **This version was shipped with Percona Server 8.0.44-35 and 8.4.7-7.**
+* PS-9840 – Prevents an assertion failure when a metadata table (DD table) exists but isn’t registered in RocksDB
+· [Jira](https://perconadev.atlassian.net/browse/PS-9840)
+
 * PS-9838 – Fixed an assertion failure in `guess_rec_per_key()` by correcting the record count estimation formula.
 · [Jira](https://perconadev.atlassian.net/browse/PS-9838) · [Changes](https://github.com/percona/percona-server/commit/d4ae78b9f753)
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5034,6 +5034,33 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     i++;
   }
 
+  if (max_dd_index_id_in_dict < Rdb_key_def::END_DICT_INDEX_ID) {
+    max_dd_index_id_in_dict = Rdb_key_def::END_DICT_INDEX_ID;
+  }
+
+  // index ids used by applications should not conflict with
+  // data dictionary index ids
+  if (max_index_id_in_dict < Rdb_key_def::END_DICT_INDEX_ID) {
+    max_index_id_in_dict = Rdb_key_def::END_DICT_INDEX_ID;
+  }
+
+  // TODO: need to revisit the dd table id initialization value after enabling
+  // upgrade/downgrade
+  // data dictionary index id is allocated in system cf
+  // user table index id is allocated in non-system cf
+  m_dd_table_sequence.init(max_dd_index_id_in_dict + 1);
+  m_user_table_sequence.init(max_index_id_in_dict + 1);
+  m_tmp_table_sequence.init(1);
+  if (!it->status().ok()) {
+    rdb_log_status_error(it->status(), "Table_store load error");
+    return true;
+  }
+  delete it;
+  LogPluginErrMsg(INFORMATION_LEVEL, 0,
+                  "Table_store: loaded DDL data for %d tables", i);
+
+  initialized = true;
+
 #if defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) && ROCKSDB_INCLUDE_VALIDATE_TABLES
   /*
     If validate_tables is greater than 0 run the validation.  Only fail the
@@ -5061,32 +5088,6 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
 #endif  // defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) &&
         // ROCKSDB_INCLUDE_VALIDATE_TABLES
 
-  if (max_dd_index_id_in_dict < Rdb_key_def::END_DICT_INDEX_ID) {
-    max_dd_index_id_in_dict = Rdb_key_def::END_DICT_INDEX_ID;
-  }
-
-  // index ids used by applications should not conflict with
-  // data dictionary index ids
-  if (max_index_id_in_dict < Rdb_key_def::END_DICT_INDEX_ID) {
-    max_index_id_in_dict = Rdb_key_def::END_DICT_INDEX_ID;
-  }
-
-  // TODO: need to revisit the dd table id initialization value after enabling
-  // upgrade/downgrade
-  // data dictionary index id is allocated in system cf
-  // user table index id is allocated in non-system cf
-  m_dd_table_sequence.init(max_dd_index_id_in_dict + 1);
-  m_user_table_sequence.init(max_index_id_in_dict + 1);
-  m_tmp_table_sequence.init(1);
-  if (!it->status().ok()) {
-    rdb_log_status_error(it->status(), "Table_store load error");
-    return true;
-  }
-  delete it;
-  LogPluginErrMsg(INFORMATION_LEVEL, 0,
-                  "Table_store: loaded DDL data for %d tables", i);
-
-  initialized = true;
   return false;
 }
 


### PR DESCRIPTION
`Rdb_validate_tbls::compare_to_mysql_dd_tables()` is invoked during the execution of `Rdb_ddl_manager::init()`. If an error occurs due to a corrupted datadir, `Rdb_ddl_manager::init()` stops midway, leaving `initialized=false`. As a result, a subsequent call to `Rdb_ddl_manager::cleanup()` is skipped, preventing some structures from being properly released. This triggers the failure:
```
 rocksdb::ColumnFamilySet::~ColumnFamilySet(): Assertion `last_ref' failed.
```
This patch relocates the table validation step to the end of `Rdb_ddl_manager::init()`, after setting `initialized=true`, ensuring that all structures are correctly freed by `Rdb_ddl_manager::cleanup()`.