### PR TITLE
PS-10227 [8.4]: Assertion failure in RocksDB initialization with system CF stats skipped

### DIFF
--- a/mysql-test/suite/rocksdb/r/percona_bugs.result
+++ b/mysql-test/suite/rocksdb/r/percona_bugs.result
@@ -200,3 +200,10 @@ ALTER TABLE t1p ADD INDEX idx2(f1);
 SELECT * FROM t1p WHERE ipkey = 10133;
 ip_col	ipkey	f1
 DROP TABLE t1p;
+#
+# PS-10227: Assertion failure in RocksDB initialization with system CF stats skipped
+# https://perconadev.atlassian.net/browse/PS-10227
+#
+CREATE TABLE t1 (ipkey int NOT NULL AUTO_INCREMENT, i int DEFAULT NULL, PRIMARY KEY (ipkey)) ENGINE=ROCKSDB;
+# Kill and restart: --rocksdb_table_stats_skip_system_cf=true
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/percona_bugs.test
+++ b/mysql-test/suite/rocksdb/t/percona_bugs.test
@@ -139,3 +139,17 @@ CREATE TABLE t1p (ip_col INT AUTO_INCREMENT, ipkey INT, f1 FLOAT, PRIMARY KEY(ip
 ALTER TABLE t1p ADD INDEX idx2(f1);
 SELECT * FROM t1p WHERE ipkey = 10133;
 DROP TABLE t1p;
+
+
+
+--echo #
+--echo # PS-10227: Assertion failure in RocksDB initialization with system CF stats skipped
+--echo # https://perconadev.atlassian.net/browse/PS-10227
+--echo #
+
+CREATE TABLE t1 (ipkey int NOT NULL AUTO_INCREMENT, i int DEFAULT NULL, PRIMARY KEY (ipkey)) ENGINE=ROCKSDB;
+
+--let $restart_parameters = restart: --rocksdb_table_stats_skip_system_cf=true
+--source include/kill_and_restart_mysqld.inc
+
+DROP TABLE t1;

--- a/storage/rocksdb/ChangeLog.md
+++ b/storage/rocksdb/ChangeLog.md
@@ -2,27 +2,30 @@
 
 ## MyRocks 9.3.1-3
 **This version was shipped with Percona Server 8.0.44-35 and 8.4.7-7.**
-* PS-9840 – Prevents an assertion failure when a metadata table (DD table) exists but isn’t registered in RocksDB
-· [Jira](https://perconadev.atlassian.net/browse/PS-9840)
+* PS-10227 – Assertion failure in RocksDB initialization with system CF stats skipped
+· [Jira](https://perconadev.atlassian.net/browse/PS-10227)
 
-* PS-9838 – Fixed an assertion failure in `guess_rec_per_key()` by correcting the record count estimation formula.
+* PS-9840 – Prevents an assertion failure when a metadata table (DD table) exists but isn’t registered in RocksDB
+· [Jira](https://perconadev.atlassian.net/browse/PS-9840) · [Changes](https://github.com/percona/percona-server/commit/805737fdaf9e)
+
+* PS-9838 – Fixed an assertion failure in `guess_rec_per_key()` by correcting the record count estimation formula
 · [Jira](https://perconadev.atlassian.net/browse/PS-9838) · [Changes](https://github.com/percona/percona-server/commit/d4ae78b9f753)
 
-* PS-10210 – Prevented misconfigurations by aligning MyRocks variable ranges with internal RocksDB limits.
+* PS-10210 – Prevented misconfigurations by aligning MyRocks variable ranges with internal RocksDB limits
 · [Jira](https://perconadev.atlassian.net/browse/PS-10210) · [Changes](https://github.com/percona/percona-server/commit/48d6a1b1fc20)
 
-* PS-10075 – Resolved checksum mismatch errors in key-value pairs by properly handling per-field metadata during record unpacking.
+* PS-10075 – Resolved checksum mismatch errors in key-value pairs by properly handling per-field metadata during record unpacking
 · [Jira](https://perconadev.atlassian.net/browse/PS-10075) · [Changes](https://github.com/percona/percona-server/commit/7c34db4ef730)
 
-* PS-10067 – Improved handling of per-field metadata in `Rdb_convert_to_record_key_decoder::skip()`.
+* PS-10067 – Improved handling of per-field metadata in `Rdb_convert_to_record_key_decoder::skip()`
 · [Jira](https://perconadev.atlassian.net/browse/PS-10067) · [Changes](https://github.com/percona/percona-server/commit/b2109a4fe1c8)
 
 ## MyRocks 9.3.1-2
 **This version was shipped with Percona Server 8.0.43-34 and 8.4.6-6.**
-* PS-9666 – Fixed a crash when inserting into a TTL-enabled table with `unique_checks=OFF`.
+* PS-9666 – Fixed a crash when inserting into a TTL-enabled table with `unique_checks=OFF`
 · [Jira](https://perconadev.atlassian.net/browse/PS-9666) · [Changes](https://github.com/percona/percona-server/commit/ecc87980002a)
 
-* PS-10067 – Prevented overflow in `unpack_unknown_varlength()` that could cause crashes.
+* PS-10067 – Prevented overflow in `unpack_unknown_varlength()` that could cause crashes
 · [Jira](https://perconadev.atlassian.net/browse/PS-10067) · [Changes](https://github.com/percona/percona-server/commit/37a50cc41d93)
 
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2214,7 +2214,7 @@ static MYSQL_SYSVAR_UINT(debug_cardinality_multiplier,
                          PLUGIN_VAR_RQCMDARG,
                          "Cardinality multiplier used in tests", nullptr,
                          nullptr, /* default */ 2,
-                         /* min */ 0, /* max */ INT_MAX, 0);
+                         /* min */ 1, /* max */ INT_MAX, 0);
 
 static MYSQL_SYSVAR_STR(compact_cf, rocksdb_compact_cf_name,
                         PLUGIN_VAR_RQCMDARG, "Compact column family",

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -588,7 +588,7 @@ Rdb_tbl_prop_coll_factory::CreateTablePropertiesCollector(
   // TODO(laurynas): if needed, possible to shorten the critical section by only
   // copying out the needed non-cost fields
   rwlock_scoped_lock guard(&lock, false, __FILE__, __LINE__);
-  if (m_skip_system_cf) {
+  if (m_skip_system_cf && m_cf_manager.is_initialized()) {
     auto cf_name = m_cf_manager.get_cf(context.column_family_id);
     if (cf_name->GetName() == DEFAULT_SYSTEM_CF_NAME) {
       return nullptr;


### PR DESCRIPTION
The issue:
After enabling the `rocksdb_table_stats_skip_system_cf` option and restarting the server,
MySQLd fails to complete startup and aborts with a fatal signal (signal 6). The backtrace
points to `ha_rocksdb.so`, inside `Rdb_cf_manager::get_cf()` and
`Rdb_tbl_prop_coll_factory::CreateTablePropertiesCollector()`, suggesting that the system
column family pointer is null during RocksDB recovery. This behavior implies that skipping
system CF stats leads to uninitialized CF references during table property collector creation.

The fix:
The issue originates in `myrocks::rocksdb_init_internal`, which calls `rocksdb::DBImpl::Open`.
During this process, `Rdb_tbl_prop_coll_factory::CreateTablePropertiesCollector` is invoked 
before `m_cf_manager` has been initialized. The fix adds a check to ensure 
`m_cf_manager.is_initialized()` before proceeding.
