### PR TITLE
PS-10283 [8.0]: Debug assertion failure: field.field_no < dict_index_get_n_fields(index)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_redundant_debug_crash.result
+++ b/mysql-test/suite/innodb/r/percona_redundant_debug_crash.result
@@ -1,0 +1,14 @@
+CREATE TABLE t1(a INT PRIMARY KEY, b INT, KEY k1(b)) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3), (4,4);
+SET GLOBAL innodb_log_checkpoint_now=ON;
+SET GLOBAL innodb_checkpoint_disabled=true;
+SET GLOBAL innodb_page_cleaner_disabled_debug=ON;
+UPDATE t1 SET b=5 WHERE a=1;
+# Kill and restart
+SELECT * FROM t1;
+a	b
+2	2
+3	3
+4	4
+1	5
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_redundant_debug_crash.test
+++ b/mysql-test/suite/innodb/t/percona_redundant_debug_crash.test
@@ -1,0 +1,12 @@
+--source include/have_debug.inc
+
+CREATE TABLE t1(a INT PRIMARY KEY, b INT, KEY k1(b)) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3), (4,4);
+SET GLOBAL innodb_log_checkpoint_now=ON;
+SET GLOBAL innodb_checkpoint_disabled=true;
+SET GLOBAL innodb_page_cleaner_disabled_debug=ON;
+UPDATE t1 SET b=5 WHERE a=1;
+# Without fix, crash recovery will fail
+--source include/kill_and_restart_mysqld.inc
+SELECT * FROM t1;
+DROP TABLE t1;

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -638,6 +638,13 @@ struct upd_t {
 
   void validate_for_index(const dict_index_t *index) const {
     validate();
+    /* For ROW_FORMAT=REDUNDANT, we don't log the number of fields in a
+    index. See log_index_column_counts(). So during recovery, the number of
+    fields in a index of ROW_FORMAT=REDUNDANT is always set to 1 in
+    parse_index_column_counts(). Hence, disable this assert during recovery
+    and if table format is REDUNDANT */
+    if (recv_recovery_on && !dict_table_is_comp(index->table)) return;
+
     for (ulint i = 0; i < n_fields; ++i) {
       const upd_field_t &field = fields[i];
       ut_a(index->is_clustered() || !field.is_virtual());


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10283

Description:
------------
When using table with ROW_FORMAT=REDUNDANT, killing server after inplace update happens on the table causes the server to abort during recovery.

8.0.44 introduced a new debug assertion that checks the modifeid field_no is less than the index total number of fields.

However, for ROW_FORMAT=REDUNDANT, we don't log the number of fields in a index. See log_index_column_counts(). So during recovery, the number of fields in a index of ROW_FORMAT=REDUNDANT is always set to 1 in parse_index_column_counts(). Due to this mismatch, the assertion always fails during recovery.

Fix:
----
Since we do not log exact number of index fields for REDUNDANT format, skip the assertion check for REDUNDANT tables during recovery.