### PR TITLE
  PS-10289 (8.0) Fix digest normalization for unary operators

### DIFF
--- a/mysql-test/suite/perfschema/r/unary_digest.result
+++ b/mysql-test/suite/perfschema/r/unary_digest.result
@@ -36,6 +36,42 @@ ERROR 42S02: Table 'test.expect_full_reduce' doesn't exist
 ERROR 42S02: Table 'test.expect_full_reduce' doesn't exist
 ERROR 42S02: Table 'test.expect_full_reduce' doesn't exist
 ERROR 42S02: Table 'test.expect_unchanged' doesn't exist
+ERROR 42S02: Table 'test.expect_where_eq' doesn't exist
+ERROR 42S02: Table 'test.expect_where_eq' doesn't exist
+ERROR 42S02: Table 'test.expect_where_eq' doesn't exist
+ERROR 42S02: Table 'test.expect_where_ne' doesn't exist
+ERROR 42S02: Table 'test.expect_where_ne' doesn't exist
+ERROR 42S02: Table 'test.expect_where_ne' doesn't exist
+ERROR 42S02: Table 'test.expect_where_lt' doesn't exist
+ERROR 42S02: Table 'test.expect_where_lt' doesn't exist
+ERROR 42S02: Table 'test.expect_where_lt' doesn't exist
+ERROR 42S02: Table 'test.expect_where_gt' doesn't exist
+ERROR 42S02: Table 'test.expect_where_gt' doesn't exist
+ERROR 42S02: Table 'test.expect_where_gt' doesn't exist
+ERROR 42S02: Table 'test.expect_where_le' doesn't exist
+ERROR 42S02: Table 'test.expect_where_le' doesn't exist
+ERROR 42S02: Table 'test.expect_where_le' doesn't exist
+ERROR 42S02: Table 'test.expect_where_ge' doesn't exist
+ERROR 42S02: Table 'test.expect_where_ge' doesn't exist
+ERROR 42S02: Table 'test.expect_where_ge' doesn't exist
+ERROR 42S02: Table 'test.expect_where_spaceship' doesn't exist
+ERROR 42S02: Table 'test.expect_where_spaceship' doesn't exist
+ERROR 42S02: Table 'test.expect_where_spaceship' doesn't exist
+ERROR 42S02: Table 'test.expect_case_then' doesn't exist
+ERROR 42S02: Table 'test.expect_case_then' doesn't exist
+ERROR 42S02: Table 'test.expect_case_then' doesn't exist
+ERROR 42S02: Table 'test.expect_case_then_else1' doesn't exist
+ERROR 42S02: Table 'test.expect_case_then_else1' doesn't exist
+ERROR 42S02: Table 'test.expect_case_then_else1' doesn't exist
+ERROR 42S02: Table 'test.expect_case_else' doesn't exist
+ERROR 42S02: Table 'test.expect_case_else' doesn't exist
+ERROR 42S02: Table 'test.expect_case_else' doesn't exist
+ERROR 42S02: Table 'test.expect_case_both' doesn't exist
+ERROR 42S02: Table 'test.expect_case_both' doesn't exist
+ERROR 42S02: Table 'test.expect_case_both' doesn't exist
+ERROR 42S02: Table 'test.expect_nested_case' doesn't exist
+ERROR 42S02: Table 'test.expect_nested_case' doesn't exist
+ERROR 42S02: Table 'test.expect_nested_case' doesn't exist
 SELECT SCHEMA_NAME, DIGEST_TEXT, COUNT_STAR
 FROM performance_schema.events_statements_summary_by_digest;
 SCHEMA_NAME	DIGEST_TEXT	COUNT_STAR
@@ -45,3 +81,15 @@ test	SELECT ? + ? FROM `expect_binary`	2
 test	SELECT ? - ? FROM `expect_binary`	2
 test	INSERT INTO `expect_full_reduce` VALUES (...)	27
 test	SELECT `a` - `b` , `a` + `b` , - `a` , - `b` , + `a` , + `b` FROM `expect_unchanged`	1
+test	SELECT * FROM `expect_where_eq` WHERE `a` = ?	3
+test	SELECT * FROM `expect_where_ne` WHERE `a` != ?	3
+test	SELECT * FROM `expect_where_lt` WHERE `a` < ?	3
+test	SELECT * FROM `expect_where_gt` WHERE `a` > ?	3
+test	SELECT * FROM `expect_where_le` WHERE `a` <= ?	3
+test	SELECT * FROM `expect_where_ge` WHERE `a` >= ?	3
+test	SELECT * FROM `expect_where_spaceship` WHERE `a` <=> ?	3
+test	SELECT CASE WHEN `a` > ? THEN ? END FROM `expect_case_then`	3
+test	SELECT CASE WHEN `a` > ? THEN ? ELSE ? END FROM `expect_case_then_else1`	3
+test	SELECT CASE WHEN `a` > ? THEN ? ELSE ? END FROM `expect_case_else`	3
+test	SELECT CASE WHEN `a` > ? THEN ? ELSE ? END FROM `expect_case_both`	3
+test	SELECT CASE WHEN `a` > ? THEN CASE WHEN `b` > ? THEN ? ELSE ? END ELSE ? END FROM `expect_nested_case`	3

--- a/mysql-test/suite/perfschema/t/unary_digest.test
+++ b/mysql-test/suite/perfschema/t/unary_digest.test
@@ -90,6 +90,98 @@ insert into expect_full_reduce values (+1, +1, +1);
 --error ER_NO_SUCH_TABLE
 select a-b, a+b, -a, -b, +a, +b from expect_unchanged;
 
+# Test WHERE clauses with comparison operators and negative numbers
+# All of these should produce the same digest per comparison operator
+--error ER_NO_SUCH_TABLE
+select * from expect_where_eq where a = 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_eq where a = -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_eq where a = +1;
+
+--error ER_NO_SUCH_TABLE
+select * from expect_where_ne where a != 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_ne where a != -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_ne where a <> +1;
+
+--error ER_NO_SUCH_TABLE
+select * from expect_where_lt where a < 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_lt where a < -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_lt where a < +1;
+
+--error ER_NO_SUCH_TABLE
+select * from expect_where_gt where a > 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_gt where a > -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_gt where a > +1;
+
+--error ER_NO_SUCH_TABLE
+select * from expect_where_le where a <= 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_le where a <= -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_le where a <= +1;
+
+--error ER_NO_SUCH_TABLE
+select * from expect_where_ge where a >= 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_ge where a >= -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_ge where a >= +1;
+
+--error ER_NO_SUCH_TABLE
+select * from expect_where_spaceship where a <=> 1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_spaceship where a <=> -1;
+--error ER_NO_SUCH_TABLE
+select * from expect_where_spaceship where a <=> +1;
+
+# Test CASE WHEN THEN with unary operators
+# All three should produce the same digest
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then 1 end from expect_case_then;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then -1 end from expect_case_then;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then +1 end from expect_case_then;
+
+# Test CASE WHEN THEN ELSE with unary operators in THEN clause
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then 1 else 0 end from expect_case_then_else1;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then -1 else 0 end from expect_case_then_else1;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then +1 else 0 end from expect_case_then_else1;
+
+# Test CASE WHEN THEN ELSE with unary operators in ELSE clause
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then 0 else 1 end from expect_case_else;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then 0 else -1 end from expect_case_else;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then 0 else +1 end from expect_case_else;
+
+# Test CASE WHEN THEN ELSE with unary operators in both clauses
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then 1 else 2 end from expect_case_both;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then -1 else -2 end from expect_case_both;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then +1 else +2 end from expect_case_both;
+
+# Test nested CASE statements
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then case when b > 0 then 1 else 2 end else 3 end from expect_nested_case;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then case when b > 0 then -1 else -2 end else -3 end from expect_nested_case;
+--error ER_NO_SUCH_TABLE
+select case when a > 0 then case when b > 0 then +1 else +2 end else +3 end from expect_nested_case;
+
 --enable_query_log
 
 SELECT SCHEMA_NAME, DIGEST_TEXT, COUNT_STAR

--- a/sql/gen_lex_token.cc
+++ b/sql/gen_lex_token.cc
@@ -413,6 +413,17 @@ static void compute_tokens() {
   set_start_expr_token(LIKE);
   set_start_expr_token(REGEXP);
 
+  set_start_expr_token(EQ);         // =
+  set_start_expr_token(EQUAL_SYM);  // <=>
+  set_start_expr_token(NE);         // != and <>
+  set_start_expr_token(LT);         // <
+  set_start_expr_token(GT_SYM);     // >
+  set_start_expr_token(LE);         // <=
+  set_start_expr_token(GE);         // >=
+
+  set_start_expr_token(THEN_SYM);  // CASE WHEN ... THEN expr
+  set_start_expr_token(ELSE);      // CASE ... ELSE expr
+
   set_start_expr_token('|');
   set_start_expr_token('&');
   set_start_expr_token(SHIFT_LEFT);


### PR DESCRIPTION
This patch fixes digest normalization for unary operators after comparison operators and CASE keywords.

Queries like "WHERE a = 1" and "WHERE a = -1" now correctly produce the same digest, which is important for proper query grouping in Performance Schema.

Files modified:
- sql/gen_lex_token.cc (marks comparison operators and CASE keywords as start_expr)
- mysql-test/suite/perfschema/t/unary_digest.test
- mysql-test/suite/perfschema/r/unary_digest.result

Simple test:
```
USE performance_schema;
SELECT
STATEMENT_DIGEST_TEXT('SELECT * FROM t WHERE a = 1') =
STATEMENT_DIGEST_TEXT('SELECT * FROM t WHERE a = -1') AS digests_match;

SELECT
STATEMENT_DIGEST_TEXT('SELECT * FROM t WHERE a < 1') =
STATEMENT_DIGEST_TEXT('SELECT * FROM t WHERE a < -1') AS digests_match;

SELECT
STATEMENT_DIGEST_TEXT('SELECT CASE WHEN a > 0 THEN 1 END FROM t') =
STATEMENT_DIGEST_TEXT('SELECT CASE WHEN a > 0 THEN -1 END FROM t') AS digests_match;

SELECT
STATEMENT_DIGEST_TEXT('SELECT CASE WHEN a > 0 THEN 1 ELSE 2 END FROM t') = STATEMENT_DIGEST_TEXT('SELECT CASE WHEN a > 0 THEN -1 ELSE -2 END FROM t') AS digests_match;
```

Thank you,
Yakir Gibraltar