### PR TITLE
PS-10324 [8.4]: Audit log filter: add missing fields, update filtering and formatting

### DIFF
--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -530,11 +530,24 @@ AuditRecordFieldsList get_audit_record_fields(
   const auto *event = record.event;
   return {
       {"general_error_code", std::to_string(event->error_code)},
+      // alias for general_connection_id
+      {"general_thread_id", std::to_string(event->connection_id)},
       {"general_connection_id", std::to_string(event->connection_id)},
       {"general_user.str", mysql_cstring_to_string(&event->user)},
       {"general_user.length", mysql_cstring_len_to_string(&event->user)},
+      {"general_command.str", mysql_cstring_to_string(&event->command)},
+      {"general_command.length", mysql_cstring_len_to_string(&event->command)},
+      {"general_query.str", mysql_cstring_to_string(&event->query)},
+      {"general_query.length", mysql_cstring_len_to_string(&event->query)},
       {"general_host.str", mysql_cstring_to_string(&event->host)},
       {"general_host.length", mysql_cstring_len_to_string(&event->host)},
+      {"general_sql_command.str", mysql_cstring_to_string(&event->sql_command)},
+      {"general_sql_command.length",
+       mysql_cstring_len_to_string(&event->sql_command)},
+      {"general_external_user.str",
+       mysql_cstring_to_string(&event->external_user)},
+      {"general_external_user.length",
+       mysql_cstring_len_to_string(&event->external_user)},
       {"general_ip.str", mysql_cstring_to_string(&event->ip)},
       {"general_ip.length", mysql_cstring_len_to_string(&event->ip)},
   };
@@ -570,6 +583,9 @@ AuditRecordFieldsList get_audit_record_fields(
   const auto *event = record.event;
   return {
       {"connection_id", std::to_string(event->connection_id)},
+      {"sql_command_id", std::to_string(event->sql_command_id)},
+      {"query.str", mysql_cstring_to_string(&event->query)},
+      {"query.length", mysql_cstring_len_to_string(&event->query)},
       {"table_database.str", mysql_cstring_to_string(&event->table_database)},
       {"table_database.length",
        mysql_cstring_len_to_string(&event->table_database)},

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -17,6 +17,7 @@
 #include "components/audit_log_filter/sys_vars.h"
 
 #include "my_dbug.h"
+#include "sql/command_mapping.h"  // get_sql_command_string
 
 #include <mysql/components/services/defs/event_tracking_authentication_defs.h>
 #include <mysql/components/services/defs/event_tracking_command_defs.h>
@@ -366,14 +367,28 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto escaped_user = make_escaped_string(&audit_record.event->user);
   const auto escaped_host = make_escaped_string(&audit_record.event->host);
   const auto escaped_ip = make_escaped_string(&audit_record.event->ip);
+  const auto esc_external_user = make_escaped_string(&audit_record.event->external_user);
+  const auto esc_proxy_user = make_escaped_string(&audit_record.event->proxy_user);
+  const auto esc_command = make_escaped_string(&audit_record.event->command);
+  const auto esc_sql_command = make_escaped_string(&audit_record.event->sql_command);
+  const auto esc_query = audit_record.extended_info.digest.empty()
+                 ? make_escaped_string(&audit_record.event->query)
+                 : make_escaped_string(audit_record.extended_info.digest);
 
   result << R"(    "id": )" << rec_id << ",\n"
          << R"(    "class": "general",)" << "\n"
          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
          << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": "")" << " },\n"
-         << R"(    "general_data": { "status": )" << audit_record.event->error_code << " }"
+         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
+         << R"(    "general_data": {)" << "\n"
+         << R"(      "command": ")" << esc_command << "\",\n";
+  if (!esc_query.empty()) {
+    result << R"(      "sql_command": ")" << esc_sql_command << "\",\n"
+           << R"(      "query": ")" << esc_query << "\",\n";
+  }
+  result << R"(      "status": )" << audit_record.event->error_code
+         << "\n    }"
          << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
@@ -427,6 +442,19 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto time_now = std::chrono::system_clock::now();
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
+  const auto sql_command_id =
+      get_sql_command_string(audit_record.event->sql_command_id);
+  const auto escaped_user = make_escaped_string(&audit_record.event->user);
+  const auto escaped_host = make_escaped_string(&audit_record.event->host);
+  const auto escaped_ip = make_escaped_string(&audit_record.event->ip);
+  const auto esc_external_user =
+      make_escaped_string(&audit_record.event->external_user);
+  const auto esc_proxy_user =
+      make_escaped_string(&audit_record.event->proxy_user);
+  const auto esc_query =
+      audit_record.extended_info.digest.empty()
+          ? make_escaped_string(&audit_record.event->query)
+          : make_escaped_string(audit_record.extended_info.digest);
 
   /* clang-format off */
   result << "  {\n"
@@ -440,9 +468,13 @@ AuditRecordString LogRecordFormatterJson::apply(
          << R"(    "class": "table_access",)" << "\n"
          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
          << R"(    "table_access_data": {)" << "\n"
          << R"(      "db": ")" << make_escaped_string(&audit_record.event->table_database) << "\",\n"
-         << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\"}"
+         << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\",\n"
+         << R"(      "query": ")" << esc_query << "\",\n"
+         << R"(      "sql_command": ")" << sql_command_id << "\"\n    }"
          << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 

--- a/components/audit_log_filter/log_record_formatter/new.cc
+++ b/components/audit_log_filter/log_record_formatter/new.cc
@@ -48,7 +48,10 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <HOST>" << make_escaped_string(&audit_record.event->host) << "</HOST>\n"
          << "    <IP>" << make_escaped_string(&audit_record.event->ip) << "</IP>\n"
          << "    <USER>" << make_escaped_string(&audit_record.event->user) << "</USER>\n"
+         << "    <OS_LOGIN>" << make_escaped_string(&audit_record.event->external_user) << "</OS_LOGIN>\n"
          << "    <STATUS>" << audit_record.event->error_code << "</STATUS>\n"
+         << "    <SQLTEXT>" << (audit_record.extended_info.digest.empty() ? make_escaped_string(&audit_record.event->query)
+                                                                          : make_escaped_string(audit_record.extended_info.digest)) << "</SQLTEXT>\n"
          << "  </AUDIT_RECORD>\n";
   /* clang-format on */
 
@@ -95,6 +98,8 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
          << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
          << "    <CONNECTION_ID>" << audit_record.event->connection_id << "</CONNECTION_ID>\n"
+         << "    <SQLTEXT>" << (audit_record.extended_info.digest.empty() ? make_escaped_string(&audit_record.event->query)
+                                                                          : make_escaped_string(audit_record.extended_info.digest)) << "</SQLTEXT>\n"
          << "    <DB>" << make_escaped_string(&audit_record.event->table_database) << "</DB>\n"
          << "    <TABLE>" << make_escaped_string(&audit_record.event->table_name) << "</TABLE>\n"
          << "  </AUDIT_RECORD>\n";

--- a/include/mysql/components/services/defs/event_tracking_general_defs.h
+++ b/include/mysql/components/services/defs/event_tracking_general_defs.h
@@ -69,6 +69,20 @@ struct mysql_event_tracking_general_data {
   mysql_cstring_with_length host;
   /** Connection IP */
   mysql_cstring_with_length ip;
+
+  /** FIELDS ADDED BY PERCONA */
+  /** External user name. */
+  mysql_cstring_with_length external_user;
+  /** Proxy user used for the connection */
+  mysql_cstring_with_length proxy_user;
+  /** Command text - ASCII */
+  mysql_cstring_with_length command;
+  /** SQL command string */
+  mysql_cstring_with_length sql_command;
+  /** SQL query. */
+  mysql_cstring_with_length query;
+  /** SQL query charset. */
+  const char *query_charset;
 };
 
 #endif  // !COMPONENT_SERVICES_DEFS_EVENT_TRACKING_GENERAL_DEFS_H

--- a/include/mysql/components/services/defs/event_tracking_table_access_defs.h
+++ b/include/mysql/components/services/defs/event_tracking_table_access_defs.h
@@ -24,6 +24,7 @@
 #ifndef COMPONENTS_SERVICES_DEFS_EVENT_TRACKING_TABLE_ACCESS_DEFS_H
 #define COMPONENTS_SERVICES_DEFS_EVENT_TRACKING_TABLE_ACCESS_DEFS_H
 
+#include "include/my_sqlcommand.h"
 #include "mysql/components/services/defs/event_tracking_common_defs.h"
 
 /**
@@ -71,6 +72,24 @@ struct mysql_event_tracking_table_access_data {
     Please use @ref s_mysql_mysql_charset to obtain charset
   */
   mysql_cstring_with_length table_name;
+
+  /** FIELDS ADDED BY PERCONA */
+  /** SQL command enum */
+  enum_sql_command sql_command_id;
+  /** SQL query. */
+  mysql_cstring_with_length query;
+  /** SQL query charset. */
+  const char *query_charset;
+  /** User name of this connection */
+  mysql_cstring_with_length user;
+  /** External user name. */
+  mysql_cstring_with_length external_user;
+  /** Proxy user used for the connection */
+  mysql_cstring_with_length proxy_user;
+  /** Connection host */
+  mysql_cstring_with_length host;
+  /** Connection IP */
+  mysql_cstring_with_length ip;
 };
 
 #endif  // !COMPONENTS_SERVICES_DEFS_EVENT_TRACKING_TABLE_ACCESS_DEFS_H

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
@@ -62,12 +62,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -83,22 +83,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
@@ -68,12 +68,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -89,22 +89,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root[root] @ localhost []", "host": "localhost"}"login": {"user": "root[root] @ localhost []", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -979,11 +979,20 @@ int mysql_event_tracking_general_notify(
 
   auto ip = sctx->ip();
   auto host = sctx->host();
+  auto external_user = sctx->external_user();
+  auto proxy_user = sctx->proxy_user();
+  auto sql_command = std::string(get_sql_command_string(thd->lex->sql_command));
+  if (sql_command == "<unknown>") sql_command.clear();
 
   event.user.str = user_buff;
   event.user.length = make_user_name(sctx, user_buff);
+  event.external_user = {external_user.str, external_user.length};
+  event.proxy_user = {proxy_user.str, proxy_user.length};
   event.ip = {ip.str, ip.length};
   event.host = {host.str, host.length};
+  event.sql_command = {sql_command.c_str(), sql_command.length()};
+  event.command = {msg, msg_len};
+  event.query_charset = thd_get_audit_query(thd, &event.query);
 
   Event_tracking_general_information general_information(
       subclass,
@@ -1281,12 +1290,27 @@ static int mysql_event_tracking_table_access_notify(
     return 0;
 
   mysql_event_tracking_table_access_data event;
+  char user_buff[MAX_USER_HOST_SIZE];
 
   event.event_subclass = subclass;
   event.connection_id = static_cast<mysql_connection_id>(thd->thread_id());
 
+  Security_context *sctx = thd->security_context();
+  auto ip = sctx->ip();
+  auto host = sctx->host();
+  auto external_user = sctx->external_user();
+  auto proxy_user = sctx->proxy_user();
+
+  event.user.str = user_buff;
+  event.user.length = make_user_name(sctx, user_buff);
+  event.external_user = {external_user.str, external_user.length};
+  event.proxy_user = {proxy_user.str, proxy_user.length};
+  event.ip = {ip.str, ip.length};
+  event.host = {host.str, host.length};
   event.table_database = {table->db, table->db_length};
   event.table_name = {table->table_name, table->table_name_length};
+  event.query_charset = thd_get_audit_query(thd, &event.query);
+  event.sql_command_id = thd->lex->sql_command;
 
   struct st_mysql_event_generic event_generic;
   event_generic.event = &event;


### PR DESCRIPTION
1. Add missing fields to `mysql_event_tracking_general_data` and `mysql_event_tracking_table_access_data` definition.
2. Populate new fields in `mysql_event_tracking_general_notify()` and `mysql_event_tracking_table_access_notify()`.
3. Integrate new fields with `get_audit_record_fields()` to enable filtering via `AuditRecordGeneral` and `AuditRecordTableAccess`.
4. Use new fields with `LogRecordFormatter` for filtering with `AuditRecordGeneral` and `AuditRecordTableAccess`.
5. Fix MTR tests to align with updated audit log behavior.