### PR TITLE
PS-10324 [8.4]: Audit log filter: add missing fields, update filtering and formatting

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -777,7 +777,7 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
     extra.sql_command = {sql_command.str, sql_command.length};
   }
 
-  // only for AuditRecordGeneral
+  // required only for AuditRecordGeneral
   mysql_cstring_with_length command;
   if (!mysql_service_mysql_thd_attributes->get(thd, "command", &command)) {
     extra.command = {command.str, command.length};
@@ -810,6 +810,13 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
   if (!mysql_service_mysql_thd_attributes->get(thd, "sql_command",
                                                &sql_command)) {
     extra.sql_command = {sql_command.str, sql_command.length};
+  }
+
+  // required only for AuditRecordTableAccess
+  uint32_t sql_command_id = 0;
+  if (!mysql_service_mysql_thd_attributes->get(thd, "sql_command_id",
+                                               &sql_command_id)) {
+    extra.sql_command_id = static_cast<enum_sql_command>(sql_command_id);
   }
 
   if (!sctx) return false;

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -511,7 +511,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   }
 
   if (auto rec = std::get_if<AuditRecordGeneral>(&audit_record)) {
-      set_extended_info(thd, sctx, *rec);
+    set_extended_info(thd, sctx, *rec);
   }
 
   if (auto rec = std::get_if<AuditRecordTableAccess>(&audit_record)) {
@@ -746,8 +746,8 @@ std::string AuditLogFilter::get_sql_text(MYSQL_THD thd) {
   // According to mysql_thd_attributes_imp::get, "sql_text" is a String*.
   String *s = reinterpret_cast<String *>(hstr);
   if (!s || !s->ptr()) {
-      delete s;
-      return "";
+    delete s;
+    return "";
   }
 
   std::string result(s->ptr(), s->length());
@@ -760,6 +760,13 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
                                        AuditRecordGeneral &record) {
   if (!thd) return false;
 
+  /** The mysql_event_tracking_general_data struct includes error_code,
+      connection_id, user, host, and ip.
+    Note that the user field is formatted as "root[root] @ localhost
+    [127.0.0.1]", which is inconsistent with other event types. Therefore, we
+    rely on user, host, and ip provided by the services. For
+    AuditRecordGeneral we need to retrieve query, sql_command, command, user,
+    host, ip, and proxy_user from the corresponding services. */
   auto &extra = record.extended_info;
 
   extra.query = get_sql_text(thd);
@@ -791,6 +798,10 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
                                        AuditRecordTableAccess &record) {
   if (!thd) return false;
 
+  /** The mysql_event_tracking_table_access_data struct contains only
+    connection_id, table_database, and table_name. To obtain the other fields
+    for AuditRecordTableAccess — query, sql_command, user, host, ip, and
+    proxy_user — we need to retrieve them from the corresponding services. */
   auto &extra = record.extended_info;
 
   extra.query = get_sql_text(thd);

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -64,6 +64,8 @@ REQUIRES_SERVICE_PLACEHOLDER(log_builtins);
 REQUIRES_SERVICE_PLACEHOLDER(log_builtins_string);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_current_thread_reader);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_attributes);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_string_get_data_in_charset);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_string_factory);
 REQUIRES_PSI_MEMORY_SERVICE_PLACEHOLDER;
 
 SERVICE_TYPE(log_builtins) *log_bi = nullptr;
@@ -736,22 +738,25 @@ bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
 }
 
 std::string AuditLogFilter::get_sql_text(MYSQL_THD thd) {
-  if (!thd) return "";
+  if (!thd) return std::string();
 
   my_h_string hstr = nullptr;
   int rc = mysql_service_mysql_thd_attributes->get(thd, "sql_text", &hstr);
 
-  if (rc != 0 || hstr == nullptr) return "";
+  if (rc != 0 || hstr == nullptr) return std::string();
 
-  // According to mysql_thd_attributes_imp::get, "sql_text" is a String*.
-  String *s = reinterpret_cast<String *>(hstr);
-  if (!s || !s->ptr()) {
-    delete s;
-    return "";
+  const char *raw_buffer = nullptr;
+  size_t raw_length = 0;
+  CHARSET_INFO_h raw_charset = nullptr;
+
+  if (mysql_service_mysql_string_get_data_in_charset->get_data(
+          hstr, &raw_buffer, &raw_length, &raw_charset)) {
+    mysql_service_mysql_string_factory->destroy(hstr);
+    return std::string();
   }
 
-  std::string result(s->ptr(), s->length());
-  delete s;  // free the allocated String
+  std::string result(raw_buffer, raw_length);
+  mysql_service_mysql_string_factory->destroy(hstr);
   return result;
 }
 
@@ -889,7 +894,9 @@ BEGIN_COMPONENT_REQUIRES(component_audit_log_filter)
 REQUIRES_SERVICE(registry), REQUIRES_SERVICE(log_builtins),
     REQUIRES_SERVICE(log_builtins_string),
     REQUIRES_SERVICE(mysql_thd_attributes),
-    REQUIRES_SERVICE(mysql_current_thread_reader), REQUIRES_PSI_MEMORY_SERVICE,
+    REQUIRES_SERVICE(mysql_current_thread_reader),
+    REQUIRES_SERVICE(mysql_string_get_data_in_charset),
+    REQUIRES_SERVICE(mysql_string_factory), REQUIRES_PSI_MEMORY_SERVICE,
     END_COMPONENT_REQUIRES();
 
 BEGIN_COMPONENT_METADATA(component_audit_log_filter)

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -719,7 +719,7 @@ bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
                                                  const std::string &name,
                                                  std::string &value) noexcept {
   MYSQL_LEX_CSTRING val{"", 0};
-
+  // calls mysql_security_context_imp::get
   if (m_security_context_opts_srv->get(ctx, name.c_str(), &val) != 0) {
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
                     "Can not get %s from security context", name.c_str());
@@ -766,7 +766,7 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
     [127.0.0.1]", which is inconsistent with other event types. Therefore, we
     rely on user, host, and ip provided by the services. For
     AuditRecordGeneral we need to retrieve query, sql_command, command, user,
-    host, ip, and proxy_user from the corresponding services. */
+    host, ip, external_user, and proxy_user from the corresponding services. */
   auto &extra = record.extended_info;
 
   extra.query = get_sql_text(thd);
@@ -788,6 +788,7 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
   get_security_context_option(sctx, "user", extra.user);
   get_security_context_option(sctx, "host", extra.host);
   get_security_context_option(sctx, "ip", extra.ip);
+  get_security_context_option(sctx, "external_user", extra.external_user);
   get_security_context_option(sctx, "proxy_user", extra.proxy_user);
 
   return true;
@@ -800,8 +801,9 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
 
   /** The mysql_event_tracking_table_access_data struct contains only
     connection_id, table_database, and table_name. To obtain the other fields
-    for AuditRecordTableAccess — query, sql_command, user, host, ip, and
-    proxy_user — we need to retrieve them from the corresponding services. */
+    for AuditRecordTableAccess — query, sql_command, user, host, ip,
+    external_user, and proxy_user — we need to retrieve them from the
+    corresponding services. */
   auto &extra = record.extended_info;
 
   extra.query = get_sql_text(thd);
@@ -824,6 +826,7 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
   get_security_context_option(sctx, "user", extra.user);
   get_security_context_option(sctx, "host", extra.host);
   get_security_context_option(sctx, "ip", extra.ip);
+  get_security_context_option(sctx, "external_user", extra.external_user);
   get_security_context_option(sctx, "proxy_user", extra.proxy_user);
 
   return true;

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -510,18 +510,12 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
     return 0;
   }
 
-  if (std::holds_alternative<AuditRecordGeneral>(audit_record)) {
-    auto rec = std::get_if<AuditRecordGeneral>(&audit_record);
-    if (rec != nullptr) {
-      set_extended_info(thd, sctx, const_cast<AuditRecordGeneral &>(*rec));
-    }
+  if (auto rec = std::get_if<AuditRecordGeneral>(&audit_record)) {
+      set_extended_info(thd, sctx, *rec);
   }
 
-  if (std::holds_alternative<AuditRecordTableAccess>(audit_record)) {
-    auto rec = std::get_if<AuditRecordTableAccess>(&audit_record);
-    if (rec != nullptr) {
-      set_extended_info(thd, sctx, const_cast<AuditRecordTableAccess &>(*rec));
-    }
+  if (auto rec = std::get_if<AuditRecordTableAccess>(&audit_record)) {
+    set_extended_info(thd, sctx, *rec);
   }
 
   // Apply filtering rule
@@ -722,7 +716,7 @@ bool AuditLogFilter::get_security_context(
 }
 
 bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
-                                                 std::string name,
+                                                 const std::string &name,
                                                  std::string &value) noexcept {
   MYSQL_LEX_CSTRING val{"", 0};
 
@@ -751,9 +745,14 @@ std::string AuditLogFilter::get_sql_text(MYSQL_THD thd) {
 
   // According to mysql_thd_attributes_imp::get, "sql_text" is a String*.
   String *s = reinterpret_cast<String *>(hstr);
-  if (!s || !s->ptr()) return "";
+  if (!s || !s->ptr()) {
+      delete s;
+      return "";
+  }
 
-  return std::string(s->ptr(), s->length());
+  std::string result(s->ptr(), s->length());
+  delete s;  // free the allocated String
+  return result;
 }
 
 bool AuditLogFilter::set_extended_info(MYSQL_THD thd,

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -29,6 +29,7 @@
 #include <mysql/components/service_implementation.h>
 
 #include <mysql/components/services/mysql_connection_attributes_iterator.h>
+#include <mysql/components/services/mysql_thd_attributes.h>
 
 #include <mysql/components/services/event_tracking_authentication_service.h>
 #include <mysql/components/services/event_tracking_command_service.h>
@@ -62,6 +63,7 @@
 REQUIRES_SERVICE_PLACEHOLDER(log_builtins);
 REQUIRES_SERVICE_PLACEHOLDER(log_builtins_string);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_current_thread_reader);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_attributes);
 REQUIRES_PSI_MEMORY_SERVICE_PLACEHOLDER;
 
 SERVICE_TYPE(log_builtins) *log_bi = nullptr;
@@ -463,7 +465,6 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   }
 
   MYSQL_THD thd = nullptr;
-
   if (mysql_service_mysql_current_thread_reader->get(&thd) == 1 ||
       thd == nullptr) {
     return 0;
@@ -471,12 +472,12 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
 
   SysVars::inc_events_total();
 
-  Security_context_handle ctx{};
+  Security_context_handle sctx{};
   std::string user_name;
   std::string user_host;
 
-  if (!get_security_context(thd, &ctx) ||
-      !get_connection_user(ctx, user_name, user_host)) {
+  if (!get_security_context(thd, &sctx) ||
+      !get_connection_user(sctx, user_name, user_host)) {
     return 0;
   }
 
@@ -509,6 +510,20 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
     return 0;
   }
 
+  if (std::holds_alternative<AuditRecordGeneral>(audit_record)) {
+    auto rec = std::get_if<AuditRecordGeneral>(&audit_record);
+    if (rec != nullptr) {
+      set_extended_info(thd, sctx, const_cast<AuditRecordGeneral &>(*rec));
+    }
+  }
+
+  if (std::holds_alternative<AuditRecordTableAccess>(audit_record)) {
+    auto rec = std::get_if<AuditRecordTableAccess>(&audit_record);
+    if (rec != nullptr) {
+      set_extended_info(thd, sctx, const_cast<AuditRecordTableAccess &>(*rec));
+    }
+  }
+
   // Apply filtering rule
   AuditAction filter_result =
       AuditEventFilter::apply(filter_rule.get(), audit_record);
@@ -519,7 +534,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   }
 
   if (filter_result == AuditAction::Block &&
-      !check_abort_exempt_privilege(ctx)) {
+      !check_abort_exempt_privilege(sctx)) {
     auto ev_name = std::visit(
         [](const auto &rec) -> std::string_view {
           return rec.event_class_name;
@@ -706,6 +721,97 @@ bool AuditLogFilter::get_security_context(
   return true;
 }
 
+bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
+                                                 std::string name,
+                                                 std::string &value) noexcept {
+  MYSQL_LEX_CSTRING val{"", 0};
+
+  if (m_security_context_opts_srv->get(ctx, name.c_str(), &val) != 0) {
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Can not get %s from security context", name.c_str());
+    return false;
+  }
+
+  if (val.length == 0 || val.str == nullptr) {
+    value.clear();
+  } else {
+    value.assign(val.str, val.length);
+  }
+
+  return true;
+}
+
+std::string AuditLogFilter::get_sql_text(MYSQL_THD thd) {
+  if (!thd) return "";
+
+  my_h_string hstr = nullptr;
+  int rc = mysql_service_mysql_thd_attributes->get(thd, "sql_text", &hstr);
+
+  if (rc != 0 || hstr == nullptr) return "";
+
+  // According to mysql_thd_attributes_imp::get, "sql_text" is a String*.
+  String *s = reinterpret_cast<String *>(hstr);
+  if (!s || !s->ptr()) return "";
+
+  return std::string(s->ptr(), s->length());
+}
+
+bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
+                                       Security_context_handle sctx,
+                                       AuditRecordGeneral &record) {
+  if (!thd) return false;
+
+  auto &extra = record.extended_info;
+
+  extra.query = get_sql_text(thd);
+
+  mysql_cstring_with_length sql_command;
+  if (!mysql_service_mysql_thd_attributes->get(thd, "sql_command",
+                                               &sql_command)) {
+    extra.sql_command = {sql_command.str, sql_command.length};
+  }
+
+  // only for AuditRecordGeneral
+  mysql_cstring_with_length command;
+  if (!mysql_service_mysql_thd_attributes->get(thd, "command", &command)) {
+    extra.command = {command.str, command.length};
+  }
+
+  if (!sctx) return false;
+
+  get_security_context_option(sctx, "user", extra.user);
+  get_security_context_option(sctx, "host", extra.host);
+  get_security_context_option(sctx, "ip", extra.ip);
+  get_security_context_option(sctx, "proxy_user", extra.proxy_user);
+
+  return true;
+}
+
+bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
+                                       Security_context_handle sctx,
+                                       AuditRecordTableAccess &record) {
+  if (!thd) return false;
+
+  auto &extra = record.extended_info;
+
+  extra.query = get_sql_text(thd);
+
+  mysql_cstring_with_length sql_command;
+  if (!mysql_service_mysql_thd_attributes->get(thd, "sql_command",
+                                               &sql_command)) {
+    extra.sql_command = {sql_command.str, sql_command.length};
+  }
+
+  if (!sctx) return false;
+
+  get_security_context_option(sctx, "user", extra.user);
+  get_security_context_option(sctx, "host", extra.host);
+  get_security_context_option(sctx, "ip", extra.ip);
+  get_security_context_option(sctx, "proxy_user", extra.proxy_user);
+
+  return true;
+}
+
 AuditUdf *AuditLogFilter::get_udf() noexcept { return m_audit_udf.get(); }
 
 AuditLogReader *AuditLogFilter::get_log_reader() noexcept {
@@ -762,6 +868,7 @@ PROVIDES_SERVICE(component_audit_log_filter, event_tracking_authentication),
 BEGIN_COMPONENT_REQUIRES(component_audit_log_filter)
 REQUIRES_SERVICE(registry), REQUIRES_SERVICE(log_builtins),
     REQUIRES_SERVICE(log_builtins_string),
+    REQUIRES_SERVICE(mysql_thd_attributes),
     REQUIRES_SERVICE(mysql_current_thread_reader), REQUIRES_PSI_MEMORY_SERVICE,
     END_COMPONENT_REQUIRES();
 

--- a/components/audit_log_filter/audit_log_filter.h
+++ b/components/audit_log_filter/audit_log_filter.h
@@ -152,7 +152,7 @@ class AuditLogFilter {
    * @return true on success, false if the option cannot be retrieved.
    */
   bool get_security_context_option(Security_context_handle &ctx,
-                                   std::string name,
+                                   const std::string &name,
                                    std::string &value) noexcept;
 
   /**

--- a/components/audit_log_filter/audit_log_filter.h
+++ b/components/audit_log_filter/audit_log_filter.h
@@ -139,6 +139,54 @@ class AuditLogFilter {
                            std::string &user_host) noexcept;
 
   /**
+   * @brief Retrieves a named option from a security context.
+   *
+   * This function queries the security context for a specific option (e.g.,
+   * "user", "host", "ip") and returns its value as a std::string. If the option
+   * is missing or cannot be retrieved, the function returns false.
+   *
+   * @param ctx   Security context handle from which to read the option.
+   * @param name  Name of the option to retrieve (e.g., "user", "host").
+   * @param value Output string that receives the option value on success.
+   *
+   * @return true on success, false if the option cannot be retrieved.
+   */
+  bool get_security_context_option(Security_context_handle &ctx,
+                                   std::string name,
+                                   std::string &value) noexcept;
+
+  /**
+   * @brief Retrieves the SQL text associated with a THD.
+   *
+   * This function accesses the "sql_text" THD attribute and returns the query
+   * text as a std::string. If the attribute is missing, null, or cannot be
+   * retrieved, an empty string is returned.
+   *
+   * @param thd Thread handle (THD) from which to extract SQL text.
+   *
+   * @return SQL text string, or an empty string on failure.
+   */
+  std::string get_sql_text(MYSQL_THD thd);
+
+  /**
+   * @brief Populates extended audit information for a record.
+   *
+   * This function extracts relevant information from the thread handle (THD)
+   * and security context and populates the `extended_info` fields of an
+   * audit record. Required attributes include user, host, and IP.
+   *
+   * @param thd    Thread handle associated with the audit event.
+   * @param sctx   Security context associated with the thread.
+   * @param record Audit record to be populated.
+   *
+   * @return true on success, false if required information cannot be retrieved.
+   */
+  bool set_extended_info(MYSQL_THD thd, Security_context_handle sctx,
+                         AuditRecordTableAccess &record);
+  bool set_extended_info(MYSQL_THD thd, Security_context_handle sctx,
+                         AuditRecordGeneral &record);
+
+  /**
    * @brief Check if user has AUDIT_ABORT_EXEMPT privilege assigned
    *
    * @param ctx Security context handle

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -528,15 +528,26 @@ void update_connection_type_pseudo_to_numeric(std::string &type) {
 AuditRecordFieldsList get_audit_record_fields(
     const AuditRecordGeneral &record) {
   const auto *event = record.event;
+  const auto &extra = record.extended_info;
+
   return {
       {"general_error_code", std::to_string(event->error_code)},
+      // alias for general_connection_id
+      {"general_thread_id", std::to_string(event->connection_id)},
       {"general_connection_id", std::to_string(event->connection_id)},
-      {"general_user.str", mysql_cstring_to_string(&event->user)},
-      {"general_user.length", mysql_cstring_len_to_string(&event->user)},
-      {"general_host.str", mysql_cstring_to_string(&event->host)},
-      {"general_host.length", mysql_cstring_len_to_string(&event->host)},
-      {"general_ip.str", mysql_cstring_to_string(&event->ip)},
-      {"general_ip.length", mysql_cstring_len_to_string(&event->ip)},
+      {"general_user.str", extra.user},
+      {"general_user.length", std::to_string(extra.user.length())},
+      {"general_command.str", extra.command},
+      {"general_command.length", std::to_string(extra.command.length())},
+      {"general_query.str", extra.query},
+      {"general_query.length", std::to_string(extra.query.length())},
+      {"general_host.str", extra.host},
+      {"general_host.length", std::to_string(extra.host.length())},
+      {"general_sql_command.str", extra.sql_command},
+      {"general_sql_command.length",
+       std::to_string(extra.sql_command.length())},
+      {"general_ip.str", extra.ip},
+      {"general_ip.length", std::to_string(extra.ip.length())},
   };
 }
 
@@ -568,8 +579,13 @@ AuditRecordFieldsList get_audit_record_fields(
 AuditRecordFieldsList get_audit_record_fields(
     const AuditRecordTableAccess &record) {
   const auto *event = record.event;
+  const auto &extra = record.extended_info;
+
   return {
       {"connection_id", std::to_string(event->connection_id)},
+      {"sql_command_id", extra.sql_command},
+      {"query.str", extra.query},
+      {"query.length", std::to_string(extra.query.length())},
       {"table_database.str", mysql_cstring_to_string(&event->table_database)},
       {"table_database.length",
        mysql_cstring_len_to_string(&event->table_database)},

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -583,7 +583,7 @@ AuditRecordFieldsList get_audit_record_fields(
 
   return {
       {"connection_id", std::to_string(event->connection_id)},
-      {"sql_command_id", extra.sql_command},
+      {"sql_command_id", std::to_string(extra.sql_command_id)},
       {"query.str", extra.query},
       {"query.length", std::to_string(extra.query.length())},
       {"table_database.str", mysql_cstring_to_string(&event->table_database)},

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -49,6 +49,7 @@ struct ExtendedInfo {
   std::string user;
   std::string host;
   std::string ip;
+  std::string external_user;
   std::string proxy_user;
   std::string command;
   std::string sql_command;

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -45,6 +45,13 @@ constexpr std::string_view CONNECTION_TYPE_FIELD_NAME = "connection_type";
 
 struct ExtendedInfo {
   std::string digest;
+  std::string user;
+  std::string host;
+  std::string ip;
+  std::string proxy_user;
+  std::string command;
+  std::string sql_command;
+  std::string query;
   std::map<std::string, std::vector<std::pair<std::string, std::string>>> attrs;
 };
 

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -17,6 +17,7 @@
 #define AUDIT_LOG_FILTER_RECORD_H_INCLUDED
 
 #include "components/audit_log_filter/audit_event_class_internal.h"
+#include "my_sqlcommand.h"  // enum_sql_command
 
 #include <map>
 #include <string>
@@ -51,6 +52,7 @@ struct ExtendedInfo {
   std::string proxy_user;
   std::string command;
   std::string sql_command;
+  enum_sql_command sql_command_id;
   std::string query;
   std::map<std::string, std::vector<std::pair<std::string, std::string>>> attrs;
 };

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -367,6 +367,7 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto escaped_user = make_escaped_string(extra.user);
   const auto escaped_host = make_escaped_string(extra.host);
   const auto escaped_ip = make_escaped_string(extra.ip);
+  const auto esc_external_user = make_escaped_string(extra.external_user);
   const auto esc_proxy_user = make_escaped_string(extra.proxy_user);
   const auto esc_command = make_escaped_string(extra.command);
   const auto esc_sql_command = make_escaped_string(extra.sql_command);
@@ -379,7 +380,7 @@ AuditRecordString LogRecordFormatterJson::apply(
          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
          << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
+         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
          << R"(    "general_data": {)" << "\n"
          << R"(      "command": ")" << esc_command << "\",\n";
   if (!esc_query.empty()) {
@@ -447,6 +448,7 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto escaped_user = make_escaped_string(extra.user);
   const auto escaped_host = make_escaped_string(extra.host);
   const auto escaped_ip = make_escaped_string(extra.ip);
+  const auto esc_external_user = make_escaped_string(extra.external_user);
   const auto esc_proxy_user = make_escaped_string(extra.proxy_user);
   const auto esc_query =
       audit_record.extended_info.digest.empty()
@@ -466,7 +468,7 @@ AuditRecordString LogRecordFormatterJson::apply(
          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
          << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
+         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
          << R"(    "table_access_data": {)" << "\n"
          << R"(      "db": ")" << make_escaped_string(&audit_record.event->table_database) << "\",\n"
          << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\",\n"

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -354,6 +354,7 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto time_now = std::chrono::system_clock::now();
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
+  const auto &extra = audit_record.extended_info;
 
   /* clang-format off */
   result << "  {\n"
@@ -363,17 +364,30 @@ AuditRecordString LogRecordFormatterJson::apply(
     result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
   }
 
-  const auto escaped_user = make_escaped_string(&audit_record.event->user);
-  const auto escaped_host = make_escaped_string(&audit_record.event->host);
-  const auto escaped_ip = make_escaped_string(&audit_record.event->ip);
+  const auto escaped_user = make_escaped_string(extra.user);
+  const auto escaped_host = make_escaped_string(extra.host);
+  const auto escaped_ip = make_escaped_string(extra.ip);
+  const auto esc_proxy_user = make_escaped_string(extra.proxy_user);
+  const auto esc_command = make_escaped_string(extra.command);
+  const auto esc_sql_command = make_escaped_string(extra.sql_command);
+  const auto esc_query = audit_record.extended_info.digest.empty()
+                 ? make_escaped_string(extra.query)
+                 : make_escaped_string(audit_record.extended_info.digest);
 
   result << R"(    "id": )" << rec_id << ",\n"
          << R"(    "class": "general",)" << "\n"
          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
          << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": "")" << " },\n"
-         << R"(    "general_data": { "status": )" << audit_record.event->error_code << " }"
+         << R"(    "login": { "user": ")" << escaped_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
+         << R"(    "general_data": {)" << "\n"
+         << R"(      "command": ")" << esc_command << "\",\n";
+  if (!esc_query.empty()) {
+    result << R"(      "sql_command": ")" << esc_sql_command << "\",\n"
+           << R"(      "query": ")" << esc_query << "\",\n";
+  }
+  result << R"(      "status": )" << audit_record.event->error_code
+         << "\n    }"
          << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
@@ -427,6 +441,17 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto time_now = std::chrono::system_clock::now();
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
+  const auto &extra = audit_record.extended_info;
+
+  const auto escaped_sql_command = make_escaped_string(extra.sql_command);
+  const auto escaped_user = make_escaped_string(extra.user);
+  const auto escaped_host = make_escaped_string(extra.host);
+  const auto escaped_ip = make_escaped_string(extra.ip);
+  const auto esc_proxy_user = make_escaped_string(extra.proxy_user);
+  const auto esc_query =
+      audit_record.extended_info.digest.empty()
+          ? make_escaped_string(extra.query)
+          : make_escaped_string(audit_record.extended_info.digest);
 
   /* clang-format off */
   result << "  {\n"
@@ -440,9 +465,13 @@ AuditRecordString LogRecordFormatterJson::apply(
          << R"(    "class": "table_access",)" << "\n"
          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+         << R"(    "login": { "user": ")" << escaped_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
          << R"(    "table_access_data": {)" << "\n"
          << R"(      "db": ")" << make_escaped_string(&audit_record.event->table_database) << "\",\n"
-         << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\"}"
+         << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\",\n"
+         << R"(      "query": ")" << esc_query << "\",\n"
+         << R"(      "sql_command": ")" << escaped_sql_command << "\"\n    }"
          << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 

--- a/components/audit_log_filter/log_record_formatter/new.cc
+++ b/components/audit_log_filter/log_record_formatter/new.cc
@@ -49,6 +49,8 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <IP>" << make_escaped_string(&audit_record.event->ip) << "</IP>\n"
          << "    <USER>" << make_escaped_string(&audit_record.event->user) << "</USER>\n"
          << "    <STATUS>" << audit_record.event->error_code << "</STATUS>\n"
+         << "    <SQLTEXT>" << (audit_record.extended_info.digest.empty() ? make_escaped_string(audit_record.extended_info.query)
+                                                                          : make_escaped_string(audit_record.extended_info.digest)) << "</SQLTEXT>\n"
          << "  </AUDIT_RECORD>\n";
   /* clang-format on */
 
@@ -95,6 +97,8 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
          << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
          << "    <CONNECTION_ID>" << audit_record.event->connection_id << "</CONNECTION_ID>\n"
+         << "    <SQLTEXT>" << (audit_record.extended_info.digest.empty() ? make_escaped_string(audit_record.extended_info.query)
+                                                                          : make_escaped_string(audit_record.extended_info.digest)) << "</SQLTEXT>\n"
          << "    <DB>" << make_escaped_string(&audit_record.event->table_database) << "</DB>\n"
          << "    <TABLE>" << make_escaped_string(&audit_record.event->table_name) << "</TABLE>\n"
          << "  </AUDIT_RECORD>\n";

--- a/components/audit_log_filter/log_record_formatter/new.cc
+++ b/components/audit_log_filter/log_record_formatter/new.cc
@@ -39,6 +39,9 @@ AuditRecordString LogRecordFormatterNew::apply(
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
 
   /* clang-format off */
+  // TODO: For AuditRecordGeneral with JSON format, we added "command" and "sql_command" fields.
+  //       We also need to update the fields according to https://perconadev.atlassian.net/browse/PS-10339.
+  //       Same as JSON format: user field appears as "root" for upstream.
   result << "  <AUDIT_RECORD>\n"
          << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
@@ -91,6 +94,9 @@ AuditRecordString LogRecordFormatterNew::apply(
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
 
   /* clang-format off */
+  // TODO: For AuditRecordTableAccess with JSON format, we added <HOST>, <IP>, <USER>, and <PROXY_USER>.
+  //       We also need to update the fields according to https://perconadev.atlassian.net/browse/PS-10339.
+  //       Unlike JSON format, the user field appears as "root[root] @ localhost [127.0.0.1]" for upstream.
   result << "  <AUDIT_RECORD>\n"
          << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"

--- a/components/audit_log_filter/log_record_formatter/old.cc
+++ b/components/audit_log_filter/log_record_formatter/old.cc
@@ -39,6 +39,9 @@ AuditRecordString LogRecordFormatterOld::apply(
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
 
   /* clang-format off */
+  // TODO: For AuditRecordGeneral with JSON format, we added "query", "command" and "sql_command" fields.
+  //       We also need to update the fields according to https://perconadev.atlassian.net/browse/PS-10339.
+  //       Same as JSON format: user field appears as "root" for upstream.
   result << "  <AUDIT_RECORD\n"
          << "    NAME=\"" << event_subclass_to_string(audit_record.event) << "\"\n"
          << "    RECORD_ID=\"" << make_record_id(tp) << "\"\n"
@@ -86,6 +89,9 @@ AuditRecordString LogRecordFormatterOld::apply(
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
 
   /* clang-format off */
+  // TODO: For AuditRecordTableAccess with JSON format, we added <SQLTEXT>, <HOST>, <IP>, <USER>, and <PROXY_USER>.
+  //       We also need to update the fields according to https://perconadev.atlassian.net/browse/PS-10339.
+  //       Unlike JSON format, the user field appears as "root[root] @ localhost [127.0.0.1]" for upstream.
   result << "  <AUDIT_RECORD\n"
          << "    NAME=\"" << event_subclass_to_string(audit_record.event) << "\"\n"
          << "    RECORD_ID=\"" << make_record_id(tp) << "\"\n"

--- a/include/mysql/components/services/mysql_thd_attributes.h
+++ b/include/mysql/components/services/mysql_thd_attributes.h
@@ -131,6 +131,7 @@ BEGIN_SERVICE_DEFINITION(mysql_thd_attributes)
   - time-zone name variable ("time_zone_name" of the returned
     mysql_cstring_with_length type)
   - Query execution status ("da_status" of the returned uint16 type).
+  - SQL Command Number/Enum ("sql_command_id" of the returned uint32 type).
 
   @param      thd           Session THD object.
   @param      name          Name of the attribute to be set.

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
@@ -62,12 +62,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -83,22 +83,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
@@ -62,12 +62,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -83,22 +83,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
@@ -68,12 +68,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -89,22 +89,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "table_access_data": {"db": "test", "table": "t1"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
@@ -68,12 +68,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -89,22 +89,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/sql/server_component/mysql_thd_attributes_imp.cc
+++ b/sql/server_component/mysql_thd_attributes_imp.cc
@@ -128,6 +128,10 @@ DEFINE_BOOL_METHOD(mysql_thd_attributes_imp::get,
           *((mysql_cstring_with_length *)inout_pvalue) = {sql_command,
                                                           strlen(sql_command)};
         }
+      } else if (!strcmp(name, "sql_command_id")) {
+        enum_sql_command cmd = SQLCOM_END;
+        if (t->lex != nullptr) cmd = t->lex->sql_command;
+        *((uint32_t *)inout_pvalue) = static_cast<uint32_t>(cmd);
       } else if (!strcmp(name, "command")) {
         const char *command = get_server_command_string(t->get_command());
         *((mysql_cstring_with_length *)inout_pvalue) = {command,


### PR DESCRIPTION
1. Add missing fields to `ExtendedInfo` and populate them with `set_extended_info()`.
2. Integrate new fields with `get_audit_record_fields()` to enable filtering via `AuditRecordGeneral` and `AuditRecordTableAccess`.
3. Use new fields with `LogRecordFormatter` for filtering with `AuditRecordGeneral` and `AuditRecordTableAccess`.
4. Fix MTR tests to align with updated audit log behavior.