### PR TITLE
Ps 9815 [9.x] Fix possible crash in  LogComponentErr

### DIFF
--- a/components/keyrings/keyring_kmip/service_implementation/keyring_load_service_definition.cc
+++ b/components/keyrings/keyring_kmip/service_implementation/keyring_load_service_definition.cc
@@ -37,19 +37,22 @@ DEFINE_BOOL_METHOD(Keyring_load_service_impl::load,
                    (const char *component_path, const char *instance_path)) {
   try {
     if (set_paths(component_path, instance_path) == true) {
-      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+        "Failed to set path to component");
       return true;
     }
 
     if (init_or_reinit_keyring() == true) {
-      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+        "Failed to initialize or reinitialize keyring ");
       return true;
     }
     g_keyring_kmip_inited = true;
     LogComponentErr(INFORMATION_LEVEL, ER_NOTE_KEYRING_COMPONENT_INITIALIZED);
     return false;
   } catch (...) {
-    LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+    LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+      "Got an exception while loading component");
     return true;
   }
 }

--- a/components/keyrings/keyring_kms/service_implementation/keyring_load_service_definition.cc
+++ b/components/keyrings/keyring_kms/service_implementation/keyring_load_service_definition.cc
@@ -38,19 +38,22 @@ DEFINE_BOOL_METHOD(Keyring_load_service_impl::load,
                    (const char *component_path, const char *instance_path)) {
   try {
     if (set_paths(component_path, instance_path) == true) {
-      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+                              "Failed to set path to component");
       return true;
     }
 
     if (init_or_reinit_keyring() == true) {
-      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+        "Failed to initialize or reinitialize keyring");
       return true;
     }
     g_keyring_kms_inited = true;
     LogComponentErr(INFORMATION_LEVEL, ER_NOTE_KEYRING_COMPONENT_INITIALIZED);
     return false;
   } catch (...) {
-    LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+    LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+      "Got an exception while loading component");
     return true;
   }
 }

--- a/components/keyrings/keyring_vault/service_implementation/keyring_load_service_definition.cc
+++ b/components/keyrings/keyring_vault/service_implementation/keyring_load_service_definition.cc
@@ -36,12 +36,14 @@ DEFINE_BOOL_METHOD(Keyring_load_service_impl::load,
                    (const char *component_path, const char *instance_path)) {
   try {
     if (set_paths(component_path, instance_path)) {
-      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+        "Failed to set path to component");
       return true;
     }
 
     if (init_or_reinit_keyring()) {
-      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+      LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+        "Failed to initialize or reinitialize keyring");
       return true;
     }
 
@@ -49,7 +51,8 @@ DEFINE_BOOL_METHOD(Keyring_load_service_impl::load,
     LogComponentErr(INFORMATION_LEVEL, ER_NOTE_KEYRING_COMPONENT_INITIALIZED);
     return false;
   } catch (...) {
-    LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED);
+    LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED,
+      "Got an exception while loading component");
     return true;
   }
 }


### PR DESCRIPTION
PS-9815 [8.4] Fix possible crash in  LogComponentErr(ERROR_LEVEL,...) when a format symbol is present in the error message
    
    https://perconadev.atlassian.net/browse/PS-9815
    
    The ER_KEYRING_COMPONENT_NOT_INITIALIZED message contains "%s" and therefore the 3rd argument is required, e.g LogComponentErr(ERROR_LEVEL, ER_KEYRING_COMPONENT_NOT_INITIALIZED, "Some mgs") to avoid undefined behavior of underlying  vsnprintf() call. For example, this patch fixes the crash of mysqld with wrong configs for keyring components.
