### PR TITLE
PS-10232 [trunk]: MySQL 8.0.40+ is about 2-3x times slower than 8.0.39 in particular index scan scenario

### DIFF
--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -769,6 +769,9 @@ bool set_record_buffer(TABLE *table, double expected_rows_to_fetch) {
     }
   }
 
+  // Do not allocate space for more rows than the handler asked for.
+  rows_in_buffer = std::min(rows_in_buffer, max_rows);
+
   // After adjustments made above, we still need a minimum of 2 rows to
   // use a record buffer.
   if (rows_in_buffer <= 1) {


### PR DESCRIPTION
A follow up fix for "Bug#36775910: Record buffer not set in index range scans" [2969af5] caused a performance regression by failing to respect the handler's recommendation to cap the number of rows in the record buffer (at the time of writing hard-coded to 100 for InnoDB). This caused a performance regression which is most pronounced when using a small LIMIT.

Fixed by re-introducing the line implementing cap.