### PR TITLE
PS-10383 [8.4]: ensure  performs phrase search in BOOLEAN MODE with Mecab plugin

### DIFF
--- a/plugin/fulltext/mecab_parser/plugin_mecab.cc
+++ b/plugin/fulltext/mecab_parser/plugin_mecab.cc
@@ -235,9 +235,12 @@ static int mecab_parse(MeCab::Lattice *mecab_lattice,
       bool_info->position = position;
       position += node->rlength;
 
-      param->mysql_add_word(param, const_cast<char *>(node->surface),
+      ret = param->mysql_add_word(param, const_cast<char *>(node->surface),
                             node->length,
                             term_converted ? &token_info : bool_info);
+      if (ret != 0) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
### Background
In the MeCab full-text parser documentation, it is described that:

- In NATURAL LANGUAGE MODE, the search term is converted into a union of tokens.
- In BOOLEAN MODE, the search term is converted into a search phrase.

However, when using the MeCab plugin, phrase search behavior in BOOLEAN MODE was not enforced correctly: rows were returned even when extra tokens existed between phrase tokens.
```
--boolean mode
select * from issue_test where match (content) against ('서울날씨' in boolean mode);
+----+-----------------+
| id | content         |
+----+-----------------+
|  1 | 서울날씨        |
|  2 | 서울봄날씨      |
+----+-----------------+

select * from issue_test where match (content) against ('"서울날씨"' in boolean mode);
+----+-----------------+
| id | content         |
+----+-----------------+
|  1 | 서울날씨        |
|  2 | 서울봄날씨      |
+----+-----------------+

--natural mode
select * from issue_test where match (content) against ('서울날씨');
+----+-----------------+
| id | content         |
+----+-----------------+
|  1 | 서울날씨        |
|  2 | 서울봄날씨      |
+----+-----------------+
```

### CAUSE
fts_query_match_phrase_add_word_for_parser() returns a non-zero value when phrase token matching fails.
However, as-is code ignored this return values.

### AFTER FIX
```
--boolean mode
select * from issue_test where match (content) against ('서울날씨' in boolean mode);
+----+--------------+
| id | content      |
+----+--------------+
|  1 | 서울날씨     |
+----+--------------+

select * from issue_test where match (content) against ('"서울날씨"' in boolean mode);
+----+--------------+
| id | content      |
+----+--------------+
|  1 | 서울날씨     |
+----+--------------+

-- natural mode
select * from issue_test where match (content) against ('서울날씨');
+----+-----------------+
| id | content         |
+----+-----------------+
|  1 | 서울날씨        |
|  2 | 서울봄날씨      |
+----+-----------------+
```