### PR TITLE
PS-10347 [9.x]: Ensure strict JSON compliance and robust field separation in audit_log_read()/AuditJsonHandler

### DIFF
--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -225,15 +225,33 @@ bool AuditLogReader::read(AuditLogReaderContext *reader_context) noexcept {
               reader_context->current_file)) {
         return false;
       }
+
+      if (reader_context->reader == nullptr) {
+        reader_context->reader = std::make_unique<rapidjson::Reader>();
+      }
+
+      reader_context->reader->IterativeParseInit();
+    } else if (reader_context->reader == nullptr) {
+      /*
+        If the previous call to read() failed to open the file (returned false),
+        current_file would be set but the reader not initialized.
+      */
+      reader_context->reader = std::make_unique<rapidjson::Reader>();
+      reader_context->reader->IterativeParseInit();
     }
 
-    rapidjson::Reader reader;
-    reader.IterativeParseInit();
-
-    while (!reader.IterativeParseComplete()) {
-      reader.IterativeParseNext<rapidjson::kParseDefaultFlags>(
+    while (!reader_context->reader->IterativeParseComplete()) {
+      reader_context->reader->IterativeParseNext<rapidjson::kParseDefaultFlags>(
           *reader_context->audit_json_read_stream,
           *reader_context->audit_json_handler);
+
+      if (reader_context->reader->HasParseError()) {
+        return false;
+      }
+
+      if (reader_context->is_batch_end) {
+        break;
+      }
     }
 
     if (reader_context->audit_json_read_stream->check_eof_reached()) {

--- a/components/audit_log_filter/audit_log_reader.h
+++ b/components/audit_log_filter/audit_log_reader.h
@@ -46,7 +46,7 @@ struct AuditLogReaderContext {
   std::unique_ptr<json_reader::AuditJsonHandler> audit_json_handler;
   std::unique_ptr<json_reader::AuditJsonReadStream> audit_json_read_stream;
   std::deque<FileInfo *> files_to_read;
-  FileInfo *current_file;
+  FileInfo *current_file{nullptr};
   bool is_session_end{false};
   bool is_batch_end{false};
 };

--- a/components/audit_log_filter/audit_log_reader.h
+++ b/components/audit_log_filter/audit_log_reader.h
@@ -45,6 +45,7 @@ struct AuditLogReaderContext {
   std::unique_ptr<AuditLogReaderArgs> batch_reader_args;
   std::unique_ptr<json_reader::AuditJsonHandler> audit_json_handler;
   std::unique_ptr<json_reader::AuditJsonReadStream> audit_json_read_stream;
+  std::unique_ptr<rapidjson::Reader> reader;
   std::deque<FileInfo *> files_to_read;
   FileInfo *current_file{nullptr};
   bool is_session_end{false};

--- a/components/audit_log_filter/json_reader/audit_json_handler.cc
+++ b/components/audit_log_filter/json_reader/audit_json_handler.cc
@@ -14,6 +14,8 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
 #include "components/audit_log_filter/json_reader/audit_json_handler.h"
+#include <cassert>
+#include <cstring>  // std::strcpy
 #include "components/audit_log_filter/audit_log_reader.h"
 
 namespace audit_log_filter::json_reader {
@@ -40,7 +42,8 @@ AuditJsonHandler::AuditJsonHandler(
       m_out_buff_size{out_buff_size},
       m_used_buff_size{0},
       m_printed_events_count{0},
-      m_reading_start_reached{false} {}
+      m_reading_start_reached{false},
+      m_is_first_field{false} {}
 
 char *AuditJsonHandler::get_result_buffer_ptr() noexcept {
   return m_out_buff.get();
@@ -62,7 +65,10 @@ void AuditJsonHandler::iterative_parse_init() noexcept {
 }
 
 void AuditJsonHandler::iterative_parse_close(bool with_null_tag) noexcept {
-  if (m_used_buff_size > 2 && !with_null_tag) {
+  // Remove the trailing ",\n" from the last event, if present,
+  // to ensure valid JSON array closing.
+  if (m_used_buff_size >= 2 && (m_current_buff - 2)[0] == ',' &&
+      (m_current_buff - 1)[0] == '\n' && !with_null_tag) {
     m_current_buff -= 2;
     m_used_buff_size -= 2;
   }
@@ -72,60 +78,74 @@ void AuditJsonHandler::iterative_parse_close(bool with_null_tag) noexcept {
   write_out_buff(closing_tag.c_str(), closing_tag.length());
 }
 
+// --- Value Handlers ---
+
 bool AuditJsonHandler::Null() { return true; }
 
 bool AuditJsonHandler::Bool(bool value) {
-  m_event_str << (value ? "true" : "false") << ", ";
+  m_event_str << (value ? "true" : "false");
   return true;
 }
 
 bool AuditJsonHandler::Int(int value) {
-  update_bookmark(value);
-  m_event_str << value << ", ";
+  update_bookmark(static_cast<uint64_t>(value));
+  m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Uint(unsigned value) {
-  update_bookmark(value);
-  m_event_str << value << ", ";
+  update_bookmark(static_cast<uint64_t>(value));
+  m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Int64(int64_t value) {
-  update_bookmark(value);
-  m_event_str << value << ", ";
+  update_bookmark(static_cast<uint64_t>(value));
+  m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Uint64(uint64_t value) {
   update_bookmark(value);
-  m_event_str << value << ", ";
+  m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Double(double value) {
-  m_event_str << value << ", ";
+  m_event_str << value;
   return true;
 }
 
-bool AuditJsonHandler::String(const char *value,
-                              rapidjson::SizeType length [[maybe_unused]],
+bool AuditJsonHandler::String(const char *value, rapidjson::SizeType length,
                               bool copy [[maybe_unused]]) {
-  update_bookmark(value);
-  m_event_str << "\"" << value << "\", ";
+  std::string s_value(value, length);
+  update_bookmark(s_value);
+  m_event_str << "\"" << s_value << "\"";
   return true;
 }
+
+// --- Structure Handlers ---
 
 bool AuditJsonHandler::StartObject() {
   ++m_obj_level;
   m_event_str << "{";
+  // Reset flag: the first key encountered will not have a comma separator
+  m_is_first_field = true;
   return true;
 }
 
-bool AuditJsonHandler::Key(const char *str,
-                           rapidjson::SizeType length [[maybe_unused]],
+bool AuditJsonHandler::Key(const char *str, rapidjson::SizeType length,
                            bool copy [[maybe_unused]]) {
-  m_current_key_name = str;
+  m_current_key_name.assign(str, length);
+
+  // Manage comma separation and state before appending the key.
+  if (m_is_first_field) {
+    m_is_first_field = false;  // This is the first field, so unset the flag
+  } else {
+    m_event_str << ", ";  // Prepend separator if a previous field exists
+  }
+
+  // Append key and colon
   m_event_str << "\"" << str << "\": ";
   return true;
 }
@@ -136,20 +156,24 @@ bool AuditJsonHandler::EndObject(rapidjson::SizeType memberCount
     --m_obj_level;
   }
 
-  if (m_obj_level > 0) {
-    // remove comma after last event
-    m_event_str.seekp(-2, std::ios_base::end);
-  }
-
+  // Append the closing brace.
   m_event_str << "}";
 
+  // If closing an inner object (m_obj_level is now > 0), or the top-level
+  // object, ensure the m_is_first_field is false, so the next Key() call
+  // (if any, in the parent) correctly prepends a comma.
+  m_is_first_field = false;
+
+  // Handle the completed top-level event object.
   if (m_obj_level == 0) {
     if (!check_reading_start_reached()) {
       clear_current_event();
       return true;
     }
 
+    // Add the inter-event separator (comma and newline).
     m_event_str << ",\n";
+
     const auto event_length = m_event_str.str().length();
     const auto max_array_length =
         m_reader_context->batch_reader_args->max_array_length;
@@ -171,6 +195,9 @@ bool AuditJsonHandler::EndObject(rapidjson::SizeType memberCount
 }
 
 bool AuditJsonHandler::StartArray() {
+  // If we ever to support such arrays (i.e. non top-level) we need to rethink
+  // and change comma separation logic between arrays and objects elements.
+  assert(m_arr_level == 0);
   ++m_arr_level;
   return true;
 }

--- a/components/audit_log_filter/json_reader/audit_json_handler.h
+++ b/components/audit_log_filter/json_reader/audit_json_handler.h
@@ -90,6 +90,7 @@ class AuditJsonHandler
   ulong m_used_buff_size;
   ulong m_printed_events_count;
   bool m_reading_start_reached;
+  bool m_is_first_field;
 
   LogBookmark m_current_event_bookmark;
 };

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
@@ -62,12 +62,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -83,22 +83,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
@@ -68,12 +68,12 @@ SELECT @current_file_start_bookmark;
 SELECT audit_log_read(@file2_start_bookmark);
 audit_log_read(@file2_start_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 
@@ -89,22 +89,22 @@ SELECT @file2_start_with_limit_bookmark;
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
-{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
 ]
 
 SELECT audit_log_read('{"max_array_length": 2}');
 audit_log_read('{"max_array_length": 2}')
 [
-{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}"login": {"user": "root", "os": "", "ip": "", "proxy": ""}"table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_validate_output.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_validate_output.result
@@ -282,7 +282,6 @@ audit_log_read(JSON_SET(@start_bookmark, '$.max_array_length', 5))
 ]
 
 Get 8 events from "INSERT INTO t1 VALUES (1)"
-TODO: We have a bug here that audit_log_read() returns all records instead of just 8 records
 SELECT audit_log_read('{"max_array_length": 8}');
 audit_log_read('{"max_array_length": 8}')
 [
@@ -293,7 +292,13 @@ audit_log_read('{"max_array_length": 8}')
 {"timestamp": "<hidden>", "id": 9, "class": "query", "event": "query_start", "connection_id": <id>, "query_data": {"query": "INSERT INTO t1 VALUES (1)", "status": 0, "sql_command": "insert"}},
 {"timestamp": "<hidden>", "id": 10, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (1)", "sql_command": "insert"}},
 {"timestamp": "<hidden>", "id": 11, "class": "query", "event": "query_status_end", "connection_id": <id>, "query_data": {"query": "INSERT INTO t1 VALUES (1)", "status": 0, "sql_command": "insert"}},
-{"timestamp": "<hidden>", "id": 12, "class": "general", "event": "result", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "insert", "query": "INSERT INTO t1 VALUES (1)", "status": 0}},
+{"timestamp": "<hidden>", "id": 12, "class": "general", "event": "result", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "insert", "query": "INSERT INTO t1 VALUES (1)", "status": 0}}
+]
+
+Get remaining events
+SELECT audit_log_read();
+audit_log_read()
+[
 {"timestamp": "<hidden>", "id": 13, "class": "general", "event": "status", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "insert", "query": "INSERT INTO t1 VALUES (1)", "status": 0}},
 {"timestamp": "<hidden>", "id": 14, "class": "command", "event": "command_end", "connection_id": <id>, "command_data": {"name": "command_end", "status": 0, "command": "Query"}},
 {"timestamp": "<hidden>", "id": 15, "class": "command", "event": "command_start", "connection_id": <id>, "command_data": {"name": "command_start", "status": 0, "command": "Query"}},
@@ -304,9 +309,5 @@ audit_log_read('{"max_array_length": 8}')
 null
 ]
 
-Get remaining events
-SELECT audit_log_read('null');
-audit_log_read('null')
-OK
 # Cleanup
 DROP TABLE t1;

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_validate_output.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_validate_output.result
@@ -1,0 +1,312 @@
+#
+# PS-10347: AuditJsonHandler used by audit_log_read UDF returns malformed JSON
+# https://perconadev.atlassian.net/browse/PS-10347
+#
+CREATE TABLE t1 (c1 INT);
+SELECT audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }');
+audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }')
+OK
+SET @start_bookmark := audit_log_read_bookmark();
+Turn on audit log
+SELECT audit_log_filter_set_user('%', 'log_all');
+audit_log_filter_set_user('%', 'log_all')
+OK
+INSERT INTO t1 VALUES (1);
+Turn off audit log
+SELECT audit_log_filter_remove_filter('log_all');
+audit_log_filter_remove_filter('log_all')
+OK
+Rotate to close a log file and get access to it
+Print audit log filter output
+[
+  {
+    "timestamp": "<hidden>",
+    "id": 0,
+    "class": "audit",
+    "event": "audit",
+    "server_id": 1
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 1,
+    "class": "query",
+    "event": "query_status_end",
+    "connection_id": <id>,
+    "query_data": {
+      "query": "SELECT audit_log_filter_set_user('%', 'log_all')",
+      "status": 0,
+      "sql_command": "select"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 2,
+    "class": "general",
+    "event": "result",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "general_data": {
+      "command": "Query",
+      "sql_command": "select",
+      "query": "SELECT audit_log_filter_set_user('%', 'log_all')",
+      "status": 0
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 3,
+    "class": "general",
+    "event": "status",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "general_data": {
+      "command": "Query",
+      "sql_command": "select",
+      "query": "SELECT audit_log_filter_set_user('%', 'log_all')",
+      "status": 0
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 4,
+    "class": "command",
+    "event": "command_end",
+    "connection_id": <id>,
+    "command_data": {
+      "name": "command_end",
+      "status": 0,
+      "command": "Query"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 5,
+    "class": "command",
+    "event": "command_start",
+    "connection_id": <id>,
+    "command_data": {
+      "name": "command_start",
+      "status": 0,
+      "command": "Query"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 6,
+    "class": "parse",
+    "event": "query_rewritten",
+    "connection_id": <id>,
+    "parse_data": {
+      "flags": 0,
+      "query": "INSERT INTO t1 VALUES (1)",
+      "rewritten_query": ""}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 7,
+    "class": "parse",
+    "event": "prepared_statement",
+    "connection_id": <id>,
+    "parse_data": {
+      "flags": 0,
+      "query": "INSERT INTO t1 VALUES (1)",
+      "rewritten_query": ""}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 8,
+    "class": "general",
+    "event": "log",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "general_data": {
+      "command": "Query",
+      "sql_command": "insert",
+      "query": "INSERT INTO t1 VALUES (1)",
+      "status": 0
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 9,
+    "class": "query",
+    "event": "query_start",
+    "connection_id": <id>,
+    "query_data": {
+      "query": "INSERT INTO t1 VALUES (1)",
+      "status": 0,
+      "sql_command": "insert"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 10,
+    "class": "table_access",
+    "event": "insert",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "table_access_data": {
+      "db": "test",
+      "table": "t1",
+      "query": "INSERT INTO t1 VALUES (1)",
+      "sql_command": "insert"
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 11,
+    "class": "query",
+    "event": "query_status_end",
+    "connection_id": <id>,
+    "query_data": {
+      "query": "INSERT INTO t1 VALUES (1)",
+      "status": 0,
+      "sql_command": "insert"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 12,
+    "class": "general",
+    "event": "result",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "general_data": {
+      "command": "Query",
+      "sql_command": "insert",
+      "query": "INSERT INTO t1 VALUES (1)",
+      "status": 0
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 13,
+    "class": "general",
+    "event": "status",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "general_data": {
+      "command": "Query",
+      "sql_command": "insert",
+      "query": "INSERT INTO t1 VALUES (1)",
+      "status": 0
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 14,
+    "class": "command",
+    "event": "command_end",
+    "connection_id": <id>,
+    "command_data": {
+      "name": "command_end",
+      "status": 0,
+      "command": "Query"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 15,
+    "class": "command",
+    "event": "command_start",
+    "connection_id": <id>,
+    "command_data": {
+      "name": "command_start",
+      "status": 0,
+      "command": "Query"}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 16,
+    "class": "parse",
+    "event": "query_rewritten",
+    "connection_id": <id>,
+    "parse_data": {
+      "flags": 0,
+      "query": "SELECT audit_log_filter_remove_filter('log_all')",
+      "rewritten_query": ""}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 17,
+    "class": "parse",
+    "event": "prepared_statement",
+    "connection_id": <id>,
+    "parse_data": {
+      "flags": 0,
+      "query": "SELECT audit_log_filter_remove_filter('log_all')",
+      "rewritten_query": ""}
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 18,
+    "class": "general",
+    "event": "log",
+    "connection_id": <id>,
+    "account": { "user": "root", "host": "localhost" },
+    "login": { "user": "root", "os": "", "ip": "", "proxy": "" },
+    "general_data": {
+      "command": "Query",
+      "sql_command": "select",
+      "query": "SELECT audit_log_filter_remove_filter('log_all')",
+      "status": 0
+    }
+  },
+  {
+    "timestamp": "<hidden>",
+    "id": 19,
+    "class": "query",
+    "event": "query_start",
+    "connection_id": <id>,
+    "query_data": {
+      "query": "SELECT audit_log_filter_remove_filter('log_all')",
+      "status": 0,
+      "sql_command": "select"}
+  }
+]
+Validate audit log filter output
+File format Ok
+Export output of audit_log_read('$start_bookmark_esc') to a file
+SET @start_bookmark_esc := REPLACE(@start_bookmark, '"', '\\"');
+Validate output of audit_log_read('$start_bookmark_esc')
+File format Ok
+Start processing audit log from the beginning. Get 5 events from "audit_log_read"
+SELECT audit_log_read(JSON_SET(@start_bookmark, '$.max_array_length', 5));
+audit_log_read(JSON_SET(@start_bookmark, '$.max_array_length', 5))
+[
+{"timestamp": "<hidden>", "id": 0, "class": "audit", "event": "audit", "server_id": 1},
+{"timestamp": "<hidden>", "id": 1, "class": "query", "event": "query_status_end", "connection_id": <id>, "query_data": {"query": "SELECT audit_log_filter_set_user('%', 'log_all')", "status": 0, "sql_command": "select"}},
+{"timestamp": "<hidden>", "id": 2, "class": "general", "event": "result", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "select", "query": "SELECT audit_log_filter_set_user('%', 'log_all')", "status": 0}},
+{"timestamp": "<hidden>", "id": 3, "class": "general", "event": "status", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "select", "query": "SELECT audit_log_filter_set_user('%', 'log_all')", "status": 0}},
+{"timestamp": "<hidden>", "id": 4, "class": "command", "event": "command_end", "connection_id": <id>, "command_data": {"name": "command_end", "status": 0, "command": "Query"}}
+]
+
+Get 8 events from "INSERT INTO t1 VALUES (1)"
+TODO: We have a bug here that audit_log_read() returns all records instead of just 8 records
+SELECT audit_log_read('{"max_array_length": 8}');
+audit_log_read('{"max_array_length": 8}')
+[
+{"timestamp": "<hidden>", "id": 5, "class": "command", "event": "command_start", "connection_id": <id>, "command_data": {"name": "command_start", "status": 0, "command": "Query"}},
+{"timestamp": "<hidden>", "id": 6, "class": "parse", "event": "query_rewritten", "connection_id": <id>, "parse_data": {"flags": 0, "query": "INSERT INTO t1 VALUES (1)", "rewritten_query": ""}},
+{"timestamp": "<hidden>", "id": 7, "class": "parse", "event": "prepared_statement", "connection_id": <id>, "parse_data": {"flags": 0, "query": "INSERT INTO t1 VALUES (1)", "rewritten_query": ""}},
+{"timestamp": "<hidden>", "id": 8, "class": "general", "event": "log", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "insert", "query": "INSERT INTO t1 VALUES (1)", "status": 0}},
+{"timestamp": "<hidden>", "id": 9, "class": "query", "event": "query_start", "connection_id": <id>, "query_data": {"query": "INSERT INTO t1 VALUES (1)", "status": 0, "sql_command": "insert"}},
+{"timestamp": "<hidden>", "id": 10, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (1)", "sql_command": "insert"}},
+{"timestamp": "<hidden>", "id": 11, "class": "query", "event": "query_status_end", "connection_id": <id>, "query_data": {"query": "INSERT INTO t1 VALUES (1)", "status": 0, "sql_command": "insert"}},
+{"timestamp": "<hidden>", "id": 12, "class": "general", "event": "result", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "insert", "query": "INSERT INTO t1 VALUES (1)", "status": 0}},
+{"timestamp": "<hidden>", "id": 13, "class": "general", "event": "status", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "insert", "query": "INSERT INTO t1 VALUES (1)", "status": 0}},
+{"timestamp": "<hidden>", "id": 14, "class": "command", "event": "command_end", "connection_id": <id>, "command_data": {"name": "command_end", "status": 0, "command": "Query"}},
+{"timestamp": "<hidden>", "id": 15, "class": "command", "event": "command_start", "connection_id": <id>, "command_data": {"name": "command_start", "status": 0, "command": "Query"}},
+{"timestamp": "<hidden>", "id": 16, "class": "parse", "event": "query_rewritten", "connection_id": <id>, "parse_data": {"flags": 0, "query": "SELECT audit_log_filter_remove_filter('log_all')", "rewritten_query": ""}},
+{"timestamp": "<hidden>", "id": 17, "class": "parse", "event": "prepared_statement", "connection_id": <id>, "parse_data": {"flags": 0, "query": "SELECT audit_log_filter_remove_filter('log_all')", "rewritten_query": ""}},
+{"timestamp": "<hidden>", "id": 18, "class": "general", "event": "log", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "general_data": {"command": "Query", "sql_command": "select", "query": "SELECT audit_log_filter_remove_filter('log_all')", "status": 0}},
+{"timestamp": "<hidden>", "id": 19, "class": "query", "event": "query_start", "connection_id": <id>, "query_data": {"query": "SELECT audit_log_filter_remove_filter('log_all')", "status": 0, "sql_command": "select"}},
+null
+]
+
+Get remaining events
+SELECT audit_log_read('null');
+audit_log_read('null')
+OK
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output-master.opt
@@ -1,0 +1,1 @@
+--loose-audit_log_filter.format=JSON

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
@@ -1,0 +1,66 @@
+--echo #
+--echo # PS-10347: AuditJsonHandler used by audit_log_read UDF returns malformed JSON
+--echo # https://perconadev.atlassian.net/browse/PS-10347
+--echo #
+
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+
+CREATE TABLE t1 (c1 INT);
+SELECT audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }');
+SET @start_bookmark := audit_log_read_bookmark();
+
+--echo Turn on audit log
+SELECT audit_log_filter_set_user('%', 'log_all');
+
+INSERT INTO t1 VALUES (1);
+
+--echo Turn off audit log
+SELECT audit_log_filter_remove_filter('log_all');
+
+--echo Rotate to close a log file and get access to it
+--let $audit_filter_rotate_name=`SELECT audit_log_rotate()`
+
+--echo Print audit log filter output
+--replace_regex /"connection_id": \d*/"connection_id": <id>/ /"timestamp":\s*"[^"]*"/"timestamp": "<hidden>"/
+--cat_file $audit_filter_log_path/$audit_filter_rotate_name
+
+--echo Validate audit log filter output
+--let $audit_filter_log_check_one = $audit_filter_rotate_name
+--let $audit_filter_log_format = json
+--source validate_logs_format.inc
+
+--echo Export output of audit_log_read('\$start_bookmark_esc') to a file
+SET @start_bookmark_esc := REPLACE(@start_bookmark, '"', '\\"');
+--let $start_bookmark_esc=`SELECT @start_bookmark_esc`
+--let $out_file=audit_read.out
+--exec $MYSQL --skip-column-names --raw -e "SELECT audit_log_read('$start_bookmark_esc');" > $audit_filter_log_path/$out_file
+# --cat_file $audit_filter_log_path/$out_file
+
+--echo Validate output of audit_log_read('\$start_bookmark_esc')
+--let $audit_filter_log_check_one = $out_file
+--let $audit_filter_log_format = json
+--source validate_logs_format.inc
+--remove_file $audit_filter_log_path/$out_file
+
+--echo Start processing audit log from the beginning. Get 5 events from "audit_log_read"
+--replace_regex /"connection_id": \d*/"connection_id": <id>/ /"timestamp":\s*"[^"]*"/"timestamp": "<hidden>"/
+SELECT audit_log_read(JSON_SET(@start_bookmark, '$.max_array_length', 5));
+
+--echo Get 8 events from "INSERT INTO t1 VALUES (1)"
+--echo TODO: We have a bug here that audit_log_read() returns all records instead of just 8 records
+--replace_regex /"connection_id": \d*/"connection_id": <id>/ /"timestamp":\s*"[^"]*"/"timestamp": "<hidden>"/
+SELECT audit_log_read('{"max_array_length": 8}');
+
+--echo Get remaining events
+--replace_regex /"connection_id": \d*/"connection_id": <id>/ /"timestamp":\s*"[^"]*"/"timestamp": "<hidden>"/
+SELECT audit_log_read('null');
+
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc
+
+DROP TABLE t1;

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
@@ -51,13 +51,12 @@ SET @start_bookmark_esc := REPLACE(@start_bookmark, '"', '\\"');
 SELECT audit_log_read(JSON_SET(@start_bookmark, '$.max_array_length', 5));
 
 --echo Get 8 events from "INSERT INTO t1 VALUES (1)"
---echo TODO: We have a bug here that audit_log_read() returns all records instead of just 8 records
 --replace_regex /"connection_id": \d*/"connection_id": <id>/ /"timestamp":\s*"[^"]*"/"timestamp": "<hidden>"/
 SELECT audit_log_read('{"max_array_length": 8}');
 
 --echo Get remaining events
 --replace_regex /"connection_id": \d*/"connection_id": <id>/ /"timestamp":\s*"[^"]*"/"timestamp": "<hidden>"/
-SELECT audit_log_read('null');
+SELECT audit_log_read();
 
 --echo # Cleanup
 --source ../inc/audit_comp_uninstall.inc


### PR DESCRIPTION
1. Refactors the JSON serialization logic within AuditJsonHandler to guarantee strict compliance with the JSON standard by eliminating trailing commas and centralizing field separation control.

The previous approach of appending ", " after every value handler was inconsistent and required error-prone comma removal logic in EndObject.

This change adopts a safer, state-driven approach:
- Centralized Comma Management: The responsibility for adding the comma separator is moved entirely from the value handlers (Int, String, etc.) to the Key() handler.
- State-Driven Separation: The new m_is_first_field state flag, set in StartObject() and checked/updated in Key(), ensures a comma is prepended only when necessary (i.e., not for the first field), thereby naturally preventing trailing commas within objects.
- Inter-Event Separation: Confirmed that the ,\n separator is correctly appended to separate top-level audit event objects in the array.

2.  The `audit_log_read()` UDF was failing to respect the `max_array_length` parameter, returning all records instead of the specified limit. This was caused by the read loop not checking the `is_batch_end` flag.
    
Additionally, attempting to read the remaining records in a subsequent call caused an infinite loop or parsing errors. This occurred because a new `rapidjson::Reader` was created for each call, losing the internal state required to resume parsing mid-stream (e.g., handling the comma separator between array elements).
    
The fix involves:
- Respecting the `is_batch_end` flag in the `AuditLogReader::read` loop to stop processing when the limit is reached.
- Storing the `rapidjson::Reader` instance within `AuditLogReaderContext` to preserve parsing state across multiple `audit_log_read()` calls.
- Adding error checking for `reader->HasParseError()` to prevent infinite loops on malformed data or state mismatches.
- Updating the `udf_audit_log_read_validate_output` test case to verify correct behavior for `max_array_length`.
