### PR TITLE
PS-10424 [9.x]: Fix `temporal-t.cc` compilation issue on macOS

### DIFF
--- a/unittest/gunit/temporal-t.cc
+++ b/unittest/gunit/temporal-t.cc
@@ -37,8 +37,8 @@ TEST(Time_val, MYSQL_TIME) {
   MYSQL_TIME mt = static_cast<MYSQL_TIME>(time1);
   Time_val time2 = Time_val(mt);
   EXPECT_EQ(0, time1.compare(time2));
-  MYSQL_TIME mytime(2023, 1, 30, 12, 0, 0, 0, false, MYSQL_TIMESTAMP_DATETIME,
-                    0);
+  MYSQL_TIME mytime{2023, 1, 30, 12, 0, 0, 0, false, MYSQL_TIMESTAMP_DATETIME,
+                    0};
   Time_val a(false, 12, 0, 0, 0);
   EXPECT_EQ(Time_val::strip_date(mytime), a);
   Time_val b{mt};


### PR DESCRIPTION
Fix the following issue:
```
/Users/runner/work/1/s/unittest/gunit/temporal-t.cc:40:14: error: no matching constructor for initialization of 'MYSQL_TIME'
  MYSQL_TIME mytime(2023, 1, 30, 12, 0, 0, 0, false, MYSQL_TIMESTAMP_DATETIME,
             ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/1/s/include/mysql_time.h:82:16: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 10 were provided
typedef struct MYSQL_TIME {
               ^
/Users/runner/work/1/s/include/mysql_time.h:82:16: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 10 were provided
/Users/runner/work/1/s/include/mysql_time.h:82:16: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 10 were provided
1 error generated.
```