### PR TITLE
PS-10345 [8.0]: Fixed crashes when creating an Audit Log filter with an invalid definition

### DIFF
--- a/plugin/audit_log_filter/audit_rule_parser.cc
+++ b/plugin/audit_log_filter/audit_rule_parser.cc
@@ -400,10 +400,18 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   actions_list.push_back(log_action);
 
   if (event_subclass_json.HasMember("print")) {
+    const auto &print_json = event_subclass_json["print"];
+    if (!print_json.IsObject()) {
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Wrong JSON filter '%s' format, "
+                      "bad format for 'print' replacement rule",
+                      audit_rule->get_rule_name().c_str());
+      return false;
+    }
     // There may be a few actions modifying record content defined within
     // "print" tag
-    for (auto it = event_subclass_json["print"].MemberBegin();
-         it != event_subclass_json["print"].MemberEnd(); ++it) {
+    for (auto it = print_json.MemberBegin(); it != print_json.MemberEnd();
+         ++it) {
       const auto action_type =
           event_field_action::get_event_action_type(it->name.GetString());
 
@@ -482,10 +490,16 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
    * "log": { "variable": { } }
    * "log": { "function": { } }
    */
-  assert(json.IsBool() || json.IsObject());
-
   if (json.IsBool()) {
     return EventFieldConditionType::Bool;
+  }
+
+  if (!json.IsObject()) {
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Wrong JSON filter '%s' format, "
+                    "the 'log' field must be of bool or object type",
+                    audit_rule->get_rule_name().c_str());
+    return EventFieldConditionType::Unknown;
   }
 
   if (json.MemberCount() != 1) {

--- a/plugin/audit_log_filter/tests/mtr/r/filter_definition_replace_field.result
+++ b/plugin/audit_log_filter/tests/mtr/r/filter_definition_replace_field.result
@@ -356,6 +356,74 @@ audit_log_filter_set_filter('incorrect_rule', '{
 }
 }')
 ERROR: Incorrect rule definition
+SELECT audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"log": false,
+"class": {
+"log": true,
+"name": "general",
+"event": {
+"name": "status",
+"print": "true"
+      }
+}
+}
+}');
+audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"log": false,
+"class": {
+"log": true,
+"name": "general",
+"event": {
+"name": "status",
+"print": "true"
+      }
+}
+}
+}')
+ERROR: Incorrect rule definition
+SELECT audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"class": [
+{
+"name": "general",
+"print": {
+"field": {
+"name": "general_query.str",
+"print": [],
+"replace": {
+"function": {
+"name": "query_digest"
+              }
+}
+}
+}
+}
+]
+}
+}');
+audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"class": [
+{
+"name": "general",
+"print": {
+"field": {
+"name": "general_query.str",
+"print": [],
+"replace": {
+"function": {
+"name": "query_digest"
+              }
+}
+}
+}
+}
+]
+}
+}')
+ERROR: Incorrect rule definition
 #
 # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_replace_field.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_replace_field.test
@@ -245,6 +245,8 @@ call mtr.add_suppression("Plugin audit_log_filter reported: 'Wrong argument: inc
 call mtr.add_suppression("Plugin audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, failed to parse 'print' replacement rule'");
 call mtr.add_suppression("Plugin audit_log_filter reported: 'Event field 'general_command.str' cannot be replaced'");
 call mtr.add_suppression("Plugin audit_log_filter reported: 'Event field 'table_name.str' cannot be replaced'");
+call mtr.add_suppression("Plugin audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, bad format for 'print' replacement rule'");
+call mtr.add_suppression("Plugin audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, the 'log' field must be of bool or object type'");
 #call mtr.add_suppression("Plugin audit_log_filter reported: 'Wrong JSON filter 'wrong_field_type' format, wrong function args format provided'");
 --enable_query_log
 
@@ -278,6 +280,45 @@ let $filter = {
         }
       }
     }
+  }
+};
+eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');
+
+# Invalid replacement definition (wrong type)
+let $filter = {
+  "filter": {
+    "log": false,
+    "class": {
+      "log": true,
+      "name": "general",
+      "event": {
+        "name": "status",
+        "print": "true"
+      }
+    }
+  }
+};
+eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');
+
+# Invalid replacement condition (wrong type)
+let $filter = {
+  "filter": {
+    "class": [
+      {
+        "name": "general",
+        "print": {
+          "field": {
+            "name": "general_query.str",
+            "print": [],
+            "replace": {
+              "function": {
+                "name": "query_digest"
+              }
+            }
+          }
+        }
+      }
+    ]
   }
 };
 eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10345

Fixed `audit_log_filter_set_filter` crashes when filter definition contained event data replacement fields with wrong data types. Additional type validation has been added.