### PR TITLE
PS-10229 [9.x]: audit_log_filter: Change default index name to `filtername` and support `filter_name` as the legacy name

### DIFF
--- a/components/audit_log_filter/audit_log_filter_linux_install.sql
+++ b/components/audit_log_filter/audit_log_filter_linux_install.sql
@@ -31,7 +31,7 @@ SET @create_user = CONCAT(
     'username VARCHAR(32) NOT NULL,',
     'userhost VARCHAR(255) NOT NULL,',
     'filtername VARCHAR(255) NOT NULL,',
-    'PRIMARY KEY (username, userhost), FOREIGN KEY `filter_name` (filtername) REFERENCES ', @db_name, '.audit_log_filter(name)'
+    'PRIMARY KEY (username, userhost), FOREIGN KEY (filtername) REFERENCES ', @db_name, '.audit_log_filter(name)'
   ') Engine = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci'
 );
 

--- a/components/audit_log_filter/audit_table/audit_log_user.cc
+++ b/components/audit_log_filter/audit_table/audit_log_user.cc
@@ -41,8 +41,16 @@ const size_t kAuditLogUserFieldsCount = 3;
 const TA_index_field_def key_filter_name_cols[] = {
     {"FILTERNAME", 10, true}, {"USERNAME", 8, true}, {"USERHOST", 8, true}};
 const size_t kKeyFilterNameNumcol = 3;
-const char *kKeyFilterNameName = "FILTER_NAME";
-const size_t kKeyFilterNameNameLength = 11;
+constexpr const char *kKeyFilterNameName = "FILTERNAME";
+constexpr size_t kKeyFilterNameNameLength =
+    std::char_traits<char>::length(kKeyFilterNameName);
+/*
+  Add support for index on FILTERNAME named `filtername` or `filter_name`
+  (legacy name for backward compatibility).
+*/
+constexpr const char *kKeyFilterNameLegacyName = "FILTER_NAME";
+constexpr size_t kKeyFilterNameLegacyNameLength =
+    std::char_traits<char>::length(kKeyFilterNameLegacyName);
 
 const TA_index_field_def key_primary_cols[] = {{"USERNAME", 8, true},
                                                {"USERHOST", 8, true}};
@@ -84,10 +92,17 @@ TableResult AuditLogUser::index_scan_locate_record_by_rule_name(
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyFilterNameName, kKeyFilterNameNameLength,
                       key_filter_name_cols, kKeyFilterNameNumcol, key)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init index access of %s table",
-                    get_table_name());
-    return TableResult::Fail;
+    // Fallback for backward compatibility where the index name is
+    // `filter_name` instead of `filtername`.
+    if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
+                        kKeyFilterNameLegacyName,
+                        kKeyFilterNameLegacyNameLength, key_filter_name_cols,
+                        kKeyFilterNameNumcol, key)) {
+      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to init index access of %s table",
+                      get_table_name());
+      return TableResult::Fail;
+    }
   }
 
   CHARSET_INFO_h utf8 = charset_srv->get_utf8mb4();

--- a/mysql-test/suite/component_audit_log_filter/inc/audit_tables_init.inc
+++ b/mysql-test/suite/component_audit_log_filter/inc/audit_tables_init.inc
@@ -38,7 +38,7 @@ eval CREATE TABLE $audit_db_name.audit_log_user(
     userhost VARCHAR(255) NOT NULL,
     filtername VARCHAR(255) NOT NULL,
     PRIMARY KEY (username, userhost),
-    FOREIGN KEY `filter_name` (filtername) REFERENCES $audit_db_name.audit_log_filter(name)
+    FOREIGN KEY (filtername) REFERENCES $audit_db_name.audit_log_filter(name)
 ) Engine=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci;
 
 #SELECT audit_log_filter_flush();

--- a/mysql-test/suite/component_audit_log_filter/r/audit_log_legacy_index.result
+++ b/mysql-test/suite/component_audit_log_filter/r/audit_log_legacy_index.result
@@ -1,0 +1,76 @@
+#
+# PS-10229: audit_log_filter: Fix foreign key index name compatibility
+# https://perconadev.atlassian.net/browse/PS-10229
+#
+#
+# Create filters
+#
+SELECT audit_log_filter_set_filter('filter_all', '{"filter": {"log": true}}');
+audit_log_filter_set_filter('filter_all', '{"filter": {"log": true}}')
+OK
+SELECT audit_log_filter_set_filter('filter_empty', '{"filter": {} }');
+audit_log_filter_set_filter('filter_empty', '{"filter": {} }')
+OK
+SELECT audit_log_filter_set_filter('filter_con', '{"filter": { "class": [ { "name": "connection" } ] } }');
+audit_log_filter_set_filter('filter_con', '{"filter": { "class": [ { "name": "connection" } ] } }')
+OK
+include/assert.inc [mysql.audit_log_filter should have 3 rows]
+#
+# Assign filters to users
+#
+SELECT audit_log_filter_set_user('percona@localhost', 'filter_empty');
+audit_log_filter_set_user('percona@localhost', 'filter_empty')
+OK
+SELECT audit_log_filter_set_user('root@localhost', 'filter_all');
+audit_log_filter_set_user('root@localhost', 'filter_all')
+OK
+include/assert.inc [mysql.audit_log_user should have 2 rows]
+#
+# Verify we can remove the filter (triggering lookup by default index name)
+#
+SELECT audit_log_filter_remove_filter('filter_empty');
+audit_log_filter_remove_filter('filter_empty')
+OK
+include/assert.inc [mysql.audit_log_filter should have 2 rows]
+include/assert.inc [mysql.audit_log_user should have 1 row (user removed with 'filter_empty')]
+#
+# Show create table to verify index name
+#
+SHOW CREATE TABLE mysql.audit_log_user;
+Table	Create Table
+audit_log_user	CREATE TABLE `audit_log_user` (
+  `username` varchar(32) COLLATE utf8mb4_0900_as_ci NOT NULL,
+  `userhost` varchar(255) COLLATE utf8mb4_0900_as_ci NOT NULL,
+  `filtername` varchar(255) COLLATE utf8mb4_0900_as_ci NOT NULL,
+  PRIMARY KEY (`username`,`userhost`),
+  KEY `filtername` (`filtername`),
+  CONSTRAINT `audit_log_user_ibfk_1` FOREIGN KEY (`filtername`) REFERENCES `audit_log_filter` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_ci
+#
+# Rename index 'FILTERNAME' to legacy name 'FILTER_NAME' (simulation)
+#
+ALTER TABLE mysql.audit_log_user RENAME INDEX filtername TO filter_name;
+#
+# Show the table state after renaming index
+#
+SHOW CREATE TABLE mysql.audit_log_user;
+Table	Create Table
+audit_log_user	CREATE TABLE `audit_log_user` (
+  `username` varchar(32) COLLATE utf8mb4_0900_as_ci NOT NULL,
+  `userhost` varchar(255) COLLATE utf8mb4_0900_as_ci NOT NULL,
+  `filtername` varchar(255) COLLATE utf8mb4_0900_as_ci NOT NULL,
+  PRIMARY KEY (`username`,`userhost`),
+  KEY `filter_name` (`filtername`),
+  CONSTRAINT `audit_log_user_ibfk_1` FOREIGN KEY (`filtername`) REFERENCES `audit_log_filter` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_ci
+#
+# Verify we can remove the filter (triggering lookup by legacy index name)
+#
+SELECT audit_log_filter_remove_filter('filter_all');
+audit_log_filter_remove_filter('filter_all')
+OK
+include/assert.inc [mysql.audit_log_filter should have 1 rows]
+include/assert.inc [mysql.audit_log_user should have 0 rows (user removed with 'filter_all')]
+#
+# Cleanup
+#

--- a/mysql-test/suite/component_audit_log_filter/t/audit_log_legacy_index.test
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_log_legacy_index.test
@@ -1,0 +1,76 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--echo #
+--echo # PS-10229: audit_log_filter: Fix foreign key index name compatibility
+--echo # https://perconadev.atlassian.net/browse/PS-10229
+--echo #
+
+--echo #
+--echo # Create filters
+--echo #
+SELECT audit_log_filter_set_filter('filter_all', '{"filter": {"log": true}}');
+SELECT audit_log_filter_set_filter('filter_empty', '{"filter": {} }');
+SELECT audit_log_filter_set_filter('filter_con', '{"filter": { "class": [ { "name": "connection" } ] } }');
+
+--let $assert_text = mysql.audit_log_filter should have 3 rows
+--let $assert_cond = [SELECT COUNT(*) from mysql.audit_log_filter] = 3
+--source include/assert.inc
+
+--echo #
+--echo # Assign filters to users
+--echo #
+SELECT audit_log_filter_set_user('percona@localhost', 'filter_empty');
+SELECT audit_log_filter_set_user('root@localhost', 'filter_all');
+
+--let $assert_text = mysql.audit_log_user should have 2 rows
+--let $assert_cond = [SELECT COUNT(*) from mysql.audit_log_user] = 2
+--source include/assert.inc
+
+--echo #
+--echo # Verify we can remove the filter (triggering lookup by default index name)
+--echo #
+SELECT audit_log_filter_remove_filter('filter_empty');
+
+--let $assert_text = mysql.audit_log_filter should have 2 rows
+--let $assert_cond = [SELECT COUNT(*) from mysql.audit_log_filter] = 2
+--source include/assert.inc
+
+--let $assert_text = mysql.audit_log_user should have 1 row (user removed with 'filter_empty')
+--let $assert_cond = [SELECT COUNT(*) from mysql.audit_log_user] = 1
+--source include/assert.inc
+
+--echo #
+--echo # Show create table to verify index name
+--echo #
+SHOW CREATE TABLE mysql.audit_log_user;
+
+--echo #
+--echo # Rename index 'FILTERNAME' to legacy name 'FILTER_NAME' (simulation)
+--echo #
+ALTER TABLE mysql.audit_log_user RENAME INDEX filtername TO filter_name;
+
+--echo #
+--echo # Show the table state after renaming index
+--echo #
+SHOW CREATE TABLE mysql.audit_log_user;
+
+--echo #
+--echo # Verify we can remove the filter (triggering lookup by legacy index name)
+--echo #
+SELECT audit_log_filter_remove_filter('filter_all');
+
+--let $assert_text = mysql.audit_log_filter should have 1 rows
+--let $assert_cond = [SELECT COUNT(*) from mysql.audit_log_filter] = 1
+--source include/assert.inc
+
+--let $assert_text = mysql.audit_log_user should have 0 rows (user removed with 'filter_all')
+--let $assert_cond = [SELECT COUNT(*) from mysql.audit_log_user] = 0
+--source include/assert.inc
+
+--echo #
+--echo # Cleanup
+--echo #
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc


### PR DESCRIPTION
The foreign key index on `audit_log_user` may be named `filtername` (default) or `filter_name` (legacy explicit name) depending on the creation method or upgrade path. For instance, `mysql_system_tables_fix.sql` creates it without an explicit name, resulting in `filtername`.

This commit adds a fallback in `AuditLogUser::index_scan_locate_record_by_rule_name` to support both naming conventions. It attempts to use `filtername` first, and falls back to the legacy `filter_name` if the index is not found.

Additionally, `audit_log_filter_linux_install.sql` and test initialization scripts are updated to use the standard foreign key definition without forcing the `filter_name` index name, aligning with other system scripts.