### PR TITLE
PS-10345 [8.4]: Fixed crashes when creating an Audit Log filter with an invalid definition

### DIFF
--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -373,10 +373,16 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   actions_list.push_back(log_action);
 
   if (event_subclass_json.HasMember("print")) {
+    const auto &print_json = event_subclass_json["print"];
+    if (!print_json.IsObject()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
+                      audit_rule->get_rule_name().c_str());
+      return false;
+    }
     // There may be a few actions modifying record content defined within
     // "print" tag
-    for (auto it = event_subclass_json["print"].MemberBegin();
-         it != event_subclass_json["print"].MemberEnd(); ++it) {
+    for (auto it = print_json.MemberBegin(); it != print_json.MemberEnd();
+         ++it) {
       const auto action_type =
           event_field_action::get_event_action_type(it->name.GetString());
 
@@ -449,10 +455,15 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
    * "log": { "variable": { } }
    * "log": { "function": { } }
    */
-  assert(json.IsBool() || json.IsObject());
-
   if (json.IsBool()) {
     return EventFieldConditionType::Bool;
+  }
+
+  if (!json.IsObject()) {
+    LogComponentErr(ERROR_LEVEL,
+                    ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_TYPE,
+                    audit_rule->get_rule_name().c_str());
+    return EventFieldConditionType::Unknown;
   }
 
   if (json.MemberCount() != 1) {

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
@@ -357,6 +357,74 @@ audit_log_filter_set_filter('incorrect_rule', '{
 }
 }')
 ERROR: Incorrect rule definition
+SELECT audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"log": false,
+"class": {
+"log": true,
+"name": "general",
+"event": {
+"name": "status",
+"print": "true"
+      }
+}
+}
+}');
+audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"log": false,
+"class": {
+"log": true,
+"name": "general",
+"event": {
+"name": "status",
+"print": "true"
+      }
+}
+}
+}')
+ERROR: Incorrect rule definition
+SELECT audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"class": [
+{
+"name": "general",
+"print": {
+"field": {
+"name": "query.str",
+"print": [],
+"replace": {
+"function": {
+"name": "query_digest"
+              }
+}
+}
+}
+}
+]
+}
+}');
+audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"class": [
+{
+"name": "general",
+"print": {
+"field": {
+"name": "query.str",
+"print": [],
+"replace": {
+"function": {
+"name": "query_digest"
+              }
+}
+}
+}
+}
+]
+}
+}')
+ERROR: Incorrect rule definition
 #
 # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
@@ -246,6 +246,7 @@ call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: 
 call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, failed to parse 'print' replacement rule'");
 call mtr.add_suppression("Component audit_log_filter reported: 'Event field 'status' cannot be replaced'");
 call mtr.add_suppression("Component audit_log_filter reported: 'Event field 'connection_id' cannot be replaced'");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, the 'log' field must be of bool or object type'");
 #call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'wrong_field_type' format, wrong function args format provided'");
 --enable_query_log
 
@@ -279,6 +280,45 @@ let $filter = {
         }
       }
     }
+  }
+};
+eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');
+
+# Invalid replacement definition (wrong type)
+let $filter = {
+  "filter": {
+    "log": false,
+    "class": {
+      "log": true,
+      "name": "general",
+      "event": {
+        "name": "status",
+        "print": "true"
+      }
+    }
+  }
+};
+eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');
+
+# Invalid replacement condition (wrong type)
+let $filter = {
+  "filter": {
+    "class": [
+      {
+        "name": "general",
+        "print": {
+          "field": {
+            "name": "query.str",
+            "print": [],
+            "replace": {
+              "function": {
+                "name": "query_digest"
+              }
+            }
+          }
+        }
+      }
+    ]
   }
 };
 eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13182,6 +13182,9 @@ ER_AUDIT_REPLACE_FIELD_UNEXPECTED_EVENT_TYPE
 ER_SSL_FIPS_MODE_ENABLED
   eng "A FIPS-approved version of the OpenSSL cryptographic library has been detected in the operating system with a properly configured FIPS module available for loading. Percona Server for MySQL will load this module and run in FIPS mode."
 
+ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_TYPE
+  eng "Wrong JSON filter '%s' format, the 'log' field must be of bool or object type"
+
 #
 # End of Percona Server 8.0 server error log messages
 #


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10345

Fixed `audit_log_filter_set_filter` crashes when filter definition contained event data replacement fields with wrong data types. Additional type validation has been added.