### PR TITLE
PS-9828 [8.0]: Fixed crash for non-existent `audit_log_filter_file` directory paths

### DIFF
--- a/plugin/audit_log_filter/sys_vars.cc
+++ b/plugin/audit_log_filter/sys_vars.cc
@@ -690,6 +690,16 @@ bool SysVars::validate() noexcept {
     return false;
   }
 
+  // Check if log file directory points to a valid file system directory or if
+  // it is left at the default setting (empty).
+  if (!SysVars::get_file_dir().empty() &&
+      !std::filesystem::is_directory(SysVars::get_file_dir())) {
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Invalid audit log filter file directory: %s",
+                    SysVars::get_file_dir().c_str());
+    return false;
+  }
+
   if (log_max_size_source == COMPILED && SysVars::get_log_prune_seconds() > 0) {
     // Clean default settings for max_size in case non-zero value for
     // prune_seconds is provided

--- a/plugin/audit_log_filter/tests/mtr/r/sys_var_audit_log_filter_file.result
+++ b/plugin/audit_log_filter/tests/mtr/r/sys_var_audit_log_filter_file.result
@@ -23,3 +23,5 @@ call mtr.add_suppression("Plugin audit_log_filter reported: 'Cannot open log wri
 call mtr.add_suppression("Plugin 'audit_log_filter' init function returned error");
 call mtr.add_suppression("Plugin 'audit_log_filter' registration as a AUDIT failed");
 # restart: --audit-log-filter-file=/audit_log
+call mtr.add_suppression("Plugin audit_log_filter reported: 'Invalid audit log filter file directory: /non_existent_dir'");
+# restart: --audit-log-filter-file=/non_existent_dir/audit_log

--- a/plugin/audit_log_filter/tests/mtr/t/sys_var_audit_log_filter_file.test
+++ b/plugin/audit_log_filter/tests/mtr/t/sys_var_audit_log_filter_file.test
@@ -45,4 +45,9 @@ call mtr.add_suppression("Plugin 'audit_log_filter' registration as a AUDIT fail
 --let $restart_parameters="restart: --audit-log-filter-file='/audit_log'"
 --source include/restart_mysqld.inc
 
+# Non-existent log file directory, should not crash
+call mtr.add_suppression("Plugin audit_log_filter reported: 'Invalid audit log filter file directory: /non_existent_dir'");
+--let $restart_parameters="restart: --audit-log-filter-file='/non_existent_dir/audit_log'"
+--source include/restart_mysqld.inc
+
 --source audit_tables_cleanup.inc


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9828

Fixed crash occuring in Audit Log Filter initialization step when `audit_log_filter_file` was pointing to a file located in a non-existent directory.