### PR TITLE
PS-10378 : enable limit optimization for single-token searches in Boolean mode

### DIFF
--- a/plugin/fulltext/mecab_parser/plugin_mecab.cc
+++ b/plugin/fulltext/mecab_parser/plugin_mecab.cc
@@ -207,6 +207,9 @@ static int mecab_parse(MeCab::Lattice *mecab_lattice,
   if (param->mode == MYSQL_FTPARSER_FULL_BOOLEAN_INFO) {
     for (const MeCab::Node *node = mecab_lattice->bos_node(); node != nullptr;
          node = node->next) {
+      if (node->stat == MECAB_BOS_NODE || node->stat == MECAB_EOS_NODE) {
+        continue;
+      }
       token_num += 1;
     }
 


### PR DESCRIPTION
## Problem
In the MeCab parser, the limit optimization is not applied to Boolean mode searches even when the search term consists of a single token.

## Root Cause Analysis
The issue originates from the mecab_parse() function in plugin_mecab.cc when handling Boolean mode (MYSQL_FTPARSER_FULL_BOOLEAN_INFO):

Token Counting Logic (lines 207-214):
The parser iterates through the mecab_lattice starting from bos_node() to count nodes.
The existing code incorrectly includes BOS (Beginning of Sentence) and EOS (End of Sentence) nodes in the total token_num.

Phrase Conversion Condition (lines 217-227):
If token_num > 1, the search term is converted into a phrase search (FT_TOKEN_LEFT_PAREN).

## Impact:
Even for a single-token search, the inclusion of BOS and EOS nodes results in a token_num of at least 3.
This forces all searches to be treated as phrase searches, which requires maintaining positional information and subsequently disables limit optimization.

## Changes
Modified the token counting loop to exclude BOS and EOS nodes:
This ensures token_num reflects the actual number of meaningful tokens.

## Expected Effects
Prevention of unnecessary phrase conversion for single-token searches.
Performance improvement by enabling limit optimization for single-token queries in Boolean mode.