### PR TITLE
PS-9828 [8.4]: Fixed crash for non-existent `audit_log_filter_file` directory paths

### DIFF
--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -823,6 +823,15 @@ bool SysVars::validate() noexcept {
     return false;
   }
 
+  // Check if log file directory points to a valid file system directory or if
+  // it is left at the default setting (empty).
+  if (!SysVars::get_file_dir().empty() &&
+      !std::filesystem::is_directory(SysVars::get_file_dir())) {
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY,
+                    SysVars::get_file_dir().c_str());
+    return false;
+  }
+
   if (log_max_size_source == COMPILED && SysVars::get_log_prune_seconds() > 0) {
     // Clean default settings for max_size in case non-zero value for
     // prune_seconds is provided

--- a/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_file.result
+++ b/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_file.result
@@ -22,3 +22,5 @@ SELECT @@global.audit_log_filter.file;
 call mtr.add_suppression("Component audit_log_filter reported: 'Cannot open log writer, error: Permission denied'");
 call mtr.add_suppression("Initialization method provided by component 'component_audit_log_filter' failed");
 # restart: --audit-log-filter.file=/audit_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Invalid audit log filter file directory: /non_existent_dir'");
+# restart: --audit-log-filter.file=/non_existent_dir/audit_log

--- a/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_file.test
+++ b/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_file.test
@@ -46,4 +46,9 @@ call mtr.add_suppression("Initialization method provided by component 'component
 --let $restart_parameters="restart: --audit-log-filter.file='/audit_log'"
 --source include/restart_mysqld.inc
 
+# Non-existent log file directory, should not crash
+call mtr.add_suppression("Component audit_log_filter reported: 'Invalid audit log filter file directory: /non_existent_dir'");
+--let $restart_parameters="restart: --audit-log-filter.file='/non_existent_dir/audit_log'"
+--source include/restart_mysqld.inc
+
 --source ../inc/audit_tables_cleanup.inc

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13185,6 +13185,9 @@ ER_SSL_FIPS_MODE_ENABLED
 ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_TYPE
   eng "Wrong JSON filter '%s' format, the 'log' field must be of bool or object type"
 
+ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY
+  eng "Invalid audit log filter file directory: %s"
+
 #
 # End of Percona Server 8.0 server error log messages
 #


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9828

Fixed crash occuring in Audit Log Filter initialization step when `audit_log_filter_file` was pointing to a file located in a non-existent directory.