### PR TITLE
PS-10332 [8.4]: Fixed Audit Log Filter crash caused by incorrect config settings

### DIFF
--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -742,7 +742,6 @@ bool SysVars::init() noexcept {
 
   if (status_var_registration_srv->register_variable(status_vars) == 1) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_STATUS_VAR_REGISTER_FAILURE);
-    SysVars::deinit();
     return false;
   }
 
@@ -753,7 +752,6 @@ bool SysVars::init() noexcept {
             var.first.check_arg, var.first.variable_value) == 1) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_SYS_VAR_REGISTER_FAILURE,
                       kCompName.data(), var.first.name);
-      SysVars::deinit();
       return false;
     }
 

--- a/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_compression.result
+++ b/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_compression.result
@@ -7,6 +7,11 @@ NONE
 SELECT @@global.audit_log_filter.compression;
 @@global.audit_log_filter.compression
 GZIP
+call mtr.add_suppression("Error while setting value 'invalid-value' to 'audit-log-filter.compression'");
+call mtr.add_suppression("Parsing options for variable 'compression' failed");
+call mtr.add_suppression("Component audit_log_filter reported: 'Failed to register audit_log_filter.compression system variable'");
+call mtr.add_suppression("Initialization method provided by component 'component_audit_log_filter' failed");
+# restart: --loose-audit-log-filter.compression=invalid-value
 # restart:
 SELECT @@global.audit_log_filter.compression;
 @@global.audit_log_filter.compression

--- a/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_compression.test
+++ b/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_compression.test
@@ -10,6 +10,14 @@ SELECT @@global.audit_log_filter.compression;
 --source include/restart_mysqld.inc
 SELECT @@global.audit_log_filter.compression;
 
+# Invalid compression setting, should not crash
+call mtr.add_suppression("Error while setting value 'invalid-value' to 'audit-log-filter.compression'");
+call mtr.add_suppression("Parsing options for variable 'compression' failed");
+call mtr.add_suppression("Component audit_log_filter reported: 'Failed to register audit_log_filter.compression system variable'");
+call mtr.add_suppression("Initialization method provided by component 'component_audit_log_filter' failed");
+--let $restart_parameters="restart: --loose-audit-log-filter.compression='invalid-value'"
+--source include/restart_mysqld.inc
+
 # Restart with original value
 --let $restart_parameters="restart:"
 --source include/restart_mysqld.inc


### PR DESCRIPTION
Passing invalid config setting or command-line parameter was causing Audit Log Filter to crash in settings validation stage. Validation failure caused unnecessary `SysVars::deinit` call. This led to `SysVars::deinit` being called twice, which in trun caused double-freeing of memory in the second call to `Mysql_thd_store_service_imp::unregister_slot`.

The problem was fixed by removing all `SysVars::deinit` calls from `SysVars::init` function. They were unnecessary, because `SysVars::deinit` is always called by `comp_scope_guard` in `audit_log_filter_init` function, regardless of whether `SysVars::init` succeeds or fails.