### PR TITLE
PS-10383 [8.4] Fix: ensure performs phrase search in BOOLEAN MODE with h Mecab plugin

### DIFF
--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_mecab_ewc_on.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_mecab_ewc_on.result
@@ -125,7 +125,6 @@ include/assert.inc [number of records for the special string containing '%' is e
 *** mode: "NATURAL LANGUAGE", pattern: "abc%", expected result: 0, result: 1
 *** mode: "NATURAL LANGUAGE", pattern: "%def", expected result: 0, result: 1
 *** mode: "NATURAL LANGUAGE", pattern: "zabc%def", expected result: 0, result: 1
-*** mode: "BOOLEAN", pattern: "abc%def", expected result: 0, result: 1
 *** mode: "BOOLEAN", pattern: "abc%", expected result: 0, result: 1
 *** mode: "BOOLEAN", pattern: "%def", expected result: 0, result: 1
 include/assert.inc [number of records for the special string containing '&' is expected to be 2]

--- a/plugin/fulltext/mecab_parser/plugin_mecab.cc
+++ b/plugin/fulltext/mecab_parser/plugin_mecab.cc
@@ -235,9 +235,12 @@ static int mecab_parse(MeCab::Lattice *mecab_lattice,
       bool_info->position = position;
       position += node->rlength;
 
-      param->mysql_add_word(param, const_cast<char *>(node->surface),
+      ret = param->mysql_add_word(param, const_cast<char *>(node->surface),
                             node->length,
                             term_converted ? &token_info : bool_info);
+      if (ret != 0) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
Fix: ensure performs phrase search in BOOLEAN MODE with h Mecab plugin (korean)

https://perconadev.atlassian.net/browse/PS-10383

In the MeCab full-text parser documentation, it is described that:

In NATURAL LANGUAGE MODE, the search term is converted into a union of tokens. In BOOLEAN MODE, the search term is converted into a search phrase. However, when using the MeCab plugin, phrase search behavior in BOOLEAN MODE was not enforced correctly: rows were returned even when extra tokens existed between phrase tokens. Please see tiket description and original PR at
https://github.com/percona/percona-server/pull/5788

This fix checks treturned value of mysql_add_word() function and returns from caller if function fails. The test result for innodb_fts.percona_ft_special_chars_mecab_ewc_on is updated accodingly.

Original fix was provided at https://github.com/percona/percona-server/pull/5788 by kakao-jenna-me