### PR TITLE
PS-10545 [8.0]: Fix MTR `--only-big-test` skipping tests with both `big_test.inc` and `no_valgrind_without_big.inc`

### DIFF
--- a/mysql-test/lib/mtr_cases.pm
+++ b/mysql-test/lib/mtr_cases.pm
@@ -1317,7 +1317,7 @@ sub collect_one_test_case {
   # only-big-test option.
   if ($::opt_only_big_test) {
     if ((!$tinfo->{'no_valgrind_without_big'} and !$tinfo->{'big_test'}) or
-        ($tinfo->{'no_valgrind_without_big'} and !$::opt_valgrind)) {
+        ($tinfo->{'no_valgrind_without_big'} and !$tinfo->{'big_test'} and !$::opt_valgrind)) {
       skip_test($tinfo, "Not a big test");
       return $tinfo;
     }


### PR DESCRIPTION
The `--only-big-test` skip condition in `mtr_cases.pm` did not account for tests that include both `big_test.inc` and `no_valgrind_without_big.inc`. The second branch of the condition skipped any test with `no_valgrind_without_big` when valgrind was not active, regardless of whether the test was also marked as a big test. This made 89 tests (across encryption, innodb, component_keyring_*, rpl, and other suites) impossible to run with `--only-big-test` outside of valgrind.

Add `!$tinfo->{'big_test'}` check to the second branch so that tests genuinely marked as big are never incorrectly skipped.