### PR TITLE
PS-10591 [8.4]: Assertion in create_digest() for XOF algorithms (SHAKE128/SHAKE256)

### DIFF
--- a/extra/opensslpp/src/opensslpp/digest_context.cpp
+++ b/extra/opensslpp/src/opensslpp/digest_context.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <openssl/evp.h>
+#include <openssl/obj_mac.h>
 
 #include <opensslpp/digest_context.hpp>
 
@@ -27,6 +28,21 @@
 #include "opensslpp/digest_context_accessor.hpp"
 
 namespace opensslpp {
+
+#ifdef EVP_MD_FLAG_XOF
+static std::size_t get_xof_output_length(const EVP_MD *md
+                                         [[maybe_unused]]) noexcept {
+#if defined(NID_shake128) && defined(NID_shake256)
+  constexpr std::size_t kShake128DefaultDigestSize = 16;
+  constexpr std::size_t kShake256DefaultDigestSize = 32;
+
+  auto md_type = EVP_MD_type(md);
+  if (md_type == NID_shake128) return kShake128DefaultDigestSize;
+  if (md_type == NID_shake256) return kShake256DefaultDigestSize;
+#endif
+  return 0;
+}
+#endif
 
 void digest_context::digest_context_deleter::operator()(
     void *dc) const noexcept {
@@ -70,7 +86,19 @@ void digest_context::swap(digest_context &obj) noexcept {
 std::size_t digest_context::get_size_in_bytes() const noexcept {
   assert(!is_empty());
 
-  return EVP_MD_CTX_size(digest_context_accessor::get_impl(*this));
+  auto *ctx = digest_context_accessor::get_impl_const_casted(*this);
+  auto size = EVP_MD_CTX_size(ctx);
+  if (size > 0) return static_cast<std::size_t>(size);
+
+#ifdef EVP_MD_FLAG_XOF
+  const auto *md = EVP_MD_CTX_md(ctx);
+  if (md != nullptr && (EVP_MD_flags(md) & EVP_MD_FLAG_XOF)) {
+    auto xof_len = get_xof_output_length(md);
+    if (xof_len > 0) return xof_len;
+  }
+#endif
+
+  return 0;
 }
 
 void digest_context::update(std::string_view data) {
@@ -83,13 +111,30 @@ void digest_context::update(std::string_view data) {
 std::string digest_context::finalize() {
   assert(!is_empty());
 
-  auto digest_size = EVP_MD_CTX_size(digest_context_accessor::get_impl(*this));
+  auto *ctx = digest_context_accessor::get_impl(*this);
+
+#ifdef EVP_MD_FLAG_XOF
+  const auto *md = EVP_MD_CTX_md(ctx);
+  if (md != nullptr && (EVP_MD_flags(md) & EVP_MD_FLAG_XOF)) {
+    auto xof_len = get_xof_output_length(md);
+    if (xof_len == 0) throw core_error{"cannot determine XOF output length"};
+
+    std::string res(xof_len, '\0');
+    if (EVP_DigestFinalXOF(ctx, reinterpret_cast<unsigned char *>(res.data()),
+                           xof_len) == 0)
+      throw core_error{"cannot finalize XOF digest context"};
+
+    digest_context_accessor::set_impl(*this, nullptr);
+    return res;
+  }
+#endif
+
+  auto digest_size = EVP_MD_CTX_size(ctx);
   assert(digest_size > 0 && digest_size <= EVP_MAX_MD_SIZE);
   std::string res(static_cast<std::size_t>(digest_size), '\0');
 
   unsigned int res_size = 0;
-  if (EVP_DigestFinal_ex(digest_context_accessor::get_impl(*this),
-                         reinterpret_cast<unsigned char *>(res.data()),
+  if (EVP_DigestFinal_ex(ctx, reinterpret_cast<unsigned char *>(res.data()),
                          &res_size) == 0)
     throw core_error{"cannot finalize digest context"};
   assert(res_size == res.size());


### PR DESCRIPTION
SHAKE128 and SHAKE256 are XOF (extendable-output function) digest algorithms with no fixed output size, causing EVP_MD_CTX_size() to return 0. This triggered an assertion failure in digest_context::finalize() and undefined behavior in release builds.

Handle XOF algorithms by detecting EVP_MD_FLAG_XOF and using EVP_DigestFinalXOF() with the output length queried from the provider derived from the Keccak block size. Also fix get_size_in_bytes() to return the correct size for XOF digests.