### PR TITLE
PS-10231 [9.x]: Fix DBLWR recovery tests for compressed+encrypted pages

### DIFF
--- a/mysql-test/suite/innodb/r/dblwr_lz4_encrypt_recv.result
+++ b/mysql-test/suite/innodb/r/dblwr_lz4_encrypt_recv.result
@@ -18,9 +18,15 @@ INSERT INTO t1 VALUES(3, repeat('/',12));
 INSERT INTO t1 VALUES(4, repeat('-',12));
 INSERT INTO t1 VALUES(5, repeat('.',12));
 COMMIT WORK;
+# Wait for purge to complete
+SET GLOBAL innodb_monitor_enable = module_log;
 # Ensure that dirty pages of table t1 is flushed.
 FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
+SET GLOBAL innodb_master_thread_disabled_debug=1;
+SET GLOBAL innodb_checkpoint_disabled = 1;
+BEGIN;
+INSERT INTO t1 VALUES (6, repeat('%', 12));
 SET SESSION innodb_interpreter = 'init';
 SET SESSION innodb_interpreter = 'open_table test/t1';
 # Identify the space_id of the given table.
@@ -36,12 +42,16 @@ SELECT @@session.innodb_interpreter_output INTO @page_type;
 SELECT @page_type;
 @page_type
 FIL_PAGE_COMPRESSED_AND_ENCRYPTED
-SET SESSION innodb_interpreter = 'corrupt_ondisk_root_page test/t1';
+SET SESSION innodb_interpreter = 'find_tablespace_file_name test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_file_name;
+SET SESSION innodb_interpreter = 'find_tablespace_physical_page_size test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_page_size;
 SET SESSION innodb_interpreter = 'destroy';
-# Kill and restart: PLUGIN_DIR_OPT
-set global innodb_interpreter = 'init';
-set global innodb_interpreter = 'print_dblwr_has_encrypted_pages';
-set global innodb_interpreter = 'destroy';
+# Kill the server
+# Corrupt the root page of table t1 in the user tablespace.
+SET SESSION innodb_interpreter = 'init';
+SET SESSION innodb_interpreter = 'print_dblwr_has_encrypted_pages';
+SET SESSION innodb_interpreter = 'destroy';
 Pattern "Double write file has encrypted pages" found
 Pattern "\[Note\] \[MY-\d+\] \[InnoDB\] Recovered page \[page id: space=\d+, page number=\d+\] from the doublewrite buffer" found
 CHECK TABLE t1;

--- a/mysql-test/suite/innodb/r/dblwr_zlib_encrypt_recv.result
+++ b/mysql-test/suite/innodb/r/dblwr_zlib_encrypt_recv.result
@@ -18,9 +18,15 @@ INSERT INTO t1 VALUES(3, repeat('/',12));
 INSERT INTO t1 VALUES(4, repeat('-',12));
 INSERT INTO t1 VALUES(5, repeat('.',12));
 COMMIT WORK;
+# Wait for purge to complete
+SET GLOBAL innodb_monitor_enable = module_log;
 # Ensure that dirty pages of table t1 is flushed.
 FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
+SET GLOBAL innodb_master_thread_disabled_debug=1;
+SET GLOBAL innodb_checkpoint_disabled = 1;
+BEGIN;
+INSERT INTO t1 VALUES (6, repeat('%', 12));
 SET SESSION innodb_interpreter = 'init';
 SET SESSION innodb_interpreter = 'open_table test/t1';
 # Identify the space_id of the given table.
@@ -36,9 +42,13 @@ SELECT @@session.innodb_interpreter_output INTO @page_type;
 SELECT @page_type;
 @page_type
 FIL_PAGE_COMPRESSED_AND_ENCRYPTED
-SET SESSION innodb_interpreter = 'corrupt_ondisk_root_page test/t1';
+SET SESSION innodb_interpreter = 'find_tablespace_file_name test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_file_name;
+SET SESSION innodb_interpreter = 'find_tablespace_physical_page_size test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_page_size;
 SET SESSION innodb_interpreter = 'destroy';
-# Kill and restart: PLUGIN_DIR_OPT
+# Kill the server
+# Corrupt the root page of table t1 in the user tablespace.
 SET SESSION innodb_interpreter = 'init';
 SET SESSION innodb_interpreter = 'print_dblwr_has_encrypted_pages';
 SET SESSION innodb_interpreter = 'destroy';

--- a/mysql-test/suite/innodb/t/dblwr_lz4_encrypt_recv-master.opt
+++ b/mysql-test/suite/innodb/t/dblwr_lz4_encrypt_recv-master.opt
@@ -1,0 +1,3 @@
+--innodb_doublewrite_pages=512
+--innodb-buffer-pool-dump-at-shutdown=OFF
+--innodb-buffer-pool-load-at-startup=OFF

--- a/mysql-test/suite/innodb/t/dblwr_lz4_encrypt_recv.test
+++ b/mysql-test/suite/innodb/t/dblwr_lz4_encrypt_recv.test
@@ -21,9 +21,20 @@ INSERT INTO t1 VALUES(4, repeat('-',12));
 INSERT INTO t1 VALUES(5, repeat('.',12));
 COMMIT WORK;
 
+--echo # Wait for purge to complete
+--source include/wait_innodb_all_purged.inc
+
+SET GLOBAL innodb_monitor_enable = module_log;
+
 --echo # Ensure that dirty pages of table t1 is flushed.
 FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
+
+SET GLOBAL innodb_master_thread_disabled_debug=1;
+SET GLOBAL innodb_checkpoint_disabled = 1;
+
+BEGIN;
+INSERT INTO t1 VALUES (6, repeat('%', 12));
 
 SET SESSION innodb_interpreter = 'init';
 SET SESSION innodb_interpreter = 'open_table test/t1';
@@ -42,15 +53,35 @@ SET SESSION innodb_interpreter = @cmd;
 SELECT @@session.innodb_interpreter_output INTO @page_type;
 SELECT @page_type;
 
-SET SESSION innodb_interpreter = 'corrupt_ondisk_root_page test/t1';
+SET SESSION innodb_interpreter = 'find_tablespace_file_name test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_file_name;
+
+SET SESSION innodb_interpreter = 'find_tablespace_physical_page_size test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_page_size;
+
 SET SESSION innodb_interpreter = 'destroy';
 
---replace_result $PLUGIN_DIR_OPT PLUGIN_DIR_OPT
---source include/kill_and_restart_mysqld.inc
+let MYSQLD_DATADIR=`SELECT @@datadir`;
+let PAGE_NUM=`select @page_no`;
+let FILE_NAME=`select @space_file_name`;
+let INNODB_PAGE_SIZE=`select @space_page_size`;
 
-set global innodb_interpreter = 'init';
-set global innodb_interpreter = 'print_dblwr_has_encrypted_pages';
-set global innodb_interpreter = 'destroy';
+# Wait till generated REDOs are synced to disk
+--let $wait_condition = SELECT COUNT =(SELECT COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME = 'log_lsn_current')  FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME = 'log_lsn_last_flush'
+--source include/wait_condition.inc
+
+--source include/kill_mysqld.inc
+
+--echo # Corrupt the root page of table t1 in the user tablespace.
+--let IBD_FILE=$MYSQLD_DATADIR/$FILE_NAME
+--let ALL_ZEROES=1
+--source ../include/corrupt_page.inc
+
+--source include/start_mysqld_no_echo.inc
+
+SET SESSION innodb_interpreter = 'init';
+SET SESSION innodb_interpreter = 'print_dblwr_has_encrypted_pages';
+SET SESSION innodb_interpreter = 'destroy';
 
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
 let SEARCH_PATTERN= Double write file has encrypted pages;

--- a/mysql-test/suite/innodb/t/dblwr_zlib_encrypt_recv-master.opt
+++ b/mysql-test/suite/innodb/t/dblwr_zlib_encrypt_recv-master.opt
@@ -1,0 +1,3 @@
+--innodb_doublewrite_pages=512
+--innodb-buffer-pool-dump-at-shutdown=OFF
+--innodb-buffer-pool-load-at-startup=OFF

--- a/mysql-test/suite/innodb/t/dblwr_zlib_encrypt_recv.test
+++ b/mysql-test/suite/innodb/t/dblwr_zlib_encrypt_recv.test
@@ -21,9 +21,20 @@ INSERT INTO t1 VALUES(4, repeat('-',12));
 INSERT INTO t1 VALUES(5, repeat('.',12));
 COMMIT WORK;
 
+--echo # Wait for purge to complete
+--source include/wait_innodb_all_purged.inc
+
+SET GLOBAL innodb_monitor_enable = module_log;
+
 --echo # Ensure that dirty pages of table t1 is flushed.
 FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
+
+SET GLOBAL innodb_master_thread_disabled_debug=1;
+SET GLOBAL innodb_checkpoint_disabled = 1;
+
+BEGIN;
+INSERT INTO t1 VALUES (6, repeat('%', 12));
 
 SET SESSION innodb_interpreter = 'init';
 SET SESSION innodb_interpreter = 'open_table test/t1';
@@ -42,11 +53,31 @@ SET SESSION innodb_interpreter = @cmd;
 SELECT @@session.innodb_interpreter_output INTO @page_type;
 SELECT @page_type;
 
-SET SESSION innodb_interpreter = 'corrupt_ondisk_root_page test/t1';
+SET SESSION innodb_interpreter = 'find_tablespace_file_name test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_file_name;
+
+SET SESSION innodb_interpreter = 'find_tablespace_physical_page_size test/t1';
+SELECT @@session.innodb_interpreter_output INTO @space_page_size;
+
 SET SESSION innodb_interpreter = 'destroy';
 
---replace_result $PLUGIN_DIR_OPT PLUGIN_DIR_OPT
---source include/kill_and_restart_mysqld.inc
+let MYSQLD_DATADIR=`SELECT @@datadir`;
+let PAGE_NUM=`select @page_no`;
+let FILE_NAME=`select @space_file_name`;
+let INNODB_PAGE_SIZE=`select @space_page_size`;
+
+# Wait till generated REDOs are synced to disk
+--let $wait_condition = SELECT COUNT =(SELECT COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME = 'log_lsn_current')  FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME = 'log_lsn_last_flush'
+--source include/wait_condition.inc
+
+--source include/kill_mysqld.inc
+
+--echo # Corrupt the root page of table t1 in the user tablespace.
+--let IBD_FILE=$MYSQLD_DATADIR/$FILE_NAME
+--let ALL_ZEROES=1
+--source ../include/corrupt_page.inc
+
+--source include/start_mysqld_no_echo.inc
 
 SET SESSION innodb_interpreter = 'init';
 SET SESSION innodb_interpreter = 'print_dblwr_has_encrypted_pages';


### PR DESCRIPTION
The `innodb.dblwr_lz4_encrypt_recv` and `innodb.dblwr_zlib_encrypt_recv tests` were failing because the DBLWR copy of the test table's root page was being overwritten by background flush activity (undo purge, system tablespace) between FLUSH TABLES FOR EXPORT and SIGKILL. This race became more likely after `Bug#37684656` reduced the DBLWR buffer size.

Additionally, without pending redo records for the test tablespace after checkpoint, crash recovery never opened it, so the per-space DBLWR recovery path never executed.

Restructure both tests to follow the robust pattern used by `innodb.dblwr_encrypt_recover`:
- Wait for purge to complete before flushing
- Disable master thread and checkpoint after flush to prevent background DBLWR slot reuse
- Perform an uncommitted INSERT to generate pending redo records, ensuring the tablespace is opened during crash recovery
- Kill the server first, then corrupt the page externally while the server is down (guaranteeing the DBLWR copy survives)
- Zero the entire page (ALL_ZEROES=1) because for compressed pages with punch hole, the second half is already zeros so partial corruption has no effect
- Add master.opt with `--innodb_doublewrite_pages=512` for extra margin