### PR TITLE
PS-10378 [9.x] fix korean mecab optimization: exclude bos/eos node from token counting

### DIFF
--- a/plugin/fulltext/mecab_parser/plugin_mecab.cc
+++ b/plugin/fulltext/mecab_parser/plugin_mecab.cc
@@ -207,6 +207,9 @@ static int mecab_parse(MeCab::Lattice *mecab_lattice,
   if (param->mode == MYSQL_FTPARSER_FULL_BOOLEAN_INFO) {
     for (const MeCab::Node *node = mecab_lattice->bos_node(); node != nullptr;
          node = node->next) {
+      if (node->stat == MECAB_BOS_NODE || node->stat == MECAB_EOS_NODE) {
+        continue;
+      }
       token_num += 1;
     }
 


### PR DESCRIPTION
fix korean mecab optimization: exclude bos/eos node from token counting

https://perconadev.atlassian.net/browse/PS-10378

This fix is provided by customer at: https://github.com/percona/percona-server/pull/5820

Please refer the Jira ticket and GitHub PR for details. In short, it fixes handling Boolean mode in mecab_parse() function in plugin_mecab.cc. It modified the token counting loop to exclude BOS and EOS nodes. This ensures token_num reflects the actual number of meaningful tokens.