### PR TITLE
PS-10593 [8.0]: Fix audit_log buffer overrun in audit_log_general_record

### DIFF
--- a/plugin/audit_log/audit_log.cc
+++ b/plugin/audit_log/audit_log.cc
@@ -540,7 +540,8 @@ static char *audit_log_general_record(char *buf, size_t buflen,
                      strlen(name) + event.general_sql_command.length +
                      20 + /* general_thread_id */
                      20 + /* status */
-                     MAX_RECORD_ID_SIZE + MAX_TIMESTAMP_SIZE;
+                     MAX_RECORD_ID_SIZE + MAX_TIMESTAMP_SIZE +
+                     static_cast<size_t>(endptr - buf);
   if (buflen_estimated > buflen) {
     *outlen = buflen_estimated;
     return NULL;

--- a/plugin/audit_log/tests/mtr/audit_log_general_record_overflow-master.opt
+++ b/plugin/audit_log/tests/mtr/audit_log_general_record_overflow-master.opt
@@ -1,0 +1,3 @@
+--audit_log_file=test_audit.log
+--audit_log_format=OLD
+--audit_log_strategy=SYNCHRONOUS

--- a/plugin/audit_log/tests/mtr/audit_log_general_record_overflow.result
+++ b/plugin/audit_log/tests/mtr/audit_log_general_record_overflow.result
@@ -1,0 +1,11 @@
+#
+# PS-10593: audit_log plugin segfaults on memcpy
+# https://perconadev.atlassian.net/browse/PS-10593
+#
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
+SELECT 'Server alive after escaped query' as status;
+status
+Server alive after escaped query
+SET GLOBAL audit_log_flush=ON;
+Escaped ampersands found: Ok

--- a/plugin/audit_log/tests/mtr/audit_log_general_record_overflow.test
+++ b/plugin/audit_log/tests/mtr/audit_log_general_record_overflow.test
@@ -1,0 +1,51 @@
+# Test that audit_log_general_record correctly handles queries with characters
+# that expand significantly during XML escaping, so the escaped scratch area
+# plus the snprintf output exceed the 4096-byte stack buffer.
+#
+# Each '&' expands to '&amp;' (5x) in OLD XML format. With 500 '&' characters
+# in a ~510 byte query, the escaped query is ~2500 bytes. The scratch area
+# (raw query + escaped strings) plus the snprintf output (which re-includes
+# the escaped strings) would total ~5800 bytes, exceeding the 4096-byte buffer.
+# Without the fix, this crashes (RelWithDebInfo) or triggers (Debug):
+#   Assertion `endptr + *outlen <= buf + buflen' failed.
+
+--echo #
+--echo # PS-10593: audit_log plugin segfaults on memcpy
+--echo # https://perconadev.atlassian.net/browse/PS-10593
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+let MYSQLD_DATADIR= $MYSQLD_DATADIR;
+
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
+--disable_query_log
+--disable_result_log
+let $amp_str= `SELECT REPEAT('&', 500)`;
+eval SELECT '$amp_str';
+--enable_result_log
+--enable_query_log
+
+SELECT 'Server alive after escaped query' as status;
+
+--move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_overflow.log
+SET GLOBAL audit_log_flush=ON;
+
+perl;
+  my $log_file = "$ENV{MYSQLD_DATADIR}/test_audit_overflow.log";
+  open(my $fh, "<", $log_file) or die "Can't open $log_file: $!";
+  my $content = do { local $/; <$fh> };
+  close($fh);
+
+  my $count = () = $content =~ /&amp;/g;
+  if ($count >= 500) {
+    print "Escaped ampersands found: Ok\n";
+  } else {
+    print "Expected >= 500 escaped ampersands, found $count\n";
+  }
+EOF
+
+--remove_file $MYSQLD_DATADIR/test_audit_overflow.log
+--remove_file $MYSQLD_DATADIR/test_audit.log


### PR DESCRIPTION
The buffer size check compared buflen_estimated against the total buffer size, but snprintf writes starting at endptr (past the scratch area where escaped strings are stored), so only buflen - (endptr - buf) bytes are actually available. When escaped strings are large enough, the snprintf output overflows the remaining space, triggering the assertion `endptr + *outlen <= buf + buflen`.

Account for the scratch area by adding (endptr - buf) to buflen_estimated, ensuring the caller allocates a buffer large enough for both the escaped string storage and the formatted output.