### PR TITLE
PS-10589 [8.0]: Add clang-21, clang-22, gcc-15 to Azure Pipelines + fix clang-22 compilation issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,37 +91,68 @@ jobs:
 
 
       # clang-12 and newer compilers
-      clang-20 RelWithDebInfo [Ubuntu 24.04 Noble]:
+      clang-22 RelWithDebInfo [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         UBUNTU_CODE_NAME: noble
         Compiler: clang
-        CompilerVer: 20
+        CompilerVer: 22
         BuildType: RelWithDebInfo
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-20 RelWithDebInfo INVERTED [Ubuntu 24.04 Noble]:
+        clang-22 RelWithDebInfo INVERTED [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 22
+          BuildType: RelWithDebInfo
+          BUILD_PARAMS_TYPE: inverted
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-22 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 22
+          BuildType: Debug
+
+      clang-22 Debug INVERTED [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        UBUNTU_CODE_NAME: noble
+        Compiler: clang
+        CompilerVer: 22
+        BuildType: Debug
+        BUILD_PARAMS_TYPE: inverted
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-21 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 21
+          BuildType: RelWithDebInfo
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-21 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 21
+          BuildType: Debug
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-20 RelWithDebInfo [Ubuntu 24.04 Noble]:
           imageName: 'ubuntu-24.04'
           UBUNTU_CODE_NAME: noble
           Compiler: clang
           CompilerVer: 20
           BuildType: RelWithDebInfo
-          BUILD_PARAMS_TYPE: inverted
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-20 Debug [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 20
-          BuildType: Debug
-
-      clang-20 Debug INVERTED [Ubuntu 24.04 Noble]:
+      clang-20 Debug [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         UBUNTU_CODE_NAME: noble
         Compiler: clang
         CompilerVer: 20
         BuildType: Debug
-        BUILD_PARAMS_TYPE: inverted
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-19 RelWithDebInfo [Ubuntu 24.04 Noble]:
@@ -237,17 +268,31 @@ jobs:
 
 
       # gcc-9 and newer compilers
-      gcc-14 RelWithDebInfo [Ubuntu 24.04 Noble]:
+      gcc-15 RelWithDebInfo [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         Compiler: gcc
-        CompilerVer: 14
+        CompilerVer: 15
         BuildType: RelWithDebInfo
 
-      gcc-14 Debug [Ubuntu 24.04 Noble]:
+      gcc-15 Debug [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         Compiler: gcc
-        CompilerVer: 14
+        CompilerVer: 15
         BuildType: Debug
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        gcc-14 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 14
+          BuildType: RelWithDebInfo
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        gcc-14 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 14
+          BuildType: Debug
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         gcc-13 RelWithDebInfo [Ubuntu 22.04 Jammy]:

--- a/components/test/test_mysql_command_services.cc
+++ b/components/test/test_mysql_command_services.cc
@@ -229,6 +229,7 @@ static char *test_mysql_command_services_apis_udf(UDF_INIT *, UDF_ARGS *args,
   uint64_t row_count = 0;
   unsigned int num_column = 0;
   std::string result_set;
+  void *option_val = nullptr;
 
   //  Execute the SQL specified in the argument.
   if (cmd_factory_srv->init(&mysql_h)) {
@@ -261,7 +262,6 @@ static char *test_mysql_command_services_apis_udf(UDF_INIT *, UDF_ARGS *args,
   }
 
   /* To get the mysql option value */
-  void *option_val;
   cmd_options_srv->get(mysql_h, MYSQL_OPT_MAX_ALLOWED_PACKET, &option_val);
 
   {

--- a/include/mysql/psi/mysql_file.h
+++ b/include/mysql/psi/mysql_file.h
@@ -526,7 +526,7 @@ static inline char *inline_mysql_file_fgets(
     char *str, int size, MYSQL_FILE *file) {
   char *result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_READ);
@@ -549,7 +549,7 @@ static inline int inline_mysql_file_fgetc(
     MYSQL_FILE *file) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_READ);
@@ -572,7 +572,7 @@ static inline int inline_mysql_file_fputs(
     const char *str, MYSQL_FILE *file) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
@@ -597,7 +597,7 @@ static inline int inline_mysql_file_fputc(
     char c, MYSQL_FILE *file) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_WRITE);
@@ -625,7 +625,7 @@ static inline int inline_mysql_file_fprintf(MYSQL_FILE *file,
   int result;
   va_list args;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_WRITE);
@@ -663,7 +663,7 @@ static inline int inline_mysql_file_vfprintf(
     MYSQL_FILE *file, const char *format, va_list args) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_WRITE);
@@ -686,7 +686,7 @@ static inline int inline_mysql_file_fflush(
     MYSQL_FILE *file) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_FLUSH);
@@ -714,7 +714,7 @@ static inline int inline_mysql_file_fstat(
     int filenr, MY_STAT *stat_area) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, filenr,
                                                             PSI_FILE_FSTAT);
@@ -737,7 +737,7 @@ static inline MY_STAT *inline_mysql_file_stat(
     const char *path, MY_STAT *stat_area, myf flags) {
   MY_STAT *result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_STAT, path, &locker);
@@ -760,7 +760,7 @@ static inline int inline_mysql_file_chsize(
     File file, my_off_t newlength, int filler, myf flags) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
                                                             PSI_FILE_CHSIZE);
@@ -787,7 +787,7 @@ static inline MYSQL_FILE *inline_mysql_file_fopen(
                                  MYF(MY_WME));
   if (likely(that != nullptr)) {
 #ifdef HAVE_PSI_FILE_INTERFACE
-    struct PSI_file_locker *locker;
+    struct PSI_file_locker *locker = nullptr;
     PSI_file_locker_state state;
     locker = PSI_FILE_CALL(get_thread_file_name_locker)(
         &state, key, PSI_FILE_STREAM_OPEN, filename, that);
@@ -822,7 +822,7 @@ static inline int inline_mysql_file_fclose(
   int result = 0;
   if (likely(file != nullptr)) {
 #ifdef HAVE_PSI_FILE_INTERFACE
-    struct PSI_file_locker *locker;
+    struct PSI_file_locker *locker = nullptr;
     PSI_file_locker_state state;
     locker = PSI_FILE_CALL(get_thread_file_stream_locker)(
         &state, file->m_psi, PSI_FILE_STREAM_CLOSE);
@@ -848,7 +848,7 @@ static inline size_t inline_mysql_file_fread(
     MYSQL_FILE *file, uchar *buffer, size_t count, myf flags) {
   size_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes_read;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
@@ -877,7 +877,7 @@ static inline size_t inline_mysql_file_fwrite(
     MYSQL_FILE *file, const uchar *buffer, size_t count, myf flags) {
   size_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes_written;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
@@ -906,7 +906,7 @@ static inline my_off_t inline_mysql_file_fseek(
     MYSQL_FILE *file, my_off_t pos, int whence) {
   my_off_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_SEEK);
@@ -929,7 +929,7 @@ static inline my_off_t inline_mysql_file_ftell(
     MYSQL_FILE *file) {
   my_off_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_stream_locker)(&state, file->m_psi,
                                                         PSI_FILE_TELL);
@@ -952,7 +952,7 @@ static inline File inline_mysql_file_create(
     const char *filename, int create_flags, int access_flags, myf myFlags) {
   File file;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_CREATE, filename, &locker);
@@ -976,7 +976,7 @@ static inline File inline_mysql_file_create_temp(
     UnlinkOrKeepFile unlink_or_keep, myf myFlags) {
   File file;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_CREATE, nullptr, &locker);
@@ -1001,7 +1001,7 @@ static inline File inline_mysql_file_open(
     const char *filename, int flags, myf myFlags) {
   File file;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_OPEN, filename, &locker);
@@ -1025,7 +1025,7 @@ static inline File inline_mysql_unix_socket_connect(
     const char *filename, myf myFlags) {
   File file;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_OPEN, filename, &locker);
@@ -1048,7 +1048,7 @@ static inline int inline_mysql_file_close(
     File file, myf flags) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
                                                             PSI_FILE_CLOSE);
@@ -1071,7 +1071,7 @@ static inline size_t inline_mysql_file_read(
     File file, uchar *buffer, size_t count, myf flags) {
   size_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes_read;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
@@ -1100,7 +1100,7 @@ static inline size_t inline_mysql_file_write(
     File file, const uchar *buffer, size_t count, myf flags) {
   size_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes_written;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
@@ -1129,7 +1129,7 @@ static inline size_t inline_mysql_file_pread(
     File file, uchar *buffer, size_t count, my_off_t offset, myf flags) {
   size_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes_read;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
@@ -1158,7 +1158,7 @@ static inline size_t inline_mysql_file_pwrite(
     File file, const uchar *buffer, size_t count, my_off_t offset, myf flags) {
   size_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   size_t bytes_written;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
@@ -1187,7 +1187,7 @@ static inline my_off_t inline_mysql_file_seek(
     File file, my_off_t pos, int whence, myf flags) {
   my_off_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
                                                             PSI_FILE_SEEK);
@@ -1210,7 +1210,7 @@ static inline my_off_t inline_mysql_file_tell(
     File file, myf flags) {
   my_off_t result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, file,
                                                             PSI_FILE_TELL);
@@ -1233,7 +1233,7 @@ static inline int inline_mysql_file_delete(
     const char *name, myf flags) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_DELETE, name, &locker);
@@ -1256,7 +1256,7 @@ static inline int inline_mysql_file_rename(
     const char *from, const char *to, myf flags) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_RENAME, from, &locker);
@@ -1281,7 +1281,7 @@ static inline File inline_mysql_file_create_with_symlink(
     int access_flags, myf flags) {
   File file;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_CREATE, filename, &locker);
@@ -1306,7 +1306,7 @@ static inline int inline_mysql_file_delete_with_symlink(
     const char *name, myf flags) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_DELETE, name, &locker);
@@ -1329,7 +1329,7 @@ static inline int inline_mysql_file_rename_with_symlink(
     const char *from, const char *to, myf flags) {
   int result;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_name_locker)(
       &state, key, PSI_FILE_RENAME, from, &locker);
@@ -1353,7 +1353,7 @@ static inline int inline_mysql_file_sync(
     File fd, myf flags) {
   int result = 0;
 #ifdef HAVE_PSI_FILE_INTERFACE
-  struct PSI_file_locker *locker;
+  struct PSI_file_locker *locker = nullptr;
   PSI_file_locker_state state;
   locker = PSI_FILE_CALL(get_thread_file_descriptor_locker)(&state, fd,
                                                             PSI_FILE_SYNC);

--- a/plugin/group_replication/libmysqlgcs/CMakeLists.txt
+++ b/plugin/group_replication/libmysqlgcs/CMakeLists.txt
@@ -149,6 +149,9 @@ IF(MY_COMPILER_IS_CLANG)
   ADD_COMPILE_FLAGS(${XCOM_SOURCES}
     COMPILE_FLAGS
     "-Wno-conditional-uninitialized")
+  ADD_COMPILE_FLAGS(${GCS_SOURCES}
+    COMPILE_FLAGS
+    "-Wno-missing-format-attribute")
 ENDIF()
 
 # disabling warnings for generated code

--- a/plugin/group_replication/libmysqlgcs/include/mysql/gcs/gcs_logging_system.h
+++ b/plugin/group_replication/libmysqlgcs/include/mysql/gcs/gcs_logging_system.h
@@ -626,6 +626,10 @@ class Gcs_default_debugger {
      @param [in] args Arguments This includes the c-style string and arguments
      to fill it in
     */
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
   template <typename... Args>
   inline void log_event(const int64_t options, Args... args) {
     if (Gcs_debug_options::test_debug_options(options)) {
@@ -643,6 +647,9 @@ class Gcs_default_debugger {
       notify_entry(event);
     }
   }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
  private:
   /**

--- a/plugin/innodb_memcached/daemon_memcached/include/memcached/util.h
+++ b/plugin/innodb_memcached/daemon_memcached/include/memcached/util.h
@@ -34,7 +34,7 @@ MEMCACHED_PUBLIC_API extern uint64_t htonll(uint64_t);
 MEMCACHED_PUBLIC_API extern uint64_t ntohll(uint64_t);
 #endif
 
-#ifdef __GCC
+#if defined(__GNUC__) || defined(__clang__)
 # define __gcc_attribute__ __attribute__
 #else
 # define __gcc_attribute__(x)

--- a/plugin/innodb_memcached/daemon_memcached/utilities/extension_loggers.c
+++ b/plugin/innodb_memcached/daemon_memcached/utilities/extension_loggers.c
@@ -16,6 +16,10 @@ static const char *stderror_get_name(void) {
 static void stderror_logger_log(EXTENSION_LOG_LEVEL severity,
                                 const void* client_cookie,
                                 const char *fmt, ...)
+    __attribute__((format(printf, 3, 4)));
+static void stderror_logger_log(EXTENSION_LOG_LEVEL severity,
+                                const void* client_cookie,
+                                const char *fmt, ...)
 {
     if (severity >= current_log_level) {
         (void)client_cookie;

--- a/plugin/test_service_sql_api/test_sql_2_sessions.cc
+++ b/plugin/test_service_sql_api/test_sql_2_sessions.cc
@@ -65,6 +65,10 @@ static void WRITE_STR(const char *format) {
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 template <typename T>
 void WRITE_VAL(const char *format, T value) {
   char buffer[STRING_BUFFER_SIZE];
@@ -78,6 +82,9 @@ void WRITE_VAL(const char *format, T1 value1, T2 value2) {
   snprintf(buffer, sizeof(buffer), format, value1, value2);
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 static const char *user_localhost = "localhost";
 static const char *user_local = "127.0.0.1";

--- a/plugin/test_service_sql_api/test_sql_cmds_1.cc
+++ b/plugin/test_service_sql_api/test_sql_cmds_1.cc
@@ -61,6 +61,10 @@ static void WRITE_STR(const char *format) {
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 template <typename T>
 void WRITE_VAL(const char *format, T value) {
   char buffer[STRING_BUFFER];
@@ -74,6 +78,9 @@ void WRITE_VAL(const char *format, T1 value1, T2 value2) {
   snprintf(buffer, sizeof(buffer), format, value1, value2);
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 static const char *user_localhost = "localhost";
 static const char *user_local = "127.0.0.1";

--- a/plugin/test_service_sql_api/test_sql_errors.cc
+++ b/plugin/test_service_sql_api/test_sql_errors.cc
@@ -67,6 +67,10 @@ static void WRITE_STR(const char *format) {
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 template <typename T>
 void WRITE_VAL(const char *format, T value) {
   char buffer[STRING_BUFFER_SIZE];
@@ -80,6 +84,9 @@ void WRITE_VAL(const char *format, T1 value1, T2 value2) {
   snprintf(buffer, sizeof(buffer), format, value1, value2);
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 static const char *user_localhost = "localhost";
 static const char *user_local = "127.0.0.1";

--- a/plugin/test_service_sql_api/test_sql_reset_connection.cc
+++ b/plugin/test_service_sql_api/test_sql_reset_connection.cc
@@ -53,6 +53,10 @@ static void WRITE_STR(const char *format) {
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 template <typename T>
 void WRITE_VAL(const char *format, T value) {
   char buffer[STRING_BUFFER];
@@ -66,6 +70,9 @@ void WRITE_VAL2(const char *format, T1 value1, T2 value2) {
   snprintf(buffer, sizeof(buffer), format, value1, value2);
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 static const char *sep =
     "=======================================================================\n";

--- a/plugin/test_service_sql_api/test_sql_shutdown.cc
+++ b/plugin/test_service_sql_api/test_sql_shutdown.cc
@@ -61,6 +61,10 @@ static void WRITE_STR(const char *format) {
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 template <typename T>
 void WRITE_VAL(const char *format, T value) {
   char buffer[STRING_BUFFER_SIZE];
@@ -74,6 +78,9 @@ void WRITE_VAL(const char *format, T1 value1, T2 value2) {
   snprintf(buffer, sizeof(buffer), format, value1, value2);
   my_write(outfile, (uchar *)buffer, strlen(buffer), MYF(0));
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 struct st_send_field_n {
   char db_name[256];

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -9667,7 +9667,7 @@ static net_async_status native_password_auth_client_nonblocking(
     MYSQL_PLUGIN_VIO *vio, MYSQL *mysql, int *result) {
   DBUG_TRACE;
   int io_result;
-  uchar *pkt;
+  uchar *pkt = nullptr;
   mysql_async_auth *ctx = ASYNC_DATA(mysql)->connect_context->auth_context;
 
   switch (static_cast<client_auth_native_password_plugin_status>(

--- a/sql/check_stack.cc
+++ b/sql/check_stack.cc
@@ -120,7 +120,8 @@ bool check_stack_overrun(const THD *thd, long margin, unsigned char *buf) {
   return false;
 #endif
 
-  long stack_used =
+  long stack_used = 0;
+  stack_used =
       used_stack(thd->thread_stack, reinterpret_cast<char *>(&stack_used));
   if (stack_used >= static_cast<long>(my_thread_stack_size - margin) ||
       DBUG_EVALUATE_IF("simulate_stack_overrun", true, false)) {

--- a/sql/sql_prepare.h
+++ b/sql/sql_prepare.h
@@ -426,7 +426,7 @@ class Prepared_statement final {
 
  public:
   Prepared_statement(THD *thd_arg);
-  virtual ~Prepared_statement();
+  ~Prepared_statement();
 
   bool set_name(const LEX_CSTRING &name);
   const LEX_CSTRING &name() const { return m_name; }

--- a/sql/srv_session.cc
+++ b/sql/srv_session.cc
@@ -848,7 +848,7 @@ false  on success
 true   on failure
 */
 bool Srv_session::open() {
-  char stack_start;
+  char stack_start = 0;
   DBUG_TRACE;
 
   DBUG_PRINT("info", ("Session=%p  THD=%p  DA=%p", this, m_thd, &m_da));

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.cpp
@@ -1965,7 +1965,7 @@ void Dbdict::readSchemaConf(Signal *signal, FsConnectRecordPtr fsPtr) {
   for (Uint32 n = 0; n < xsf->noOfPages; n++) {
     SchemaFile *sf = &xsf->schemaPage[n];
     bool ok = false;
-    const char *reason;
+    const char *reason = nullptr;
     if (memcmp(sf->Magic, NDB_SF_MAGIC, sizeof(sf->Magic)) != 0) {
       jam();
       reason = "magic code";

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -4287,7 +4287,7 @@ int MgmtSrvr::setDbParameter(int node, int param, const char *value,
   int p_type;
   unsigned val_32;
   Uint64 val_64 = 0;
-  const char *val_char;
+  const char *val_char = nullptr;
   do {
     p_type = 0;
     if (iter.get(param, &val_32) == 0) {

--- a/storage/ndb/src/ndbapi/NdbOperationExec.cpp
+++ b/storage/ndb/src/ndbapi/NdbOperationExec.cpp
@@ -1063,7 +1063,7 @@ int NdbOperation::buildSignalsNdbRecord(Uint32 aTC_ConnectPtr, Uint64 aTransId,
       if (col->flags & NdbRecord::IsDisk) no_disk_flag = 0;
 
       Uint32 length;
-      const char *data;
+      const char *data = nullptr;
 
       if (likely(!(col->flags &
                    (NdbRecord::IsBlob | NdbRecord::IsMysqldBitfield)))) {

--- a/storage/perfschema/unittest/pfs-t.cc
+++ b/storage/perfschema/unittest/pfs-t.cc
@@ -2349,7 +2349,7 @@ static void test_file_operations() {
 
   PFS_file_class *file_class;
   PSI_thread *thread_A, *thread_B;
-  PSI_file_locker *locker_A, *locker_B;
+  PSI_file_locker *locker_A = nullptr, *locker_B = nullptr;
   PSI_file_locker_state state_A, state_B;
   File fd1, fd2;
   const char *filename1, *filename2;

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -237,6 +237,11 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-range-loop-analysis FILES rocksdb/db/db_impl/db_impl_compaction_flush.cc)
 ENDIF()
 
+# Suppress warnings for clang-21 or newer
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 21)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-missing-format-attribute FILES rocksdb/env/file_system.cc rocksdb/env/env.cc rocksdb/env/mock_env.cc rocksdb/logging/auto_roll_logger.cc rocksdb/util/stderr_logger.cc rocksdb/logging/log_buffer.cc)
+ENDIF()
+
 # Suppress warnings for clang-15 or newer
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-unused-but-set-variable FILES rocksdb/db/version_set.cc rocksdb/db/version_edit_handler.cc rocksdb/cache/lru_cache.cc rocksdb/db/internal_stats.cc)

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -5587,7 +5587,8 @@ static bool print_stats(THD *const thd, std::string const &type,
                     status.c_str(), status.size());
 }
 
-static std::string format_string(const char *const format, ...) {
+static std::string MY_ATTRIBUTE((format(printf, 1, 2)))
+    format_string(const char *const format, ...) {
   std::string res;
   va_list args;
   va_list args_copy;
@@ -5745,12 +5746,12 @@ class Rdb_snapshot_status : public Rdb_tx_list_walker {
       THD *thd = tx->get_thd();
       char buffer[1024];
       thd_security_context(thd, buffer, sizeof buffer, 0);
-      m_data += format_string(
-          "---SNAPSHOT, ACTIVE %lld sec\n"
-          "%s\n"
-          "lock count %llu, write count %llu\n",
-          curr_time - snapshot_timestamp, buffer, tx->get_row_lock_count(),
-          tx->get_write_count());
+      m_data += format_string("---SNAPSHOT, ACTIVE %" PRId64
+                              " sec\n"
+                              "%s\n"
+                              "lock count %llu, write count %llu\n",
+                              curr_time - snapshot_timestamp, buffer,
+                              tx->get_row_lock_count(), tx->get_write_count());
     }
   }
 

--- a/storage/rocksdb/logger.h
+++ b/storage/rocksdb/logger.h
@@ -28,6 +28,10 @@
 
 namespace myrocks {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 class Rdb_logger : public rocksdb::Logger {
  public:
   explicit Rdb_logger(const rocksdb::InfoLogLevel log_level =
@@ -88,5 +92,8 @@ class Rdb_logger : public rocksdb::Logger {
   std::shared_ptr<rocksdb::Logger> m_logger;
   rocksdb::InfoLogLevel m_mysql_log_level;
 };
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 }  // namespace myrocks

--- a/strings/ctype.cc
+++ b/strings/ctype.cc
@@ -363,6 +363,10 @@ static int fill_uint16(uint16 *a, uint size, const char *str, size_t len) {
   return 0;
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-format-attribute"
+#endif
 static int tailoring_append(MY_XML_PARSER *st, const char *fmt, size_t len,
                             const char *attr) {
   struct my_cs_file_info *i = (struct my_cs_file_info *)st->user_data;
@@ -389,6 +393,9 @@ static int tailoring_append2(MY_XML_PARSER *st, const char *fmt, size_t len1,
   }
   return MY_XML_ERROR;
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 static size_t scan_one_character(const char *s, const char *e, my_wc_t *wc) {
   CHARSET_INFO *cs = &my_charset_utf8mb3_general_ci;

--- a/testclients/mysql_client_test.cc
+++ b/testclients/mysql_client_test.cc
@@ -19134,7 +19134,7 @@ static void test_wl6791() {
   }
 
   for (idx = 0; idx < sizeof(err_opts) / sizeof(enum mysql_option); idx++) {
-    void *dummy_arg;
+    void *dummy_arg = nullptr;
     if (!opt_silent)
       fprintf(stdout, "testing invalid option #%d (%d)\n", idx,
               (int)err_opts[idx]);

--- a/unittest/gunit/components/keyring_common/backend_mem.h
+++ b/unittest/gunit/components/keyring_common/backend_mem.h
@@ -33,7 +33,7 @@ class Memory_backend final {
  public:
   Memory_backend() = default;
 
-  virtual ~Memory_backend() = default;
+  ~Memory_backend() = default;
 
   bool get(const keyring_common::meta::Metadata &metadata,
            keyring_common::data::Data &data) const {


### PR DESCRIPTION
1. Add clang-21, clang-22, gcc-15 to Azure Pipelines
2. Fix compilation errors introduced by new warnings in Clang 22:

` -Wuninitialized-const-pointer`: fires when an
uninitialized variable is passed by address as a const pointer argument.
Fixed by initializing variables to nullptr/0 in cases where only the
address is used (stack probes) or the variable is an output parameter:
 - include/mysql/psi/mysql_file.h (33 PSI_file_locker instances)
 - sql-common/client.cc (pkt)
 - sql/check_stack.cc (stack_used)
 - sql/srv_session.cc (stack_start)
 - storage/ndb/src/ndbapi/NdbOperationExec.cpp (data)
 - storage/perfschema/unittest/pfs-t.cc (locker_A, locker_B)
 - testclients/mysql_client_test.cc (dummy_arg)
 - components/test/test_mysql_command_services.cc (option_val, also moved
   declaration before goto labels)
    
`-Wmissing-format-attribute` (new in Clang 21): fires when a function
passes a format string to printf/vsnprintf but lacks the format
attribute itself. Suppressed via pragma for template functions and
non-variadic functions where the attribute cannot be applied:
 - strings/ctype.cc (tailoring_append, tailoring_append2)
 - plugin/test_service_sql_api/test_sql_*.cc (WRITE_VAL templates)
 - plugin/group_replication/libmysqlgcs/ (Gcs_default_debugger::log_event
   template, plus CMake-level -Wno-missing-format-attribute for
   GCS_SOURCES)
    
`-Wunnecessary-virtual-specifier` (new in Clang 22): fires on virtual
methods in final classes. Removed redundant virtual keyword:
 - sql/sql_prepare.h (Prepared_statement destructor)
 - unittest/gunit/components/keyring_common/backend_mem.h
   (Memory_backend destructor)
