### PR TITLE
PS-10436 [8.4]: Reorganize error log messages and add error number markers

### DIFF
--- a/mysql-test/r/distinct.result
+++ b/mysql-test/r/distinct.result
@@ -1069,7 +1069,7 @@ DROP TABLE t1;
 SET @tmp_table_size_save= @@tmp_table_size;
 SET @@tmp_table_size= 1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (a INT);
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5),(6),(7),(8);
 INSERT INTO t1 SELECT a+8 FROM t1;

--- a/mysql-test/r/error_simulation.result
+++ b/mysql-test/r/error_simulation.result
@@ -21,7 +21,7 @@ INSERT INTO t1 VALUES
 set session internal_tmp_mem_storage_engine='memory';
 set tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 set session debug="d,raise_error";
 SELECT MAX(a) FROM t1 GROUP BY a,b;
 MAX(a)

--- a/mysql-test/r/func_gconcat.result
+++ b/mysql-test/r/func_gconcat.result
@@ -1227,7 +1227,7 @@ a	3
 b,c	5
 SET @@tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT GROUP_CONCAT(DISTINCT a) FROM t1;
 GROUP_CONCAT(DISTINCT a)
 a,b,c

--- a/mysql-test/r/multi_update_innodb.result
+++ b/mysql-test/r/multi_update_innodb.result
@@ -146,7 +146,7 @@ INSERT INTO t1 VALUES ('a','j',10);
 INSERT INTO t1 VALUES ('a','k',11);
 SET @@SESSION.tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET @@SESSION.internal_tmp_mem_storage_engine=MEMORY;
 UPDATE t1 a, t1 b SET a.c3=22 WHERE a.c1 = b.c1;
 SELECT COUNT(*) FROM t1 WHERE c3=22;

--- a/mysql-test/r/opt_hints_set_var.result
+++ b/mysql-test/r/opt_hints_set_var.result
@@ -696,7 +696,7 @@ SELECT /*+ SET_VAR(tmp_table_size=1024) */ COUNT(DISTINCT a) FROM t1;
 COUNT(DISTINCT a)
 128
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SHOW STATUS LIKE 'Created_tmp_files';
 Variable_name	Value
 Created_tmp_files	0

--- a/mysql-test/r/query_expression.result
+++ b/mysql-test/r/query_expression.result
@@ -5075,7 +5075,7 @@ SET SESSION optimizer_trace="enabled=on";
 # a) When we spill
 SET SESSION tmp_table_size=100000;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT * FROM (SELECT * FROM t INTERSECT SELECT * FROM t) AS derived ORDER BY i LIMIT 20;
 i	d	c
 0	2022-04-30	abracadabra
@@ -5485,7 +5485,7 @@ SET SESSION optimizer_trace="enabled=on";
 # a) When we spill
 SET SESSION tmp_table_size=100000;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT * FROM (SELECT * FROM t INTERSECT SELECT * FROM t) AS derived ORDER BY i LIMIT 20;
 i	d	c
 0	2022-04-30	abracadabra

--- a/mysql-test/r/query_expression_debug.result
+++ b/mysql-test/r/query_expression_debug.result
@@ -138,7 +138,7 @@ DROP TABLE no_hashing;
 SET SESSION optimizer_trace="enabled=on";
 SET SESSION tmp_table_size=100000;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 # b) With secondary overflow
 SET SESSION debug_set_operations_secondary_overflow_at='0 10 20';
 SELECT * FROM (SELECT * FROM t INTERSECT SELECT * FROM t) AS derived ORDER BY i LIMIT 20;
@@ -429,7 +429,7 @@ DROP TABLE no_hashing;
 SET SESSION optimizer_trace="enabled=on";
 SET SESSION tmp_table_size=100000;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 # b) With secondary overflow
 SET SESSION debug_set_operations_secondary_overflow_at='0 10 20';
 SELECT * FROM (SELECT * FROM t INTERSECT SELECT * FROM t) AS derived ORDER BY i LIMIT 20;

--- a/mysql-test/r/range_all.result
+++ b/mysql-test/r/range_all.result
@@ -3372,7 +3372,7 @@ DROP TABLE t1;
 SET @old_tmp_table_size=@@tmp_table_size;
 SET tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (
 pk INT NOT NULL,
 col_int_key INT,

--- a/mysql-test/r/range_icp.result
+++ b/mysql-test/r/range_icp.result
@@ -3372,7 +3372,7 @@ DROP TABLE t1;
 SET @old_tmp_table_size=@@tmp_table_size;
 SET tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (
 pk INT NOT NULL,
 col_int_key INT,

--- a/mysql-test/r/range_icp_mrr.result
+++ b/mysql-test/r/range_icp_mrr.result
@@ -3372,7 +3372,7 @@ DROP TABLE t1;
 SET @old_tmp_table_size=@@tmp_table_size;
 SET tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (
 pk INT NOT NULL,
 col_int_key INT,

--- a/mysql-test/r/range_mrr.result
+++ b/mysql-test/r/range_mrr.result
@@ -3373,7 +3373,7 @@ DROP TABLE t1;
 SET @old_tmp_table_size=@@tmp_table_size;
 SET tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (
 pk INT NOT NULL,
 col_int_key INT,

--- a/mysql-test/r/range_mrr_cost.result
+++ b/mysql-test/r/range_mrr_cost.result
@@ -3373,7 +3373,7 @@ DROP TABLE t1;
 SET @old_tmp_table_size=@@tmp_table_size;
 SET tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (
 pk INT NOT NULL,
 col_int_key INT,

--- a/mysql-test/r/range_none.result
+++ b/mysql-test/r/range_none.result
@@ -3372,7 +3372,7 @@ DROP TABLE t1;
 SET @old_tmp_table_size=@@tmp_table_size;
 SET tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1 (
 pk INT NOT NULL,
 col_int_key INT,

--- a/mysql-test/r/union.result
+++ b/mysql-test/r/union.result
@@ -963,7 +963,7 @@ insert into t1 select * from t2;
 insert into t2 select * from t1;
 set local tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 select count(*) from (select * from t1 union all select * from t2 order by 1) b;
 count(*)
 21

--- a/mysql-test/r/update.result
+++ b/mysql-test/r/update.result
@@ -440,7 +440,7 @@ a	quux
 DROP TABLE t1;
 set tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 create table t1 (id int, a int, key idx(a));
 create table t2 (id int unsigned not null auto_increment primary key, a int);
 insert into t2(a) values(1),(2),(3),(4),(5),(6),(7),(8);

--- a/mysql-test/r/variables.result
+++ b/mysql-test/r/variables.result
@@ -603,7 +603,7 @@ set timestamp=1, timestamp=default;
 set tmp_table_size=100;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '100'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 set transaction_isolation="READ-COMMITTED";
 set wait_timeout=100;
 set global log_error_verbosity=2;

--- a/mysql-test/r/window_functions.result
+++ b/mysql-test/r/window_functions.result
@@ -7435,7 +7435,7 @@ Warning	1681	Integer display width is deprecated and will be removed in a future
 Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
 SET tmp_table_size= 16384;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT DISTINCT MAX( table2.`col_varchar_255_utf8` ) AS max1 ,
 MIN( table1.`col_date` ) AS min1 ,
 AVG( table2.`col_int` ) AS avg1 ,
@@ -9586,7 +9586,7 @@ INSERT INTO t1 VALUES
 SET @@session.max_heap_table_size=16*1024;
 SET @@session.tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET optimizer_switch="derived_condition_pushdown=off";
 SET SESSION internal_tmp_mem_storage_engine=MEMORY;
 SELECT * FROM (SELECT c2, c3, c4, SUM(c1) OVER (PARTITION BY c2) AS wcol FROM t1)o WHERE c2=10;

--- a/mysql-test/r/window_functions_big.result
+++ b/mysql-test/r/window_functions_big.result
@@ -75,7 +75,7 @@ d	summ	nth	lagg
 TRUNCATE cpy;
 set tmp_table_size=16384;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 set max_heap_table_size=16384;
 Spill frame buffer to INNODB
 INSERT INTO cpy SELECT d, SUM(d) OVER w summ, NTH_VALUE(d, 3) OVER w nth, LAG(d, 20) OVER w lagg FROM td

--- a/mysql-test/r/with_recursive_closure.result
+++ b/mysql-test/r/with_recursive_closure.result
@@ -38,7 +38,7 @@ Variable_name	Value
 Created_tmp_disk_tables	0
 set @@tmp_table_size=1024,@@max_heap_table_size=16384;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 set session internal_tmp_mem_storage_engine='memory';
 with recursive closure as
 (select @start_node as n union select e from edges, closure where s=closure.n)

--- a/mysql-test/r/with_recursive_innodb_tmp_table.result
+++ b/mysql-test/r/with_recursive_innodb_tmp_table.result
@@ -138,7 +138,7 @@ set big_tables=0;
 # limits and queries.
 set @@tmp_table_size=1024,@@max_heap_table_size=16384;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 set cte_max_recursion_depth=5000;
 flush status;
 with recursive q (b) as
@@ -212,7 +212,7 @@ Variable_name	Value
 Created_tmp_disk_tables	1
 set @@tmp_table_size=30000,@@max_heap_table_size=30000;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 Warning	1292	Truncated incorrect max_heap_table_size value: '30000'
 set cte_max_recursion_depth=5000;
 flush status;
@@ -287,7 +287,7 @@ Variable_name	Value
 Created_tmp_disk_tables	1
 set @@tmp_table_size=60000,@@max_heap_table_size=61000;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 Warning	1292	Truncated incorrect max_heap_table_size value: '61000'
 set cte_max_recursion_depth=5000;
 flush status;

--- a/mysql-test/suite/innodb/r/optimizer_temporary_table.result
+++ b/mysql-test/suite/innodb/r/optimizer_temporary_table.result
@@ -4105,7 +4105,7 @@ set @@session.sql_mode = ANSI;
 set @@session.tmp_table_size = 0;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '0'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 set @@session.big_tables = 1;
 select @@big_tables;
 @@big_tables

--- a/mysql-test/suite/opt_trace/r/temp_table.result
+++ b/mysql-test/suite/opt_trace/r/temp_table.result
@@ -347,7 +347,7 @@ select @@tmp_table_size;
 SET @old_size= @@tmp_table_size;
 SET SESSION tmp_table_size= 1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET SESSION internal_tmp_mem_storage_engine='memory';
 INSERT INTO t1 SELECT pk+8, col1, col1 FROM tmp;
 SELECT uniq, col1, col2 FROM t1 GROUP BY uniq;
@@ -1344,7 +1344,7 @@ SET SESSION internal_tmp_mem_storage_engine=MEMORY;
 SET @@session.optimizer_trace='enabled=on';
 SET @@session.tmp_table_size = 1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET @@optimizer_switch='semijoin=off';
 SELECT name, data FROM t2 WHERE name IN
 ( SELECT name FROM t1 WHERE type='table');

--- a/mysql-test/suite/percona/r/bug_ps8647.result
+++ b/mysql-test/suite/percona/r/bug_ps8647.result
@@ -1,7 +1,7 @@
 call mtr.add_suppression("Tmp_table_size is set below 1MiB.");
 set session tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 select * from information_schema.APPLICABLE_ROLES;
 USER	HOST	GRANTEE	GRANTEE_HOST	ROLE_NAME	ROLE_HOST	IS_GRANTABLE	IS_DEFAULT	IS_MANDATORY
 select * from information_schema.ADMINISTRABLE_ROLE_AUTHORIZATIONS;

--- a/mysql-test/suite/percona/r/encrypt_tmp_files.result
+++ b/mysql-test/suite/percona/r/encrypt_tmp_files.result
@@ -68,7 +68,7 @@ DROP TABLE universal_seq;
 #
 SET SESSION tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 CREATE TABLE t1(a TEXT,b TEXT);
 INSERT INTO t1 VALUES(7553,'7553');
 INSERT INTO t1 VALUES(662,'aaaaaaaaaaaaaaaaaaaa');

--- a/mysql-test/suite/rocksdb/r/instant_add_column_intrinsic_table.result
+++ b/mysql-test/suite/rocksdb/r/instant_add_column_intrinsic_table.result
@@ -74,7 +74,7 @@ INSERT INTO t1 VALUES
 SET @@session.max_heap_table_size=16*1024;
 SET @@session.tmp_table_size=1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET optimizer_switch="derived_condition_pushdown=off";
 SET SESSION internal_tmp_mem_storage_engine=MEMORY;
 SELECT * FROM (SELECT c2, c3, c4, SUM(c1) OVER (PARTITION BY c2) AS wcol FROM t1)o WHERE c2=10;

--- a/mysql-test/suite/rpl/r/rpl_opt_hints.result
+++ b/mysql-test/suite/rpl/r/rpl_opt_hints.result
@@ -7,7 +7,7 @@ CREATE TABLE t1 (f1 INT NOT NULL AUTO_INCREMENT PRIMARY KEY, f2 INT);
 INSERT /*+ SET_VAR(auto_increment_increment=10)  SET_VAR(tmp_table_size=1024)*/ 
 INTO t1 VALUES (NULL, @@tmp_table_size), (NULL, @@tmp_table_size);
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the replica.
 include/rpl/sync_to_replica.inc
 SELECT * FROM t1;

--- a/mysql-test/suite/sys_vars/r/maximum_basic.result
+++ b/mysql-test/suite/sys_vars/r/maximum_basic.result
@@ -7,7 +7,7 @@ SELECT @@session.auto_increment_increment;
 SET @@session.tmp_table_size=40960;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '40960'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.tmp_table_size;
 @@session.tmp_table_size
 1048576

--- a/mysql-test/suite/sys_vars/r/tmp_table_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/tmp_table_size_basic.result
@@ -4,12 +4,12 @@ SET @start_session_value = @@session.tmp_table_size;
 SET @@global.tmp_table_size = 100;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '100'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET @@global.tmp_table_size = DEFAULT;
 SET @@session.tmp_table_size = 200;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '200'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET @@session.tmp_table_size = DEFAULT;
 '#--------------------FN_DYNVARS_005_02-------------------------#'
 SELECT @@global.tmp_table_size >= 16777216;
@@ -21,13 +21,13 @@ SELECT @@session.tmp_table_size >= 16777216;
 '#--------------------FN_DYNVARS_005_03-------------------------#'
 SET @@global.tmp_table_size = 1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
 SET @@global.tmp_table_size = 60020;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
@@ -38,7 +38,7 @@ SELECT @@global.tmp_table_size;
 '#--------------------FN_DYNVARS_005_04-------------------------#'
 SET @@session.tmp_table_size = 1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.tmp_table_size;
 @@session.tmp_table_size
 1048576
@@ -48,7 +48,7 @@ SELECT @@session.tmp_table_size;
 4294967295
 SET @@session.tmp_table_size = 65535;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.tmp_table_size;
 @@session.tmp_table_size
 1048576
@@ -56,21 +56,21 @@ SELECT @@session.tmp_table_size;
 SET @@global.tmp_table_size = 0;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '0'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
 SET @@global.tmp_table_size = -1024;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '-1024'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
 SET @@global.tmp_table_size = 1000;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '1000'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
@@ -90,14 +90,14 @@ ERROR 42000: Incorrect argument type to variable 'tmp_table_size'
 SET @@global.tmp_table_size = True;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '1'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
 SET @@global.tmp_table_size = False;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '0'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@global.tmp_table_size;
 @@global.tmp_table_size
 1048576
@@ -112,7 +112,7 @@ ERROR 42000: Incorrect argument type to variable 'tmp_table_size'
 SET @@session.tmp_table_size = True;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '1'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.tmp_table_size;
 @@session.tmp_table_size
 1048576
@@ -121,7 +121,7 @@ ERROR 42000: Incorrect argument type to variable 'tmp_table_size'
 SET @@session.tmp_table_size = False;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '0'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.tmp_table_size;
 @@session.tmp_table_size
 1048576
@@ -135,7 +135,7 @@ SELECT @@session.tmp_table_size;
 SET @@session.tmp_table_size = 1000;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '1000'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.tmp_table_size;
 @@session.tmp_table_size
 1048576
@@ -158,7 +158,7 @@ WHERE VARIABLE_NAME='tmp_table_size';
 '#---------------------FN_DYNVARS_001_09----------------------#'
 SET @@global.tmp_table_size = 1024;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SET @@tmp_table_size = 4294967295;
 SELECT @@tmp_table_size = @@global.tmp_table_size;
 @@tmp_table_size = @@global.tmp_table_size
@@ -167,7 +167,7 @@ SELECT @@tmp_table_size = @@global.tmp_table_size;
 SET @@tmp_table_size = 100;
 Warnings:
 Warning	1292	Truncated incorrect tmp_table_size value: '100'
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@tmp_table_size = @@local.tmp_table_size;
 @@tmp_table_size = @@local.tmp_table_size
 1
@@ -177,7 +177,7 @@ SELECT @@local.tmp_table_size = @@session.tmp_table_size;
 '#---------------------FN_DYNVARS_001_11----------------------#'
 SET tmp_table_size = 1027;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@tmp_table_size;
 @@tmp_table_size
 1048576

--- a/mysql-test/suite/sys_vars/r/transaction_alloc_block_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/transaction_alloc_block_size_basic.result
@@ -172,7 +172,7 @@ SELECT @@global.transaction_alloc_block_size;
 8192
 SET @@session.tmp_table_size = @start_session_value;
 Warnings:
-Warning	48038	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
+Warning	48040	Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning.
 SELECT @@session.transaction_alloc_block_size;
 @@session.transaction_alloc_block_size
 1024

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -10551,6 +10551,18 @@ ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT
 
 
 #
+# Start of Percona Server 8.4/9.7 error messages to be sent to client
+#
+
+start-error-number 7100
+
+#
+# End of Percona Server 8.4/9.7 client messages
+#
+
+
+
+#
 # Start of MyRocks specific messages to be sent to client
 #
 

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12835,6 +12835,7 @@ ER_AUTH_INITIAL_PLUGIN_OVERRIDE
 # End of 8.1, 8.2, 8.3, 8.4 error messages intended to be written to the server error log.
 #
 
+
 #
 # Start of Percona Server 8.0 server error log messages
 #
@@ -12852,10 +12853,10 @@ ER_XB_MSG_1
 ER_COMPRESSION_DICTIONARY_NO_CREATE
   eng "Cannot create compression dictionary tables in %s%sread-only mode."
 
-ER_XB_UNUSED_1
+ER_UNUSED_48004
   eng "%s"
 
-ER_XB_UNUSED_2
+ER_UNUSED_48005
   eng "%s"
 
 ER_XB_MSG_4
@@ -12867,13 +12868,14 @@ ER_XB_MSG_5
 ER_XB_MSG_WAIT_FOR_KEYRING_ENCRYPT_THREAD
   eng "Waiting for keyring encryption threads to exit"
 
-ER_XB_UNUSED_3
+ER_UNUSED_48009
   eng "%s"
 
+# 48010
 ER_XB_MSG_6
   eng "Key rotation of encrypted session temporary tablespace %s failed"
 
-ER_XB_UNUSED_4
+ER_UNUSED_48011
   eng "%s"
 
 ER_UPGRADE_KEYRING_UNSUPPORTED_VERSION_ENCRYPTION
@@ -12900,6 +12902,7 @@ ER_REDO_ENCRYPTION_CANT_PARSE_KEY
 ER_REDO_ENCRYPTION_KEYRING
   eng "Redo log cannot be encrypted if the keyring is not loaded."
 
+# 48020
 ER_UNDO_NO_KEYRING
   eng "Undo log can't be encrypted if the keyring is not loaded."
 
@@ -12930,6 +12933,13 @@ ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB
 ER_XPLUGIN_SSL_RELOAD_REGISTER_FAILED
   eng "X plugin failed to register SSL reload callback. ALTER INSTANCE RELOAD TLS will have no effect on the plugin."
 
+# 48030
+ER_UNUSED_48030
+  eng "deprecated ER_IB_MSG_INNODB_PARALLEL_DOUBLEWRITE_PATH"
+
+ER_UNUSED_48031
+  eng "deprecated ER_IB_MSG_INNODB_PARALLEL_DBLWR_ENCRYPT"
+
 ER_KEYRING_COMPONENT_NO_CONFIG
   eng "Keyring configuration doesn't exists: %s"
 
@@ -12954,6 +12964,7 @@ ER_RPL_ENABLE_EVENT_ADD_WILD_PATTERN_FAILED
 ER_GRP_RPL_FLOW_CONTROL_TIMEOUT
   eng "Flow control auto evict timeout reached. The server will now leave the group."
 
+# 48040
 ER_PERCONA_IGNORE_TMP_TABLE_SIZE
   eng "Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning."
 
@@ -12968,6 +12979,19 @@ ER_CONN_CONTROL_DELAYED_CONN_STATS
 
 ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH
   eng "The --secure-file-path is configured, %s must be set accordingly."
+
+ER_SSL_FIPS_MODE_ENABLED
+  eng "A FIPS-approved version of the OpenSSL cryptographic library has been detected in the operating system with a properly configured FIPS module available for loading. Percona Server for MySQL will load this module and run in FIPS mode."
+
+#
+# End of Percona Server 8.0 server error log messages
+#
+
+
+#
+# Start of Audit Log Filter error log messages
+#
+start-error-number 48100
 
 ER_AUDIT_INIT_STARTED
   eng "Initializing Audit Event Filter..."
@@ -12999,6 +13023,7 @@ ER_AUDIT_INIT_WRITER_INIT_FAILURE
 ER_AUDIT_INIT_WRITER_OPEN_FAILURE
   eng "Cannot open log writer, error: %s"
 
+# 48110
 ER_AUDIT_INIT_READER_INIT_FAILURE
   eng "Failed to create log reader instance"
 
@@ -13029,6 +13054,7 @@ ER_AUDIT_SET_USER_UDF_FAIL
 ER_AUDIT_REMOVE_USER_UDF_FAIL
   eng "Failed to remove filter for user '%s@%s' from users table"
 
+# 48120
 ER_AUDIT_LOG_ROTATE_UDF_FAIL
   eng "Log rotation failed: '%s'"
 
@@ -13059,6 +13085,7 @@ ER_AUDIT_PARSE_EVENT_CLASS_BAD_CLASS_TYPE
 ER_AUDIT_PARSE_EVENT_CLASS_NO_CLASS_NAME
   eng "Wrong JSON filter '%s' format, no name provided for event class"
 
+# 48130
 ER_AUDIT_PARSE_EVENT_CLASS_BAD_ABORT_DEF
   eng "Wrong JSON filter '%s' format, 'abort' condition should be set for subclass only"
 
@@ -13089,6 +13116,7 @@ ER_AUDIT_PARSE_EVENT_SUBCLASS_BAD_SUBCLASS_TYPE
 ER_AUDIT_PARSE_ACTION_BAD_ABORT_TYPE
   eng "Wrong JSON filter '%s' format, 'abort' must be of bool or object type"
 
+# 48140
 ER_AUDIT_PARSE_ACTION_BAD_REPLACE
   eng "Event field '%s' cannot be replaced"
 
@@ -13119,6 +13147,7 @@ ER_AUDIT_PARSE_CONDITION_BAD_AND_COND_OPERANDS
 ER_AUDIT_PARSE_CONDITION_BAD_OR_COND_TYPE
   eng "Wrong JSON filter '%s' format, condition definition 'or' must be of array type"
 
+# 48150
 ER_AUDIT_PARSE_CONDITION_BAD_OR_COND_FORMAT
   eng "Wrong JSON filter '%s' format, a member of 'or' condition must be of object type"
 
@@ -13149,6 +13178,7 @@ ER_AUDIT_PARSE_FUNCTION_BAD_ARGS_FORMAT
 ER_AUDIT_PARSE_FUNCTION_BAD_ARGS
   eng "Wrong JSON filter '%s' format, invalid arguments for '%s' function"
 
+# 48160
 ER_AUDIT_PARSE_NO_SUBCLASS_NAME
   eng "Wrong JSON filter '%s' format, no name provided for event subclass"
 
@@ -13179,6 +13209,7 @@ ER_AUDIT_UDF_SET_FILTER_BAD_DEFINITION
 ER_AUDIT_UDF_SET_FILTER_UNIQUE_CHECK_FAIL
   eng "Failed to check filtering rule name existence"
 
+# 48170
 ER_AUDIT_UDF_SET_FILTER_NAME_EXISTS
   eng "Filtering rule with the name '%s' already exists"
 
@@ -13188,9 +13219,6 @@ ER_AUDIT_UDF_SET_FILTER_FAILURE
 ER_AUDIT_REPLACE_FIELD_UNEXPECTED_EVENT_TYPE
   eng "Unexpected event type for replace_field action"
 
-ER_SSL_FIPS_MODE_ENABLED
-  eng "A FIPS-approved version of the OpenSSL cryptographic library has been detected in the operating system with a properly configured FIPS module available for loading. Percona Server for MySQL will load this module and run in FIPS mode."
-
 ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_TYPE
   eng "Wrong JSON filter '%s' format, the 'log' field must be of bool or object type"
 
@@ -13198,8 +13226,29 @@ ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY
   eng "Invalid audit log filter file directory: %s"
 
 #
-# End of Percona Server 8.0 server error log messages
+# End of Audit Log Filter error log messages
 #
+
+
+#
+# Start of Percona Server 8.4 error log messages
+#
+start-error-number 48200
+
+#
+# End of Percona Server 8.4 error log messages
+#
+
+
+#
+# Start of Percona Server 9.7 error log messages
+#
+start-error-number 48300
+
+#
+# End of Percona Server 9.7 error log messages
+#
+
 
 ################################################################################
 # Error numbers 50000 to 51999 are reserved. Please do not use them for


### PR DESCRIPTION
Rename unused error slots to include their error numbers (`ER_XB_UNUSED_1` -> `ER_UNUSED_48004`, etc.), replace `OBSOLETE_` entries with numbered `ER_UNUSED_` placeholders, and add comment markers at every 10th error number boundary for easier navigation. Separate Audit Log Filter messages into their own section (`start-error-number 48100`) and add reserved sections for Percona Server 8.4 (`48200`) and 9.7 (`48300`). Move `ER_SSL_FIPS_MODE_ENABLED` to its correct position in the Percona Server 8.0 section.