### PR TITLE
PS-10338 [9.x]: Validate audit log filter field names at parse time

### DIFF
--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -546,6 +546,9 @@ AuditRecordFieldsList get_audit_record_fields(
       {"general_sql_command.str", extra.sql_command},
       {"general_sql_command.length",
        std::to_string(extra.sql_command.length())},
+      {"general_external_user.str", extra.external_user},
+      {"general_external_user.length",
+       std::to_string(extra.external_user.length())},
       {"general_ip.str", extra.ip},
       {"general_ip.length", std::to_string(extra.ip.length())},
   };
@@ -706,6 +709,59 @@ AuditRecordFieldsList get_audit_record_fields(const AuditRecordAudit &record
 AuditRecordFieldsList get_audit_record_fields(const AuditRecordUnknown &record
                                               [[maybe_unused]]) {
   return {};
+}
+
+bool is_valid_event_field_name(const std::string &event_class_name,
+                               const std::string &field_name) {
+  using FieldSet = std::set<std::string>;
+  static const std::unordered_map<std::string, FieldSet> valid_fields_map{
+      {"general",
+       {"general_error_code", "general_thread_id", "general_connection_id",
+        "general_user.str", "general_user.length", "general_command.str",
+        "general_command.length", "general_query.str", "general_query.length",
+        "general_host.str", "general_host.length", "general_sql_command.str",
+        "general_sql_command.length", "general_external_user.str",
+        "general_external_user.length", "general_ip.str", "general_ip.length"}},
+      {"connection",
+       {"status", "connection_id", "user.str", "user.length", "priv_user.str",
+        "priv_user.length", "external_user.str", "external_user.length",
+        "proxy_user.str", "proxy_user.length", "host.str", "host.length",
+        "ip.str", "ip.length", "database.str", "database.length",
+        "connection_type"}},
+      {"table_access",
+       {"connection_id", "sql_command_id", "query.str", "query.length",
+        "table_database.str", "table_database.length", "table_name.str",
+        "table_name.length"}},
+      {"global_variable",
+       {"connection_id", "variable_name.str", "variable_name.length",
+        "variable_value.str", "variable_value.length"}},
+      {"server_startup", {}},
+      {"server_shutdown", {"exit_code", "reason"}},
+      {"command", {"status", "connection_id", "command.str", "command.length"}},
+      {"query",
+       {"status", "connection_id", "sql_command_id", "query.str",
+        "query.length", "query_charset"}},
+      {"stored_program",
+       {"connection_id", "database.str", "database.length", "name.str",
+        "name.length"}},
+      {"authentication",
+       {"status", "connection_id", "user.str", "user.length", "host.str",
+        "host.length"}},
+      {"message",
+       {"connection_id", "component.str", "component.length", "producer.str",
+        "producer.length", "message.str", "message.length"}},
+      {"parse",
+       {"connection_id", "flags", "query.str", "query.length",
+        "rewritten_query.str", "rewritten_query.length"}},
+      {"audit", {"server_id"}},
+  };
+
+  const auto class_it = valid_fields_map.find(event_class_name);
+  if (class_it == valid_fields_map.cend()) {
+    return false;
+  }
+
+  return class_it->second.count(field_name) > 0;
 }
 
 }  // namespace audit_log_filter

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -20,6 +20,7 @@
 #include "my_sqlcommand.h"  // enum_sql_command
 
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -313,6 +314,17 @@ AuditRecordFieldsList get_audit_record_fields(const AuditRecordAudit &record);
  * @return Fields list, @ref AuditRecordFieldsList
  */
 AuditRecordFieldsList get_audit_record_fields(const AuditRecordUnknown &record);
+
+/**
+ * @brief Check if a field name is valid for the given event class.
+ *
+ * @param event_class_name Audit event class name (e.g. "table_access")
+ * @param field_name Field name to validate (e.g. "table_name.str")
+ * @return true if the field name is recognized for the event class,
+ *         false otherwise
+ */
+bool is_valid_event_field_name(const std::string &event_class_name,
+                               const std::string &field_name);
 
 }  // namespace audit_log_filter
 

--- a/components/audit_log_filter/audit_rule.cc
+++ b/components/audit_log_filter/audit_rule.cc
@@ -85,6 +85,16 @@ void AuditRule::add_action_for_event(
   }
 }
 
+void AuditRule::set_parse_error(const std::string &error) noexcept {
+  if (m_parse_error.empty()) {
+    m_parse_error = error;
+  }
+}
+
+const std::string &AuditRule::get_parse_error() const noexcept {
+  return m_parse_error;
+}
+
 bool AuditRule::has_actions_for(
     std::string_view event_class_name,
     std::string_view event_subclass_name) const noexcept {

--- a/components/audit_log_filter/audit_rule.h
+++ b/components/audit_log_filter/audit_rule.h
@@ -113,6 +113,20 @@ class AuditRule {
       const std::string &event_class_name,
       const std::string &event_subclass_name = "") noexcept;
 
+  /**
+   * @brief Set parse error description (only stores the first error).
+   *
+   * @param error Human-readable parse error description
+   */
+  void set_parse_error(const std::string &error) noexcept;
+
+  /**
+   * @brief Get parse error description, empty if no error.
+   *
+   * @return Parse error description string
+   */
+  [[nodiscard]] const std::string &get_parse_error() const noexcept;
+
  private:
   uint64_t m_filter_id;
   std::string m_rule_name;
@@ -123,6 +137,7 @@ class AuditRule {
       m_matched_event_to_action_map;
 
   AuditRule *m_replacement_rule;
+  std::string m_parse_error;
 };
 
 }  // namespace audit_log_filter

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -46,16 +46,19 @@ bool AuditRuleParser::parse(rapidjson::Document &json_doc,
                             AuditRule *audit_rule) noexcept {
   // Do basic check of rule structure
   if (json_doc.HasParseError()) {
+    audit_rule->set_parse_error("JSON parse error");
     return false;
   }
 
   // The root of the JSON rule must be an object
   if (!json_doc.IsObject()) {
+    audit_rule->set_parse_error("root element must be a JSON object");
     return false;
   }
 
   // The basic JSON rule format must be like the following: '{"filter": {}}'
   if (!json_doc.HasMember("filter") || !json_doc["filter"].IsObject()) {
+    audit_rule->set_parse_error("missing or invalid 'filter' object");
     return false;
   }
 
@@ -95,6 +98,7 @@ bool AuditRuleParser::parse_default_log_action_json(
       LogComponentErr(ERROR_LEVEL,
                       ER_AUDIT_PARSE_DEFAULT_LOG_ACTION_BAD_LOG_TYPE,
                       audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("the 'log' member must be of type bool");
       return false;
     }
 
@@ -147,6 +151,8 @@ bool AuditRuleParser::parse_event_class_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_EVENT_CLASS_BAD_CLASS_LIST_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "'class' array element must be of object type");
         return false;
       }
 
@@ -157,6 +163,7 @@ bool AuditRuleParser::parse_event_class_json(
   } else {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_CLASS_TYPE,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error("'class' must be an object or an array");
     return false;
   }
 
@@ -170,12 +177,15 @@ bool AuditRuleParser::parse_event_class_obj_json(
   if (!event_class_json.HasMember("name")) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_NO_CLASS_NAME,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error("no name provided for event class");
     return false;
   }
 
   if (event_class_json.HasMember("abort")) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_ABORT_DEF,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "'abort' condition should be set for subclass only");
     return false;
   }
 
@@ -186,6 +196,7 @@ bool AuditRuleParser::parse_event_class_obj_json(
     } else {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_LOG_TYPE,
                       audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("'log' must be of bool type");
       return false;
     }
   }
@@ -199,6 +210,7 @@ bool AuditRuleParser::parse_event_class_obj_json(
     if (replace_field == nullptr) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
                       audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("failed to parse 'print' replacement rule");
       return false;
     }
   }
@@ -211,6 +223,8 @@ bool AuditRuleParser::parse_event_class_obj_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_EVENT_CLASS_UNEXPECTED_PRINT_DEF,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "replacement rule not expected for event class");
         return false;
       }
 
@@ -238,6 +252,9 @@ bool AuditRuleParser::parse_event_class_obj_json(
       LogComponentErr(ERROR_LEVEL,
                       ER_AUDIT_PARSE_EVENT_CLASS_UNEXPECTED_EVENT_DEF,
                       audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error(
+          "there must be no 'event' in case class names provided as an array "
+          "of strings");
       return false;
     }
 
@@ -251,6 +268,8 @@ bool AuditRuleParser::parse_event_class_obj_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_EVENT_CLASS_BAD_EVENT_NAME_FOR_LIST,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "event class name within an array should be of a string type");
         return false;
       }
 
@@ -264,6 +283,8 @@ bool AuditRuleParser::parse_event_class_obj_json(
   } else {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_EVENT_NAME_TYPE,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "event class name type must be either string or an array of strings");
     return false;
   }
 
@@ -301,6 +322,8 @@ bool AuditRuleParser::parse_event_subclass_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_EVENT_SUBCLASS_BAD_SUBCLASS_LIST_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "'event' array element must be of object type");
         return false;
       }
 
@@ -312,6 +335,8 @@ bool AuditRuleParser::parse_event_subclass_json(
     LogComponentErr(ERROR_LEVEL,
                     ER_AUDIT_PARSE_EVENT_SUBCLASS_BAD_SUBCLASS_TYPE,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "type of 'event' must be either an object or an array of objects");
     return false;
   }
 
@@ -326,6 +351,7 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   if (!event_subclass_json.HasMember("name")) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_NO_SUBCLASS_NAME,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error("no name provided for event subclass");
     return false;
   }
 
@@ -339,6 +365,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
       if (!it->IsString()) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_BAD_SUBCLASS_NAME_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "event subclass name within an array should be of a string type");
         return false;
       }
 
@@ -347,6 +375,9 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   } else {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_BAD_SUBCLASS_NAME_LIST_TYPE,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "event subclass name type must be either string or an array of "
+        "strings");
     return false;
   }
 
@@ -356,6 +387,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   if (has_log_tag && has_abort_tag) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_CONDITION_DUPLICATED,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "there must be only one condition provided, 'log' or 'abort'");
     return false;
   }
 
@@ -377,6 +410,7 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
     if (!print_json.IsObject()) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
                       audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("failed to parse 'print' replacement rule");
       return false;
     }
     // There may be a few actions modifying record content defined within
@@ -390,6 +424,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_UNKNOWN_TAG,
                         audit_rule->get_rule_name().c_str(),
                         it->name.GetString());
+        audit_rule->set_parse_error(std::string("unknown tag '") +
+                                    it->name.GetString() + "'");
         return false;
       }
 
@@ -400,6 +436,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_BAD_ACTION_FORMAT,
                         audit_rule->get_rule_name().c_str(),
                         it->name.GetString());
+        audit_rule->set_parse_error(std::string("bad format for '") +
+                                    it->name.GetString() + "' action");
         return false;
       }
 
@@ -416,6 +454,7 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
     if (replace_filter_action == nullptr) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_BAD_REPLACEMENT_RULE,
                       audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("failed to parse 'filter' replacement rule");
       return false;
     }
 
@@ -463,6 +502,8 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
     LogComponentErr(ERROR_LEVEL,
                     ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_TYPE,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "the 'log' field must be of bool or object type");
     return EventFieldConditionType::Unknown;
   }
 
@@ -470,6 +511,8 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
     LogComponentErr(ERROR_LEVEL,
                     ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_FORMAT,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "there must be only one condition specified for 'log' field");
     return EventFieldConditionType::Unknown;
   }
 
@@ -478,6 +521,8 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
   if (!condition->name.IsString()) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_CONDITION_TYPE_BAD_COND_TYPE,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error(
+        "the 'log' condition name must be of string type");
     return EventFieldConditionType::Unknown;
   }
 
@@ -500,6 +545,8 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
   LogComponentErr(ERROR_LEVEL,
                   ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_NAME,
                   audit_rule->get_rule_name().c_str(), condition_name.c_str());
+  audit_rule->set_parse_error("unknown 'log' condition name '" +
+                              condition_name + "'");
 
   return EventFieldConditionType::Unknown;
 }
@@ -528,6 +575,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
       if (!condition_json["field"].IsObject()) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_CONDITION_BAD_FIELD_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "condition definition 'field' must be of object type");
         return nullptr;
       }
 
@@ -538,6 +587,9 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "event field definition 'field' must have field 'name' and "
+            "'value' provided as strings");
         return nullptr;
       }
 
@@ -577,6 +629,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
       if (!condition_json["and"].IsArray()) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_CONDITION_BAD_AND_COND_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "condition definition 'and' must be of array type");
         return nullptr;
       }
 
@@ -588,6 +642,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
           LogComponentErr(ERROR_LEVEL,
                           ER_AUDIT_PARSE_CONDITION_BAD_AND_COND_FORMAT,
                           audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "a member of 'and' condition must be of object type");
           return nullptr;
         }
 
@@ -610,6 +666,9 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_CONDITION_BAD_AND_COND_OPERANDS,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "there should be at least two fields provided for 'and' "
+            "condition");
         return nullptr;
       }
 
@@ -631,6 +690,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
       if (!condition_json["or"].IsArray()) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_CONDITION_BAD_OR_COND_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "condition definition 'or' must be of array type");
         return nullptr;
       }
 
@@ -642,6 +703,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
           LogComponentErr(ERROR_LEVEL,
                           ER_AUDIT_PARSE_CONDITION_BAD_OR_COND_FORMAT,
                           audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "a member of 'or' condition must be of object type");
           return nullptr;
         }
 
@@ -664,6 +727,9 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_CONDITION_BAD_OR_COND_OPERANDS,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "there should be at least two fields provided for 'or' "
+            "condition");
         return nullptr;
       }
 
@@ -680,6 +746,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
       if (!condition_json["not"].IsObject()) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_CONDITION_BAD_NOT_COND_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "condition definition 'not' must be of object type");
         return nullptr;
       }
 
@@ -715,6 +783,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_CONDITION_BAD_VARIABLE_COND_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "condition definition 'variable' must be of object type");
         return nullptr;
       }
 
@@ -725,6 +795,9 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_CONDITION_BAD_VARIABLE_NAME_AND_VALUE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "event field definition 'variable' must have field 'name' and "
+            "'value' provided as strings");
         return nullptr;
       }
 
@@ -767,12 +840,14 @@ std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
   if (!function_json.IsObject()) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_NOT_OBJECT,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error("'function' must be of object type");
     return nullptr;
   }
 
   if (!function_json.HasMember("name") || !function_json["name"].IsString()) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_NO_FUNCTION_NAME,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error("missing 'function' name or not a string");
     return nullptr;
   }
 
@@ -782,6 +857,7 @@ std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
   if (func_type == EventFilterFunctionType::Unknown) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_UNKNOWN_FUNCTION_NAME,
                     audit_rule->get_rule_name().c_str(), func_name.c_str());
+    audit_rule->set_parse_error("unknown function name '" + func_name + "'");
     return nullptr;
   }
 
@@ -791,12 +867,15 @@ std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
       !parse_function_args_json(function_json["args"], args)) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_BAD_ARGS_FORMAT,
                     audit_rule->get_rule_name().c_str());
+    audit_rule->set_parse_error("wrong function args format provided");
     return nullptr;
   }
 
   if (!validate_filter_function_args(func_type, args, expected_return_type)) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_BAD_ARGS,
                     audit_rule->get_rule_name().c_str(), func_name.c_str());
+    audit_rule->set_parse_error("invalid arguments for '" + func_name +
+                                "' function");
     return nullptr;
   }
 
@@ -893,6 +972,7 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
       if (block_cond == nullptr) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_ACTION_BAD_ABORT_TYPE,
                         audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error("'abort' must be of bool or object type");
         return nullptr;
       }
 
@@ -934,6 +1014,8 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
               replaced_field_name)) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_ACTION_BAD_REPLACE,
                         replaced_field_name.c_str());
+        audit_rule->set_parse_error("event field '" + replaced_field_name +
+                                    "' cannot be replaced");
         return nullptr;
       }
 

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -203,9 +203,14 @@ bool AuditRuleParser::parse_event_class_obj_json(
 
   std::shared_ptr<EventFieldActionBase> replace_field;
 
+  const std::string early_class_name =
+      event_class_json["name"].IsString() ? event_class_json["name"].GetString()
+                                          : std::string{};
+
   if (event_class_json.HasMember("print")) {
-    replace_field = parse_action_json(EventActionType::ReplaceField,
-                                      event_class_json, audit_rule);
+    replace_field =
+        parse_action_json(EventActionType::ReplaceField, event_class_json,
+                          early_class_name, audit_rule);
 
     if (replace_field == nullptr) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
@@ -395,8 +400,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   const EventActionType log_action_type =
       has_abort_tag ? EventActionType::Block : EventActionType::Log;
 
-  std::shared_ptr<EventFieldActionBase> log_action =
-      parse_action_json(log_action_type, event_subclass_json, audit_rule);
+  std::shared_ptr<EventFieldActionBase> log_action = parse_action_json(
+      log_action_type, event_subclass_json, class_name, audit_rule);
 
   if (log_action == nullptr) {
     return false;
@@ -429,8 +434,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
         return false;
       }
 
-      auto action =
-          parse_action_json(action_type, event_subclass_json, audit_rule);
+      auto action = parse_action_json(action_type, event_subclass_json,
+                                      class_name, audit_rule);
 
       if (action == nullptr) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_BAD_ACTION_FORMAT,
@@ -448,8 +453,9 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
   std::shared_ptr<EventFieldActionBase> replace_filter_action;
 
   if (event_subclass_json.HasMember("filter")) {
-    replace_filter_action = parse_action_json(EventActionType::ReplaceFilter,
-                                              event_subclass_json, audit_rule);
+    replace_filter_action =
+        parse_action_json(EventActionType::ReplaceFilter, event_subclass_json,
+                          class_name, audit_rule);
 
     if (replace_filter_action == nullptr) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_BAD_REPLACEMENT_RULE,
@@ -471,14 +477,16 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
 }
 
 std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition(
-    const rapidjson::Value &condition_json, AuditRule *audit_rule) noexcept {
+    const rapidjson::Value &condition_json, const std::string &class_name,
+    AuditRule *audit_rule) noexcept {
   auto cond_type = get_condition_type(condition_json, audit_rule);
 
   if (cond_type == EventFieldConditionType::Unknown) {
     return nullptr;
   }
 
-  return parse_condition_json(condition_json, cond_type, audit_rule);
+  return parse_condition_json(condition_json, cond_type, class_name,
+                              audit_rule);
 }
 
 EventFieldConditionType AuditRuleParser::get_condition_type(
@@ -553,7 +561,8 @@ EventFieldConditionType AuditRuleParser::get_condition_type(
 
 std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
     const rapidjson::Value &condition_json,
-    const EventFieldConditionType cond_type, AuditRule *audit_rule) noexcept {
+    const EventFieldConditionType cond_type, const std::string &class_name,
+    AuditRule *audit_rule) noexcept {
   assert(condition_json.IsBool() || condition_json.IsObject());
 
   switch (cond_type) {
@@ -595,6 +604,18 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
 
       std::string field_name{condition_json["field"]["name"].GetString()};
       std::string field_value{condition_json["field"]["value"].GetString()};
+
+      if (!class_name.empty() &&
+          !is_valid_event_field_name(class_name, field_name)) {
+        LogComponentErr(ERROR_LEVEL,
+                        ER_AUDIT_PARSE_CONDITION_FIELD_NAME_NOT_FOUND,
+                        audit_rule->get_rule_name().c_str(), field_name.c_str(),
+                        class_name.c_str());
+        audit_rule->set_parse_error("field name '" + field_name +
+                                    "' is not valid for event class '" +
+                                    class_name + "'");
+        return nullptr;
+      }
 
       if (field_name == CONNECTION_TYPE_FIELD_NAME) {
         /*
@@ -653,7 +674,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
           return nullptr;
         }
 
-        auto condition = parse_condition_json(*it, sub_cond_type, audit_rule);
+        auto condition =
+            parse_condition_json(*it, sub_cond_type, class_name, audit_rule);
 
         if (condition == nullptr) {
           return nullptr;
@@ -714,7 +736,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
           return nullptr;
         }
 
-        auto condition = parse_condition_json(*it, sub_cond_type, audit_rule);
+        auto condition =
+            parse_condition_json(*it, sub_cond_type, class_name, audit_rule);
 
         if (condition == nullptr) {
           return nullptr;
@@ -758,8 +781,8 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
         return nullptr;
       }
 
-      auto condition = parse_condition_json(condition_json["not"],
-                                            sub_cond_type, audit_rule);
+      auto condition = parse_condition_json(
+          condition_json["not"], sub_cond_type, class_name, audit_rule);
 
       if (condition == nullptr) {
         return nullptr;
@@ -817,8 +840,9 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
        *   }
        * }
        */
-      auto func = parse_function(condition_json["function"],
-                                 FunctionReturnType::Bool, audit_rule);
+      auto func =
+          parse_function(condition_json["function"], FunctionReturnType::Bool,
+                         class_name, audit_rule);
 
       if (func == nullptr) {
         return nullptr;
@@ -836,7 +860,7 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
 std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
     const rapidjson::Value &function_json,
     const FunctionReturnType expected_return_type,
-    AuditRule *audit_rule) noexcept {
+    const std::string &class_name, AuditRule *audit_rule) noexcept {
   if (!function_json.IsObject()) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_NOT_OBJECT,
                     audit_rule->get_rule_name().c_str());
@@ -864,7 +888,8 @@ std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
   FunctionArgsList args;
 
   if (function_json.HasMember("args") &&
-      !parse_function_args_json(function_json["args"], args)) {
+      !parse_function_args_json(function_json["args"], args, class_name,
+                                audit_rule)) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_BAD_ARGS_FORMAT,
                     audit_rule->get_rule_name().c_str());
     audit_rule->set_parse_error("wrong function args format provided");
@@ -883,8 +908,8 @@ std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
 }
 
 bool AuditRuleParser::parse_function_args_json(
-    const rapidjson::Value &function_args_json,
-    FunctionArgsList &args) noexcept {
+    const rapidjson::Value &function_args_json, FunctionArgsList &args,
+    const std::string &class_name, AuditRule *audit_rule) noexcept {
   /*
    * Parse 'function' arguments list, must be an array of objects with each
    * object containing argument type and its value along with the value source
@@ -937,8 +962,22 @@ bool AuditRuleParser::parse_function_args_json(
       return false;
     }
 
-    args.push_back(
-        {arg_type, arg_source_type, arg_value_json->value.GetString()});
+    const std::string arg_value = arg_value_json->value.GetString();
+
+    if (arg_source_type == FunctionArgSourceType::Field &&
+        !class_name.empty() &&
+        !is_valid_event_field_name(class_name, arg_value)) {
+      LogComponentErr(ERROR_LEVEL,
+                      ER_AUDIT_PARSE_CONDITION_FIELD_NAME_NOT_FOUND,
+                      audit_rule->get_rule_name().c_str(), arg_value.c_str(),
+                      class_name.c_str());
+      audit_rule->set_parse_error("field name '" + arg_value +
+                                  "' is not valid for event class '" +
+                                  class_name + "'");
+      return false;
+    }
+
+    args.push_back({arg_type, arg_source_type, arg_value});
   }
 
   return true;
@@ -946,7 +985,7 @@ bool AuditRuleParser::parse_function_args_json(
 
 std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
     const EventActionType action_type, const rapidjson::Value &action_json,
-    AuditRule *audit_rule) noexcept {
+    const std::string &class_name, AuditRule *audit_rule) noexcept {
   assert(action_json.IsObject());
 
   switch (action_type) {
@@ -954,7 +993,7 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
       std::shared_ptr<EventFieldConditionBase> log_cond;
 
       if (action_json.HasMember("log")) {
-        log_cond = parse_condition(action_json["log"], audit_rule);
+        log_cond = parse_condition(action_json["log"], class_name, audit_rule);
 
         if (log_cond == nullptr) {
           return nullptr;
@@ -967,7 +1006,8 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
       return std::make_shared<EventFieldActionLog>(log_cond);
     }
     case EventActionType::Block: {
-      auto block_cond = parse_condition(action_json["abort"], audit_rule);
+      auto block_cond =
+          parse_condition(action_json["abort"], class_name, audit_rule);
 
       if (block_cond == nullptr) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_ACTION_BAD_ABORT_TYPE,
@@ -1019,7 +1059,8 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
         return nullptr;
       }
 
-      auto print_cond = parse_condition(field_json["print"], audit_rule);
+      auto print_cond =
+          parse_condition(field_json["print"], class_name, audit_rule);
 
       if (print_cond == nullptr) {
         return nullptr;
@@ -1032,7 +1073,7 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
 
       auto replacement_func =
           parse_function(field_json["replace"]["function"],
-                         FunctionReturnType::String, audit_rule);
+                         FunctionReturnType::String, class_name, audit_rule);
 
       if (replacement_func == nullptr) {
         return nullptr;
@@ -1078,8 +1119,8 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
         return nullptr;
       }
 
-      auto activation_cond =
-          parse_condition(action_json["filter"]["activate"], audit_rule);
+      auto activation_cond = parse_condition(action_json["filter"]["activate"],
+                                             class_name, audit_rule);
 
       if (activation_cond == nullptr) {
         return nullptr;

--- a/components/audit_log_filter/audit_rule_parser.h
+++ b/components/audit_log_filter/audit_rule_parser.h
@@ -115,11 +115,13 @@ class AuditRuleParser {
    *        represented by a JSON string.
    *
    * @param condition_json JSON object representing condition definition
+   * @param class_name Audit event class name for field name validation
    * @param audit_rule Audit filtering rule instance to be initialized
    * @return Pointer to an instance representing parsed condition
    */
   static std::shared_ptr<EventFieldConditionBase> parse_condition(
-      const rapidjson::Value &condition_json, AuditRule *audit_rule) noexcept;
+      const rapidjson::Value &condition_json, const std::string &class_name,
+      AuditRule *audit_rule) noexcept;
 
   /**
    * @brief Get type of condition specified for an event field.
@@ -137,12 +139,13 @@ class AuditRuleParser {
    *
    * @param condition_json JSON object representing audit event filter condition
    * @param cond_type Condition type, one of @ref EventFieldConditionType
+   * @param class_name Audit event class name for field name validation
    * @param audit_rule Audit filtering rule instance to be initialized
    * @return Logical condition instance
    */
   static std::shared_ptr<EventFieldConditionBase> parse_condition_json(
       const rapidjson::Value &condition_json, EventFieldConditionType cond_type,
-      AuditRule *audit_rule) noexcept;
+      const std::string &class_name, AuditRule *audit_rule) noexcept;
 
   /**
    * @brief Parse function definition in a filtering rule represented by
@@ -150,12 +153,14 @@ class AuditRuleParser {
    *
    * @param function_json JSON object representing a function
    * @param expected_return_type Expected return type of the function
+   * @param class_name Audit event class name for field name validation
    * @param audit_rule Audit filtering rule instance to be initialized
    * @return Function instance
    */
   static std::unique_ptr<EventFilterFunctionBase> parse_function(
       const rapidjson::Value &function_json,
-      FunctionReturnType expected_return_type, AuditRule *audit_rule) noexcept;
+      FunctionReturnType expected_return_type, const std::string &class_name,
+      AuditRule *audit_rule) noexcept;
 
   /**
    * @brief Parse function arguments in a filtering rule represented
@@ -163,11 +168,13 @@ class AuditRuleParser {
    *
    * @param function_args_obj JSON object representing function arguments
    * @param args Container to store parsed arguments in
+   * @param class_name Audit event class name for field name validation
+   * @param audit_rule Audit filtering rule instance to be initialized
    * @return true in case of success, false otherwise
    */
   static bool parse_function_args_json(
-      const rapidjson::Value &function_args_obj,
-      FunctionArgsList &args) noexcept;
+      const rapidjson::Value &function_args_obj, FunctionArgsList &args,
+      const std::string &class_name, AuditRule *audit_rule) noexcept;
 
   /**
    * @brief Parse action definition in a filtering rule represented by
@@ -175,12 +182,13 @@ class AuditRuleParser {
    *
    * @param action_type Action type
    * @param action_json JSON object representing action
+   * @param class_name Audit event class name for field name validation
    * @param audit_rule Audit filtering rule instance to be initialized
    * @return Action instance
    */
   [[nodiscard]] static std::shared_ptr<EventFieldActionBase> parse_action_json(
       EventActionType action_type, const rapidjson::Value &action_json,
-      AuditRule *audit_rule) noexcept;
+      const std::string &class_name, AuditRule *audit_rule) noexcept;
 
   /**
    * @brief Build replacement filtering rule.

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -13,7 +13,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
-#define ALLOW_COMPONENT_INCLUDE // for plugin.h
+#define ALLOW_COMPONENT_INCLUDE  // for plugin.h
 #include "components/audit_log_filter/audit_udf.h"
 #include "components/audit_log_filter/audit_error_log.h"
 
@@ -31,7 +31,7 @@
 
 #include "rapidjson/document.h"
 
-#include <mysql/components/services/bits/my_err_bits.h> // MYSQL_ERRMSG_SIZE
+#include <mysql/components/services/bits/my_err_bits.h>  // MYSQL_ERRMSG_SIZE
 #include <mysql/components/services/dynamic_privilege.h>
 #include <mysql/components/services/mysql_current_thread_reader.h>
 #include <mysql/components/services/security_context.h>
@@ -312,8 +312,14 @@ char *AuditUdf::audit_log_filter_set_filter_udf(
   if (!AuditRuleParser::parse(udf_args->args[1], rule.get())) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_UDF_SET_FILTER_BAD_DEFINITION,
                     udf_args->args[1]);
-    std::snprintf(result, MYSQL_ERRMSG_SIZE,
-                  "ERROR: Incorrect rule definition");
+    if (rule->get_parse_error().empty()) {
+      std::snprintf(result, MYSQL_ERRMSG_SIZE,
+                    "ERROR: Incorrect rule definition");
+    } else {
+      std::snprintf(result, MYSQL_ERRMSG_SIZE,
+                    "ERROR: Incorrect rule definition: %s",
+                    rule->get_parse_error().c_str());
+    }
     *length = std::strlen(result);
     return result;
   }

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_function_query_digest.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_function_query_digest.result
@@ -81,7 +81,7 @@ audit_log_filter_set_filter('log_by_digest_no_args', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: invalid arguments for 'query_digest' function
 #
 # Wrong arguments for query_digest()
 SELECT audit_log_filter_set_filter('wrong_digest_type', '{
@@ -120,7 +120,7 @@ audit_log_filter_set_filter('wrong_digest_type', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: wrong function args format provided
 SELECT audit_log_filter_set_filter('too_many_args', '{
 "filter": {
 "class": {
@@ -152,7 +152,7 @@ audit_log_filter_set_filter('too_many_args', '{
 "args": [
 {"string": {"string": "INSERT INTO `t` VALUES (?)"}},
 {"string": {"string": "unexp
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: invalid arguments for 'query_digest' function
 SELECT * FROM mysql.audit_log_filter;
 filter_id	name	filter
 1	log_by_digest	{"filter": {"class": {"name": "query", "event": {"log": {"function": {"args": [{"string": {"string": "INSERT INTO `t` VALUES (?)"}}], "name": "query_digest"}}, "name": "start"}}}}

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_function_string_find.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_function_string_find.result
@@ -127,7 +127,7 @@ audit_log_filter_set_filter('missing_args', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: invalid arguments for 'string_find' function
 SELECT audit_log_filter_set_filter('one_missing_arg', '{
 "filter": {
 "class": {
@@ -164,7 +164,7 @@ audit_log_filter_set_filter('one_missing_arg', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: invalid arguments for 'string_find' function
 SELECT audit_log_filter_set_filter('wrong_pattern_type', '{
 "filter": {
 "class": {
@@ -199,7 +199,7 @@ audit_log_filter_set_filter('wrong_pattern_type', '{
 ]
 }
 }
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: wrong function args format provided
 SELECT audit_log_filter_set_filter('wrong_field_type', '{
 "filter": {
 "class": {
@@ -238,7 +238,7 @@ audit_log_filter_set_filter('wrong_field_type', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: wrong function args format provided
 #
 # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_print_query_attrs.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_print_query_attrs.result
@@ -145,7 +145,7 @@ audit_log_filter_set_filter('query_attrs_no_tag', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'query_attributes' action
 SELECT audit_log_filter_set_filter('query_attrs_bad_tag', '{
 "filter": {
 "class": {
@@ -184,7 +184,7 @@ audit_log_filter_set_filter('query_attrs_bad_tag', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'query_attributes' action
 #
 # Wrong format, missing "element" or invalid format
 SELECT audit_log_filter_set_filter('query_attrs_no_element', '{
@@ -217,7 +217,7 @@ audit_log_filter_set_filter('query_attrs_no_element', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'query_attributes' action
 SELECT audit_log_filter_set_filter('query_attrs_element_not_arr', '{
 "filter": {
 "class": {
@@ -250,7 +250,7 @@ audit_log_filter_set_filter('query_attrs_element_not_arr', '{
 "name": "attr1",
 "name": "attr2"
          
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'query_attributes' action
 SELECT audit_log_filter_set_filter('query_attrs_element_empty', '{
 "filter": {
 "class": {
@@ -283,7 +283,7 @@ audit_log_filter_set_filter('query_attrs_element_empty', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'query_attributes' action
 SELECT audit_log_filter_set_filter('query_attrs_element_bad_args', '{
 "filter": {
 "class": {
@@ -320,7 +320,7 @@ audit_log_filter_set_filter('query_attrs_element_bad_args', '{
 }
 }
 
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'query_attributes' action
 #
 # Cleanup
 DROP TABLE t1;

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_print_query_statistics.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_print_query_statistics.result
@@ -129,7 +129,7 @@ audit_log_filter_set_filter('query_stats_no_tag', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'service' action
 SELECT audit_log_filter_set_filter('query_stats_bad_tag', '{
 "filter": {
 "class": {
@@ -166,7 +166,7 @@ audit_log_filter_set_filter('query_stats_bad_tag', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'service' action
 #
 # Wrong format, missing "element" or invalid format
 SELECT audit_log_filter_set_filter('query_stats_no_element', '{
@@ -199,7 +199,7 @@ audit_log_filter_set_filter('query_stats_no_element', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'service' action
 SELECT audit_log_filter_set_filter('query_stats_element_not_arr', '{
 "filter": {
 "class": {
@@ -234,7 +234,7 @@ audit_log_filter_set_filter('query_stats_element_not_arr', '{
             }
 }
 }
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'service' action
 SELECT audit_log_filter_set_filter('query_stats_element_empty', '{
 "filter": {
 "class": {
@@ -267,7 +267,7 @@ audit_log_filter_set_filter('query_stats_element_empty', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'service' action
 SELECT audit_log_filter_set_filter('query_stats_element_bad_args', '{
 "filter": {
 "class": {
@@ -304,7 +304,7 @@ audit_log_filter_set_filter('query_stats_element_bad_args', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: bad format for 'service' action
 #
 # Cleanup
 DROP TABLE t1;

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
@@ -327,7 +327,7 @@ audit_log_filter_set_filter('incorrect_rule', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: event field 'status' cannot be replaced
 SELECT audit_log_filter_set_filter('incorrect_rule', '{
 "filter": {
 "class": {
@@ -356,7 +356,7 @@ audit_log_filter_set_filter('incorrect_rule', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: event field 'connection_id' cannot be replaced
 SELECT audit_log_filter_set_filter('incorrect_rule', '{
 "filter": {
 "log": false,
@@ -383,7 +383,7 @@ audit_log_filter_set_filter('incorrect_rule', '{
 }
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: failed to parse 'print' replacement rule
 SELECT audit_log_filter_set_filter('incorrect_rule', '{
 "filter": {
 "class": [
@@ -424,7 +424,7 @@ audit_log_filter_set_filter('incorrect_rule', '{
 ]
 }
 }')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: the 'log' field must be of bool or object type
 #
 # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_set_filter.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_set_filter.result
@@ -31,10 +31,10 @@ ERROR HY000: Can't initialize function 'audit_log_filter_set_filter'; Wrong argu
 # Filter validity check, incorrect JSON
 SELECT audit_log_filter_set_filter('filter_1', '{}');
 audit_log_filter_set_filter('filter_1', '{}')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: missing or invalid 'filter' object
 SELECT audit_log_filter_set_filter('filter_1', '{"filter": {"class": {"name": "connection"}}}}');
 audit_log_filter_set_filter('filter_1', '{"filter": {"class": {"name": "connection"}}}}')
-ERROR: Incorrect rule definition
+ERROR: Incorrect rule definition: JSON parse error
 SELECT * FROM mysql.audit_log_filter;
 filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13752,6 +13752,9 @@ ER_AUDIT_PARSE_CONDITION_TYPE_UNEXPECTED_COND_TYPE
 ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY
   eng "Invalid audit log filter file directory: %s"
 
+ER_AUDIT_PARSE_CONDITION_FIELD_NAME_NOT_FOUND
+  eng "Wrong JSON filter '%s' format, field name '%s' is not valid for event class '%s'"
+
 #
 # End of Audit Log Filter error log messages
 #


### PR DESCRIPTION
audit_log_filter_set_filter() UDF returned a generic
"ERROR: Incorrect rule definition" message to the SQL client while the
detailed parse error was only written to the server error log. This made
it hard to diagnose filter definition issues without access to the error
log.

Add m_parse_error field to AuditRule and populate it alongside every
LogComponentErr call in the parser. The UDF now returns
"ERROR: Incorrect rule definition: <specific reason>" so the user gets
actionable feedback directly in the SQL result.

Percona Server accepted audit log filters with unknown field names
(e.g. "WRONG.str") without error, while MySQL Enterprise rejects them
with "Field name not found". Filters with invalid field names were
silently stored but their conditions never matched at runtime.

Add parse-time validation of field names in audit_log_filter_set_filter
against a per-event-class registry of known fields. Unknown field names
now cause the filter to be rejected with "Incorrect rule definition",
matching MySQL Enterprise behavior.

The validation covers field conditions ("log": {"field": ...}) and
function arguments ({"string": {"field": "..."}}).
