### PR TITLE
PS-10348 [8.4]: Add typed field values to audit log filter

### DIFF
--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -334,7 +334,52 @@ inline std::string mysql_cstring_len_to_string(
   return str != nullptr ? std::to_string(str->length) : "0";
 }
 
+inline uint64_t mysql_cstring_len_to_uint64(
+    const mysql_cstring_with_length *str) {
+  return str != nullptr ? static_cast<uint64_t>(str->length) : 0;
+}
+
 }  // namespace
+
+std::string field_value_to_string(const AuditRecordFieldValue &value) {
+  return std::visit(
+      [](const auto &v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::string>)
+          return v;
+        else
+          return std::to_string(v);
+      },
+      value);
+}
+
+bool field_value_matches(const AuditRecordFieldValue &value,
+                         const std::string &expected) {
+  return std::visit(
+      [&expected](const auto &v) -> bool {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::string>) {
+          return v == expected;
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+          try {
+            size_t pos = 0;
+            int64_t num = std::stoll(expected, &pos);
+            return pos == expected.size() && v == num;
+          } catch (...) {
+            return false;
+          }
+        } else {
+          try {
+            size_t pos = 0;
+            uint64_t num = std::stoull(expected, &pos);
+            return pos == expected.size() && v == num;
+          } catch (...) {
+            return false;
+          }
+        }
+      },
+      value);
+}
 
 AuditRecordVariant get_audit_record(audit_event_class_t event_class,
                                     const void *event) {
@@ -525,32 +570,37 @@ void update_connection_type_pseudo_to_numeric(std::string &type) {
   }
 }
 
+bool is_valid_connection_type_value(const std::string &value) {
+  static const std::set<std::string> valid_values{"0", "1", "2", "3", "4", "5"};
+  return valid_values.count(value) != 0;
+}
+
 AuditRecordFieldsList get_audit_record_fields(
     const AuditRecordGeneral &record) {
   const auto *event = record.event;
   const auto &extra = record.extended_info;
 
   return {
-      {"general_error_code", std::to_string(event->error_code)},
+      {"general_error_code", static_cast<int64_t>(event->error_code)},
       // alias for general_connection_id
-      {"general_thread_id", std::to_string(event->connection_id)},
-      {"general_connection_id", std::to_string(event->connection_id)},
+      {"general_thread_id", static_cast<uint64_t>(event->connection_id)},
+      {"general_connection_id", static_cast<uint64_t>(event->connection_id)},
       {"general_user.str", extra.user},
-      {"general_user.length", std::to_string(extra.user.length())},
+      {"general_user.length", static_cast<uint64_t>(extra.user.length())},
       {"general_command.str", extra.command},
-      {"general_command.length", std::to_string(extra.command.length())},
+      {"general_command.length", static_cast<uint64_t>(extra.command.length())},
       {"general_query.str", extra.query},
-      {"general_query.length", std::to_string(extra.query.length())},
+      {"general_query.length", static_cast<uint64_t>(extra.query.length())},
       {"general_host.str", extra.host},
-      {"general_host.length", std::to_string(extra.host.length())},
+      {"general_host.length", static_cast<uint64_t>(extra.host.length())},
       {"general_sql_command.str", extra.sql_command},
       {"general_sql_command.length",
-       std::to_string(extra.sql_command.length())},
+       static_cast<uint64_t>(extra.sql_command.length())},
       {"general_external_user.str", extra.external_user},
       {"general_external_user.length",
-       std::to_string(extra.external_user.length())},
+       static_cast<uint64_t>(extra.external_user.length())},
       {"general_ip.str", extra.ip},
-      {"general_ip.length", std::to_string(extra.ip.length())},
+      {"general_ip.length", static_cast<uint64_t>(extra.ip.length())},
   };
 }
 
@@ -558,24 +608,24 @@ AuditRecordFieldsList get_audit_record_fields(
     const AuditRecordConnection &record) {
   const auto *event = record.event;
   return {
-      {"status", std::to_string(event->status)},
-      {"connection_id", std::to_string(event->connection_id)},
+      {"status", static_cast<int64_t>(event->status)},
+      {"connection_id", static_cast<uint64_t>(event->connection_id)},
       {"user.str", mysql_cstring_to_string(&event->user)},
-      {"user.length", mysql_cstring_len_to_string(&event->user)},
+      {"user.length", mysql_cstring_len_to_uint64(&event->user)},
       {"priv_user.str", mysql_cstring_to_string(&event->priv_user)},
-      {"priv_user.length", mysql_cstring_len_to_string(&event->priv_user)},
+      {"priv_user.length", mysql_cstring_len_to_uint64(&event->priv_user)},
       {"external_user.str", mysql_cstring_to_string(&event->external_user)},
       {"external_user.length",
-       mysql_cstring_len_to_string(&event->external_user)},
+       mysql_cstring_len_to_uint64(&event->external_user)},
       {"proxy_user.str", mysql_cstring_to_string(&event->proxy_user)},
-      {"proxy_user.length", mysql_cstring_len_to_string(&event->proxy_user)},
+      {"proxy_user.length", mysql_cstring_len_to_uint64(&event->proxy_user)},
       {"host.str", mysql_cstring_to_string(&event->host)},
-      {"host.length", mysql_cstring_len_to_string(&event->host)},
+      {"host.length", mysql_cstring_len_to_uint64(&event->host)},
       {"ip.str", mysql_cstring_to_string(&event->ip)},
-      {"ip.length", mysql_cstring_len_to_string(&event->ip)},
+      {"ip.length", mysql_cstring_len_to_uint64(&event->ip)},
       {"database.str", mysql_cstring_to_string(&event->database)},
-      {"database.length", mysql_cstring_len_to_string(&event->database)},
-      {"connection_type", std::to_string(event->connection_type)},
+      {"database.length", mysql_cstring_len_to_uint64(&event->database)},
+      {"connection_type", static_cast<int64_t>(event->connection_type)},
   };
 }
 
@@ -585,15 +635,15 @@ AuditRecordFieldsList get_audit_record_fields(
   const auto &extra = record.extended_info;
 
   return {
-      {"connection_id", std::to_string(event->connection_id)},
-      {"sql_command_id", std::to_string(extra.sql_command_id)},
+      {"connection_id", static_cast<uint64_t>(event->connection_id)},
+      {"sql_command_id", static_cast<int64_t>(extra.sql_command_id)},
       {"query.str", extra.query},
-      {"query.length", std::to_string(extra.query.length())},
+      {"query.length", static_cast<uint64_t>(extra.query.length())},
       {"table_database.str", mysql_cstring_to_string(&event->table_database)},
       {"table_database.length",
-       mysql_cstring_len_to_string(&event->table_database)},
+       mysql_cstring_len_to_uint64(&event->table_database)},
       {"table_name.str", mysql_cstring_to_string(&event->table_name)},
-      {"table_name.length", mysql_cstring_len_to_string(&event->table_name)},
+      {"table_name.length", mysql_cstring_len_to_uint64(&event->table_name)},
   };
 }
 
@@ -762,6 +812,53 @@ bool is_valid_event_field_name(const std::string &event_class_name,
   }
 
   return class_it->second.count(field_name) > 0;
+}
+
+EventFieldValueType get_event_field_value_type(
+    const std::string &event_class_name, const std::string &field_name) {
+  using FieldTypeMap = std::map<std::string, EventFieldValueType>;
+  static const std::unordered_map<std::string, FieldTypeMap> field_type_map{
+      {"connection",
+       {{"status", EventFieldValueType::SignedInteger},
+        {"connection_id", EventFieldValueType::UnsignedInteger},
+        {"user.length", EventFieldValueType::UnsignedInteger},
+        {"priv_user.length", EventFieldValueType::UnsignedInteger},
+        {"external_user.length", EventFieldValueType::UnsignedInteger},
+        {"proxy_user.length", EventFieldValueType::UnsignedInteger},
+        {"host.length", EventFieldValueType::UnsignedInteger},
+        {"ip.length", EventFieldValueType::UnsignedInteger},
+        {"database.length", EventFieldValueType::UnsignedInteger},
+        {"connection_type", EventFieldValueType::SignedInteger}}},
+      {"general",
+       {{"general_error_code", EventFieldValueType::SignedInteger},
+        {"general_thread_id", EventFieldValueType::UnsignedInteger},
+        {"general_connection_id", EventFieldValueType::UnsignedInteger},
+        {"general_user.length", EventFieldValueType::UnsignedInteger},
+        {"general_command.length", EventFieldValueType::UnsignedInteger},
+        {"general_query.length", EventFieldValueType::UnsignedInteger},
+        {"general_host.length", EventFieldValueType::UnsignedInteger},
+        {"general_sql_command.length", EventFieldValueType::UnsignedInteger},
+        {"general_external_user.length", EventFieldValueType::UnsignedInteger},
+        {"general_ip.length", EventFieldValueType::UnsignedInteger}}},
+      {"table_access",
+       {{"connection_id", EventFieldValueType::UnsignedInteger},
+        {"sql_command_id", EventFieldValueType::SignedInteger},
+        {"query.length", EventFieldValueType::UnsignedInteger},
+        {"table_database.length", EventFieldValueType::UnsignedInteger},
+        {"table_name.length", EventFieldValueType::UnsignedInteger}}},
+  };
+
+  const auto class_it = field_type_map.find(event_class_name);
+  if (class_it == field_type_map.cend()) {
+    return EventFieldValueType::String;
+  }
+
+  const auto field_it = class_it->second.find(field_name);
+  if (field_it == class_it->second.cend()) {
+    return EventFieldValueType::String;
+  }
+
+  return field_it->second;
 }
 
 }  // namespace audit_log_filter

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -28,64 +28,76 @@
 #include <mysql/components/services/event_tracking_stored_program_service.h>
 #include <mysql/components/services/event_tracking_table_access_service.h>
 
+#include <algorithm>
+#include <array>
 #include <cstring>
 #include <unordered_map>
 
 namespace audit_log_filter {
 namespace {
-const std::string_view kClassNameGeneral{"general"};
-const std::string_view kClassNameConnection{"connection"};
-const std::string_view kClassNameAuthorization{"authorization"};
-const std::string_view kClassNameTableAccess{"table_access"};
-const std::string_view kClassNameGlobalVariable{"global_variable"};
-const std::string_view kClassNameServerStartup{"server_startup"};
-const std::string_view kClassNameServerShutdown{"server_shutdown"};
-const std::string_view kClassNameCommand{"command"};
-const std::string_view kClassNameQuery{"query"};
-const std::string_view kClassNameStoredProgram{"stored_program"};
-const std::string_view kClassNameAuthentication{"authentication"};
-const std::string_view kClassNameMessage{"message"};
-const std::string_view kClassNameParse{"parse"};
-const std::string_view kClassNameInternalAudit{"audit"};
+constexpr std::string_view kClassNameGeneral{"general"};
+constexpr std::string_view kClassNameConnection{"connection"};
+constexpr std::string_view kClassNameAuthorization{"authorization"};
+constexpr std::string_view kClassNameTableAccess{"table_access"};
+constexpr std::string_view kClassNameGlobalVariable{"global_variable"};
+constexpr std::string_view kClassNameServerStartup{"server_startup"};
+constexpr std::string_view kClassNameServerShutdown{"server_shutdown"};
+constexpr std::string_view kClassNameCommand{"command"};
+constexpr std::string_view kClassNameQuery{"query"};
+constexpr std::string_view kClassNameStoredProgram{"stored_program"};
+constexpr std::string_view kClassNameAuthentication{"authentication"};
+constexpr std::string_view kClassNameMessage{"message"};
+constexpr std::string_view kClassNameParse{"parse"};
+constexpr std::string_view kClassNameInternalAudit{"audit"};
 
-const std::string_view kSubclassNameGeneralLog{"log"};
-const std::string_view kSubclassNameGeneralError{"error"};
-const std::string_view kSubclassNameGeneralResult{"result"};
-const std::string_view kSubclassNameGeneralStatus{"status"};
-const std::string_view kSubclassNameUser{"user"};
-const std::string_view kSubclassNameRead{"read"};
-const std::string_view kSubclassNameInsert{"insert"};
-const std::string_view kSubclassNameUpdate{"update"};
-const std::string_view kSubclassNameDelete{"delete"};
-const std::string_view kSubclassNameGet{"get"};
-const std::string_view kSubclassNameSet{"set"};
-const std::string_view kSubclassNameStartup{"startup"};
-const std::string_view kSubclassNameShutdown{"shutdown"};
-const std::string_view kSubclassNameEnd{"end"};
-const std::string_view kSubclassNameStart{"start"};
-const std::string_view kSubclassNameNestedStart{"nested_start"};
-const std::string_view kSubclassNameStatusEnd{"status_end"};
-const std::string_view kSubclassNameNestedStatusEnd{"nested_status_end"};
-const std::string_view kSubclassNameExecute{"execute"};
-const std::string_view kSubclassNameFlush{"flush"};
-const std::string_view kSubclassNameAuthidCreate{"authid_create"};
-const std::string_view kSubclassNameCredentialChange{"credential_change"};
-const std::string_view kSubclassNameAuthidRename{"authid_rename"};
-const std::string_view kSubclassNameAuthidDrop{"authid_drop"};
-const std::string_view kSubclassNameConnect{"connect"};
-const std::string_view kSubclassNameDisconnect{"disconnect"};
-const std::string_view kSubclassNameChangeUser{"change_user"};
-const std::string_view kSubclassNamePreAuthenticate{"pre_authenticate"};
-const std::string_view kSubclassNameMessageInternal{"internal"};
-const std::string_view kSubclassNameInternalAudit{"audit"};
-const std::string_view kSubclassNameInternalNoAudit{"noaudit"};
-const std::string_view kSubclassNameParseRewriteNone{"rewrite_none"};
-const std::string_view kSubclassNameParseRewriteQueryRewritten{
+constexpr std::string_view kSubclassNameGeneralLog{"log"};
+constexpr std::string_view kSubclassNameGeneralError{"error"};
+constexpr std::string_view kSubclassNameGeneralResult{"result"};
+constexpr std::string_view kSubclassNameGeneralStatus{"status"};
+constexpr std::string_view kSubclassNameUser{"user"};
+constexpr std::string_view kSubclassNameRead{"read"};
+constexpr std::string_view kSubclassNameInsert{"insert"};
+constexpr std::string_view kSubclassNameUpdate{"update"};
+constexpr std::string_view kSubclassNameDelete{"delete"};
+constexpr std::string_view kSubclassNameGet{"get"};
+constexpr std::string_view kSubclassNameSet{"set"};
+constexpr std::string_view kSubclassNameStartup{"startup"};
+constexpr std::string_view kSubclassNameShutdown{"shutdown"};
+constexpr std::string_view kSubclassNameEnd{"end"};
+constexpr std::string_view kSubclassNameStart{"start"};
+constexpr std::string_view kSubclassNameNestedStart{"nested_start"};
+constexpr std::string_view kSubclassNameStatusEnd{"status_end"};
+constexpr std::string_view kSubclassNameNestedStatusEnd{"nested_status_end"};
+constexpr std::string_view kSubclassNameExecute{"execute"};
+constexpr std::string_view kSubclassNameFlush{"flush"};
+constexpr std::string_view kSubclassNameAuthidCreate{"authid_create"};
+constexpr std::string_view kSubclassNameCredentialChange{"credential_change"};
+constexpr std::string_view kSubclassNameAuthidRename{"authid_rename"};
+constexpr std::string_view kSubclassNameAuthidDrop{"authid_drop"};
+constexpr std::string_view kSubclassNameConnect{"connect"};
+constexpr std::string_view kSubclassNameDisconnect{"disconnect"};
+constexpr std::string_view kSubclassNameChangeUser{"change_user"};
+constexpr std::string_view kSubclassNamePreAuthenticate{"pre_authenticate"};
+constexpr std::string_view kSubclassNameMessageInternal{"internal"};
+constexpr std::string_view kSubclassNameInternalAudit{"audit"};
+constexpr std::string_view kSubclassNameInternalNoAudit{"noaudit"};
+constexpr std::string_view kSubclassNameParseRewriteNone{"rewrite_none"};
+constexpr std::string_view kSubclassNameParseRewriteQueryRewritten{
     "rewrite_query_rewritten"};
-const std::string_view kSubclassNameParseRewritePreparedStatement{
+constexpr std::string_view kSubclassNameParseRewritePreparedStatement{
     "rewrite_prepared_statement"};
 
-const std::string_view kNameUnknown{"unknown"};
+template <typename Container>
+bool contains_string_view(std::string_view value,
+                          const Container &valid_values) {
+  return std::find(valid_values.cbegin(), valid_values.cend(), value) !=
+         valid_values.cend();
+}
+
+template <typename>
+struct UnsupportedFieldValueType : std::false_type {};
+
+constexpr std::string_view kNameUnknown{"unknown"};
 
 std::string_view event_class_to_string(audit_event_class_t event_class) {
   switch (event_class) {
@@ -368,7 +380,7 @@ bool field_value_matches(const AuditRecordFieldValue &value,
           } catch (...) {
             return false;
           }
-        } else {
+        } else if constexpr (std::is_same_v<T, uint64_t>) {
           try {
             size_t pos = 0;
             uint64_t num = std::stoull(expected, &pos);
@@ -376,6 +388,9 @@ bool field_value_matches(const AuditRecordFieldValue &value,
           } catch (...) {
             return false;
           }
+        } else {
+          static_assert(UnsupportedFieldValueType<T>::value,
+                        "Unsupported AuditRecordFieldValue alternative");
         }
       },
       value);
@@ -570,9 +585,8 @@ void update_connection_type_pseudo_to_numeric(std::string &type) {
   }
 }
 
-bool is_valid_connection_type_value(const std::string &value) {
-  static const std::set<std::string> valid_values{"0", "1", "2", "3", "4", "5"};
-  return valid_values.count(value) != 0;
+bool is_valid_connection_type_value(std::string_view value) {
+  return value.size() == 1 && value[0] >= '0' && value[0] <= '5';
 }
 
 AuditRecordFieldsList get_audit_record_fields(
@@ -761,49 +775,162 @@ AuditRecordFieldsList get_audit_record_fields(const AuditRecordUnknown &record
   return {};
 }
 
-bool is_valid_event_field_name(const std::string &event_class_name,
-                               const std::string &field_name) {
-  using FieldSet = std::set<std::string>;
-  static const std::unordered_map<std::string, FieldSet> valid_fields_map{
-      {"general",
+bool is_valid_event_class_name(std::string_view class_name) {
+  // Filter definitions intentionally accept only the supported subset of
+  // class names. That excludes authorization, internal audit lifecycle,
+  // and server startup/shutdown lifecycle classes.
+  static constexpr std::array<std::string_view, 10> valid_classes{{
+      kClassNameGeneral,
+      kClassNameConnection,
+      kClassNameTableAccess,
+      kClassNameGlobalVariable,
+      kClassNameCommand,
+      kClassNameQuery,
+      kClassNameStoredProgram,
+      kClassNameAuthentication,
+      kClassNameMessage,
+      kClassNameParse,
+  }};
+  return contains_string_view(class_name, valid_classes);
+}
+
+bool is_valid_event_subclass_name(std::string_view class_name,
+                                  std::string_view subclass_name) {
+  if (class_name == kClassNameGeneral) {
+    static constexpr std::array<std::string_view, 4> valid_subclasses{{
+        kSubclassNameGeneralLog,
+        kSubclassNameGeneralError,
+        kSubclassNameGeneralResult,
+        kSubclassNameGeneralStatus,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameConnection) {
+    static constexpr std::array<std::string_view, 4> valid_subclasses{{
+        kSubclassNameConnect,
+        kSubclassNameDisconnect,
+        kSubclassNameChangeUser,
+        kSubclassNamePreAuthenticate,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameTableAccess) {
+    static constexpr std::array<std::string_view, 4> valid_subclasses{{
+        kSubclassNameRead,
+        kSubclassNameInsert,
+        kSubclassNameUpdate,
+        kSubclassNameDelete,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameGlobalVariable) {
+    static constexpr std::array<std::string_view, 2> valid_subclasses{{
+        kSubclassNameGet,
+        kSubclassNameSet,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameCommand) {
+    static constexpr std::array<std::string_view, 2> valid_subclasses{{
+        kSubclassNameStart,
+        kSubclassNameEnd,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameQuery) {
+    static constexpr std::array<std::string_view, 4> valid_subclasses{{
+        kSubclassNameStart,
+        kSubclassNameNestedStart,
+        kSubclassNameStatusEnd,
+        kSubclassNameNestedStatusEnd,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameStoredProgram) {
+    static constexpr std::array<std::string_view, 1> valid_subclasses{{
+        kSubclassNameExecute,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameAuthentication) {
+    static constexpr std::array<std::string_view, 5> valid_subclasses{{
+        kSubclassNameFlush,
+        kSubclassNameAuthidCreate,
+        kSubclassNameCredentialChange,
+        kSubclassNameAuthidRename,
+        kSubclassNameAuthidDrop,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameMessage) {
+    static constexpr std::array<std::string_view, 2> valid_subclasses{{
+        kSubclassNameMessageInternal,
+        kSubclassNameUser,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  if (class_name == kClassNameParse) {
+    static constexpr std::array<std::string_view, 3> valid_subclasses{{
+        kSubclassNameParseRewriteNone,
+        kSubclassNameParseRewriteQueryRewritten,
+        kSubclassNameParseRewritePreparedStatement,
+    }};
+    return contains_string_view(subclass_name, valid_subclasses);
+  }
+
+  return false;
+}
+
+bool is_valid_event_field_name(std::string_view event_class_name,
+                               std::string_view field_name) {
+  using FieldVec = std::vector<std::string_view>;
+  static const std::unordered_map<std::string_view, FieldVec> valid_fields_map{
+      {kClassNameGeneral,
        {"general_error_code", "general_thread_id", "general_connection_id",
         "general_user.str", "general_user.length", "general_command.str",
         "general_command.length", "general_query.str", "general_query.length",
         "general_host.str", "general_host.length", "general_sql_command.str",
         "general_sql_command.length", "general_external_user.str",
         "general_external_user.length", "general_ip.str", "general_ip.length"}},
-      {"connection",
+      {kClassNameConnection,
        {"status", "connection_id", "user.str", "user.length", "priv_user.str",
         "priv_user.length", "external_user.str", "external_user.length",
         "proxy_user.str", "proxy_user.length", "host.str", "host.length",
         "ip.str", "ip.length", "database.str", "database.length",
         "connection_type"}},
-      {"table_access",
+      {kClassNameTableAccess,
        {"connection_id", "sql_command_id", "query.str", "query.length",
         "table_database.str", "table_database.length", "table_name.str",
         "table_name.length"}},
-      {"global_variable",
+      {kClassNameGlobalVariable,
        {"connection_id", "variable_name.str", "variable_name.length",
         "variable_value.str", "variable_value.length"}},
-      {"server_startup", {}},
-      {"server_shutdown", {"exit_code", "reason"}},
-      {"command", {"status", "connection_id", "command.str", "command.length"}},
-      {"query",
+      {kClassNameCommand,
+       {"status", "connection_id", "command.str", "command.length"}},
+      {kClassNameQuery,
        {"status", "connection_id", "sql_command_id", "query.str",
         "query.length", "query_charset"}},
-      {"stored_program",
+      {kClassNameStoredProgram,
        {"connection_id", "database.str", "database.length", "name.str",
         "name.length"}},
-      {"authentication",
+      {kClassNameAuthentication,
        {"status", "connection_id", "user.str", "user.length", "host.str",
         "host.length"}},
-      {"message",
+      {kClassNameMessage,
        {"connection_id", "component.str", "component.length", "producer.str",
         "producer.length", "message.str", "message.length"}},
-      {"parse",
+      {kClassNameParse,
        {"connection_id", "flags", "query.str", "query.length",
         "rewritten_query.str", "rewritten_query.length"}},
-      {"audit", {"server_id"}},
   };
 
   const auto class_it = valid_fields_map.find(event_class_name);
@@ -811,42 +938,45 @@ bool is_valid_event_field_name(const std::string &event_class_name,
     return false;
   }
 
-  return class_it->second.count(field_name) > 0;
+  return contains_string_view(field_name, class_it->second);
 }
 
 EventFieldValueType get_event_field_value_type(
-    const std::string &event_class_name, const std::string &field_name) {
-  using FieldTypeMap = std::map<std::string, EventFieldValueType>;
-  static const std::unordered_map<std::string, FieldTypeMap> field_type_map{
-      {"connection",
-       {{"status", EventFieldValueType::SignedInteger},
-        {"connection_id", EventFieldValueType::UnsignedInteger},
-        {"user.length", EventFieldValueType::UnsignedInteger},
-        {"priv_user.length", EventFieldValueType::UnsignedInteger},
-        {"external_user.length", EventFieldValueType::UnsignedInteger},
-        {"proxy_user.length", EventFieldValueType::UnsignedInteger},
-        {"host.length", EventFieldValueType::UnsignedInteger},
-        {"ip.length", EventFieldValueType::UnsignedInteger},
-        {"database.length", EventFieldValueType::UnsignedInteger},
-        {"connection_type", EventFieldValueType::SignedInteger}}},
-      {"general",
-       {{"general_error_code", EventFieldValueType::SignedInteger},
-        {"general_thread_id", EventFieldValueType::UnsignedInteger},
-        {"general_connection_id", EventFieldValueType::UnsignedInteger},
-        {"general_user.length", EventFieldValueType::UnsignedInteger},
-        {"general_command.length", EventFieldValueType::UnsignedInteger},
-        {"general_query.length", EventFieldValueType::UnsignedInteger},
-        {"general_host.length", EventFieldValueType::UnsignedInteger},
-        {"general_sql_command.length", EventFieldValueType::UnsignedInteger},
-        {"general_external_user.length", EventFieldValueType::UnsignedInteger},
-        {"general_ip.length", EventFieldValueType::UnsignedInteger}}},
-      {"table_access",
-       {{"connection_id", EventFieldValueType::UnsignedInteger},
-        {"sql_command_id", EventFieldValueType::SignedInteger},
-        {"query.length", EventFieldValueType::UnsignedInteger},
-        {"table_database.length", EventFieldValueType::UnsignedInteger},
-        {"table_name.length", EventFieldValueType::UnsignedInteger}}},
-  };
+    std::string_view event_class_name, std::string_view field_name) {
+  using FieldTypeMap = std::map<std::string_view, EventFieldValueType>;
+  static const std::unordered_map<std::string_view, FieldTypeMap>
+      field_type_map{
+          {kClassNameConnection,
+           {{"status", EventFieldValueType::SignedInteger},
+            {"connection_id", EventFieldValueType::UnsignedInteger},
+            {"user.length", EventFieldValueType::UnsignedInteger},
+            {"priv_user.length", EventFieldValueType::UnsignedInteger},
+            {"external_user.length", EventFieldValueType::UnsignedInteger},
+            {"proxy_user.length", EventFieldValueType::UnsignedInteger},
+            {"host.length", EventFieldValueType::UnsignedInteger},
+            {"ip.length", EventFieldValueType::UnsignedInteger},
+            {"database.length", EventFieldValueType::UnsignedInteger},
+            {"connection_type", EventFieldValueType::SignedInteger}}},
+          {kClassNameGeneral,
+           {{"general_error_code", EventFieldValueType::SignedInteger},
+            {"general_thread_id", EventFieldValueType::UnsignedInteger},
+            {"general_connection_id", EventFieldValueType::UnsignedInteger},
+            {"general_user.length", EventFieldValueType::UnsignedInteger},
+            {"general_command.length", EventFieldValueType::UnsignedInteger},
+            {"general_query.length", EventFieldValueType::UnsignedInteger},
+            {"general_host.length", EventFieldValueType::UnsignedInteger},
+            {"general_sql_command.length",
+             EventFieldValueType::UnsignedInteger},
+            {"general_external_user.length",
+             EventFieldValueType::UnsignedInteger},
+            {"general_ip.length", EventFieldValueType::UnsignedInteger}}},
+          {kClassNameTableAccess,
+           {{"connection_id", EventFieldValueType::UnsignedInteger},
+            {"sql_command_id", EventFieldValueType::SignedInteger},
+            {"query.length", EventFieldValueType::UnsignedInteger},
+            {"table_database.length", EventFieldValueType::UnsignedInteger},
+            {"table_name.length", EventFieldValueType::UnsignedInteger}}},
+      };
 
   const auto class_it = field_type_map.find(event_class_name);
   if (class_it == field_type_map.cend()) {

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -19,6 +19,7 @@
 #include "components/audit_log_filter/audit_event_class_internal.h"
 #include "my_sqlcommand.h"  // enum_sql_command
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>
@@ -41,7 +42,10 @@ struct mysql_event_tracking_parse_data;
 
 namespace audit_log_filter {
 
-using AuditRecordFieldsList = std::map<std::string, std::string>;
+using AuditRecordFieldValue = std::variant<std::string, int64_t, uint64_t>;
+using AuditRecordFieldsList = std::map<std::string, AuditRecordFieldValue>;
+
+enum class EventFieldValueType { String, SignedInteger, UnsignedInteger };
 
 constexpr std::string_view CONNECTION_TYPE_FIELD_NAME = "connection_type";
 
@@ -197,6 +201,16 @@ AuditRecordVariant get_audit_record(audit_event_class_t event_class,
 void update_connection_type_pseudo_to_numeric(std::string &type);
 
 /**
+ * @brief Check if connection_type value is valid.
+ *
+ * Valid values are "0" through "5" (after pseudo-to-numeric conversion).
+ *
+ * @param value Connection type value to validate
+ * @return true if the value is a valid connection type, false otherwise
+ */
+bool is_valid_connection_type_value(const std::string &value);
+
+/**
  * @brief Get fields list from AuditRecordGeneral event record.
  *
  * @param record Audit event record
@@ -316,6 +330,21 @@ AuditRecordFieldsList get_audit_record_fields(const AuditRecordAudit &record);
 AuditRecordFieldsList get_audit_record_fields(const AuditRecordUnknown &record);
 
 /**
+ * @brief Convert an AuditRecordFieldValue to its string representation.
+ */
+std::string field_value_to_string(const AuditRecordFieldValue &value);
+
+/**
+ * @brief Compare an AuditRecordFieldValue against a string expected value.
+ *
+ * For string alternatives the comparison is direct. For integer alternatives
+ * the expected string is parsed to the matching integer type first; returns
+ * false on parse failure.
+ */
+bool field_value_matches(const AuditRecordFieldValue &value,
+                         const std::string &expected);
+
+/**
  * @brief Check if a field name is valid for the given event class.
  *
  * @param event_class_name Audit event class name (e.g. "table_access")
@@ -325,6 +354,17 @@ AuditRecordFieldsList get_audit_record_fields(const AuditRecordUnknown &record);
  */
 bool is_valid_event_field_name(const std::string &event_class_name,
                                const std::string &field_name);
+
+/**
+ * @brief Get the expected value type for a field in the given event class.
+ *
+ * @param event_class_name Audit event class name (e.g. "table_access")
+ * @param field_name Field name to check (e.g. "connection_id")
+ * @return EventFieldValueType indicating String, SignedInteger, or
+ *         UnsignedInteger
+ */
+EventFieldValueType get_event_field_value_type(
+    const std::string &event_class_name, const std::string &field_name);
 
 }  // namespace audit_log_filter
 

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -208,7 +208,7 @@ void update_connection_type_pseudo_to_numeric(std::string &type);
  * @param value Connection type value to validate
  * @return true if the value is a valid connection type, false otherwise
  */
-bool is_valid_connection_type_value(const std::string &value);
+bool is_valid_connection_type_value(std::string_view value);
 
 /**
  * @brief Get fields list from AuditRecordGeneral event record.
@@ -345,18 +345,40 @@ bool field_value_matches(const AuditRecordFieldValue &value,
                          const std::string &expected);
 
 /**
- * @brief Check if a field name is valid for the given event class.
+ * @brief Check if an event class name is supported by filter definitions.
+ *
+ * @param class_name Event class name to validate (e.g. "connection")
+ * @return true if the class name is accepted by filter-rule validation,
+ *         false otherwise
+ */
+bool is_valid_event_class_name(std::string_view class_name);
+
+/**
+ * @brief Check if an event subclass name is valid for a filterable class.
+ *
+ * @param class_name Event class name (e.g. "connection")
+ * @param subclass_name Event subclass name to validate (e.g. "connect")
+ * @return true if the subclass name is recognized for the class by
+ *         filter-rule validation,
+ *         false otherwise
+ */
+bool is_valid_event_subclass_name(std::string_view class_name,
+                                  std::string_view subclass_name);
+
+/**
+ * @brief Check if a field name is valid for a filterable event class.
  *
  * @param event_class_name Audit event class name (e.g. "table_access")
  * @param field_name Field name to validate (e.g. "table_name.str")
- * @return true if the field name is recognized for the event class,
+ * @return true if the field name is recognized for the event class by
+ *         filter-rule validation,
  *         false otherwise
  */
-bool is_valid_event_field_name(const std::string &event_class_name,
-                               const std::string &field_name);
+bool is_valid_event_field_name(std::string_view event_class_name,
+                               std::string_view field_name);
 
 /**
- * @brief Get the expected value type for a field in the given event class.
+ * @brief Get the expected value type for a field in a filterable event class.
  *
  * @param event_class_name Audit event class name (e.g. "table_access")
  * @param field_name Field name to check (e.g. "connection_id")
@@ -364,7 +386,7 @@ bool is_valid_event_field_name(const std::string &event_class_name,
  *         UnsignedInteger
  */
 EventFieldValueType get_event_field_value_type(
-    const std::string &event_class_name, const std::string &field_name);
+    std::string_view event_class_name, std::string_view field_name);
 
 }  // namespace audit_log_filter
 

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -31,9 +31,26 @@
 
 #include <limits>
 #include <memory>
+#include <set>
+#include <string_view>
 
 namespace audit_log_filter {
-namespace {}  // namespace
+namespace {
+
+std::string find_unknown_key(const rapidjson::Value &json_obj,
+                             const std::set<std::string_view> &allowed_keys) {
+  for (auto it = json_obj.MemberBegin(); it != json_obj.MemberEnd(); ++it) {
+    if (it->name.IsString()) {
+      std::string_view key{it->name.GetString(), it->name.GetStringLength()};
+      if (allowed_keys.count(key) == 0) {
+        return std::string{key};
+      }
+    }
+  }
+  return {};
+}
+
+}  // namespace
 
 bool AuditRuleParser::parse(const char *rule_str,
                             AuditRule *audit_rule) noexcept {
@@ -61,6 +78,19 @@ bool AuditRuleParser::parse(rapidjson::Document &json_doc,
   if (!json_doc.HasMember("filter") || !json_doc["filter"].IsObject()) {
     audit_rule->set_parse_error("missing or invalid 'filter' object");
     return false;
+  }
+
+  if (!json_doc["filter"].ObjectEmpty()) {
+    static const std::set<std::string_view> allowed_filter_keys{"id", "log",
+                                                                "class"};
+    auto unknown = find_unknown_key(json_doc["filter"], allowed_filter_keys);
+    if (!unknown.empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_UNEXPECTED_KEY,
+                      audit_rule->get_rule_name().c_str(), unknown.c_str());
+      audit_rule->set_parse_error("unexpected key '" + unknown +
+                                  "' in 'filter' definition");
+      return false;
+    }
   }
 
   if (!parse_default_log_action_json(json_doc, audit_rule)) {
@@ -146,6 +176,13 @@ bool AuditRuleParser::parse_event_class_json(
   if (ev_class_json.IsObject()) {
     return parse_event_class_obj_json(ev_class_json, audit_rule);
   } else if (ev_class_json.IsArray()) {
+    if (ev_class_json.Empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EMPTY_ARRAY,
+                      audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("'class' must not be an empty array");
+      return false;
+    }
+
     for (const auto *it = ev_class_json.Begin(); it != ev_class_json.End();
          ++it) {
       if (!it->IsObject()) {
@@ -180,6 +217,19 @@ bool AuditRuleParser::parse_event_class_obj_json(
                     audit_rule->get_rule_name().c_str());
     audit_rule->set_parse_error("no name provided for event class");
     return false;
+  }
+
+  {
+    static const std::set<std::string_view> allowed_class_keys{
+        "name", "log", "event", "print", "abort"};
+    auto unknown = find_unknown_key(event_class_json, allowed_class_keys);
+    if (!unknown.empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_UNEXPECTED_KEY,
+                      audit_rule->get_rule_name().c_str(), unknown.c_str());
+      audit_rule->set_parse_error("unexpected key '" + unknown +
+                                  "' in 'class' definition");
+      return false;
+    }
   }
 
   if (event_class_json.HasMember("abort")) {
@@ -224,6 +274,15 @@ bool AuditRuleParser::parse_event_class_obj_json(
   if (event_class_json["name"].IsString()) {
     const std::string event_class_name = event_class_json["name"].GetString();
 
+    if (!is_valid_event_class_name(event_class_name)) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_INVALID_EVENT_CLASS_NAME,
+                      audit_rule->get_rule_name().c_str(),
+                      event_class_name.c_str());
+      audit_rule->set_parse_error("unknown event class name '" +
+                                  event_class_name + "'");
+      return false;
+    }
+
     if (event_class_json.HasMember("event")) {
       if (replace_field != nullptr) {
         LogComponentErr(ERROR_LEVEL,
@@ -252,6 +311,13 @@ bool AuditRuleParser::parse_event_class_obj_json(
       audit_rule->add_action_for_event(replace_field, event_class_name);
     }
   } else if (event_class_json["name"].IsArray()) {
+    if (event_class_json["name"].Empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EMPTY_ARRAY,
+                      audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("class 'name' must not be an empty array");
+      return false;
+    }
+
     // There may be no event subclass specified in case event class name is
     // defined as an array { "name": [ "class_name_1", "class_name_2" ] }
     if (event_class_json.HasMember("event")) {
@@ -280,6 +346,16 @@ bool AuditRuleParser::parse_event_class_obj_json(
       }
 
       const std::string event_class_name = it->GetString();
+
+      if (!is_valid_event_class_name(event_class_name)) {
+        LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_INVALID_EVENT_CLASS_NAME,
+                        audit_rule->get_rule_name().c_str(),
+                        event_class_name.c_str());
+        audit_rule->set_parse_error("unknown event class name '" +
+                                    event_class_name + "'");
+        return false;
+      }
+
       audit_rule->add_action_for_event(log_action, event_class_name);
 
       if (replace_field != nullptr) {
@@ -322,6 +398,13 @@ bool AuditRuleParser::parse_event_subclass_json(
       return false;
     }
   } else if (event_subclass_json.IsArray()) {
+    if (event_subclass_json.Empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EMPTY_ARRAY,
+                      audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("'event' must not be an empty array");
+      return false;
+    }
+
     for (const auto *it = event_subclass_json.Begin();
          it != event_subclass_json.End(); ++it) {
       if (!it->IsObject()) {
@@ -361,11 +444,32 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
     return false;
   }
 
+  {
+    static const std::set<std::string_view> allowed_event_keys{
+        "name", "log", "abort", "print", "filter"};
+    auto unknown = find_unknown_key(event_subclass_json, allowed_event_keys);
+    if (!unknown.empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_UNEXPECTED_KEY,
+                      audit_rule->get_rule_name().c_str(), unknown.c_str());
+      audit_rule->set_parse_error("unexpected key '" + unknown +
+                                  "' in 'event' definition");
+      return false;
+    }
+  }
+
   std::vector<std::string> subclass_names;
 
   if (event_subclass_json["name"].IsString()) {
     subclass_names.emplace_back(event_subclass_json["name"].GetString());
   } else if (event_subclass_json["name"].IsArray()) {
+    if (event_subclass_json["name"].Empty()) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EMPTY_ARRAY,
+                      audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error(
+          "event subclass 'name' must not be an empty array");
+      return false;
+    }
+
     for (const auto *it = event_subclass_json["name"].Begin();
          it != event_subclass_json["name"].End(); ++it) {
       if (!it->IsString()) {
@@ -385,6 +489,17 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
         "event subclass name type must be either string or an array of "
         "strings");
     return false;
+  }
+
+  for (const auto &name : subclass_names) {
+    if (!is_valid_event_subclass_name(class_name, name)) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_INVALID_EVENT_SUBCLASS_NAME,
+                      audit_rule->get_rule_name().c_str(), name.c_str(),
+                      class_name.c_str());
+      audit_rule->set_parse_error("unknown event subclass name '" + name +
+                                  "' for class '" + class_name + "'");
+      return false;
+    }
   }
 
   const auto has_log_tag = event_subclass_json.HasMember("log");

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -29,6 +29,7 @@
 #include "components/audit_log_filter/event_field_condition/or.h"
 #include "components/audit_log_filter/event_field_condition/variable.h"
 
+#include <limits>
 #include <memory>
 
 namespace audit_log_filter {
@@ -591,19 +592,35 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
 
       if (!condition_json["field"].HasMember("name") ||
           !condition_json["field"].HasMember("value") ||
-          !condition_json["field"]["name"].IsString() ||
-          !condition_json["field"]["value"].IsString()) {
+          !condition_json["field"]["name"].IsString()) {
         LogComponentErr(ERROR_LEVEL,
                         ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
                         audit_rule->get_rule_name().c_str());
         audit_rule->set_parse_error(
-            "event field definition 'field' must have field 'name' and "
-            "'value' provided as strings");
+            "event field definition 'field' must have field 'name' "
+            "provided as a string and 'value' as a string or integer");
         return nullptr;
       }
 
+      const auto &value_json = condition_json["field"]["value"];
       std::string field_name{condition_json["field"]["name"].GetString()};
-      std::string field_value{condition_json["field"]["value"].GetString()};
+      std::string field_value;
+
+      if (value_json.IsString()) {
+        field_value = value_json.GetString();
+      } else if (value_json.IsInt64()) {
+        field_value = std::to_string(value_json.GetInt64());
+      } else if (value_json.IsUint64()) {
+        field_value = std::to_string(value_json.GetUint64());
+      } else {
+        LogComponentErr(ERROR_LEVEL,
+                        ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
+                        audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error(
+            "event field definition 'field' 'value' must be "
+            "a string or integer");
+        return nullptr;
+      }
 
       if (!class_name.empty() &&
           !is_valid_event_field_name(class_name, field_name)) {
@@ -615,6 +632,83 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
                                     "' is not valid for event class '" +
                                     class_name + "'");
         return nullptr;
+      }
+
+      if (!value_json.IsString() && !class_name.empty()) {
+        auto field_type = get_event_field_value_type(class_name, field_name);
+
+        if (field_type == EventFieldValueType::String) {
+          LogComponentErr(ERROR_LEVEL,
+                          ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
+                          audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "field '" + field_name +
+              "' is not an integer field; 'value' must be a string");
+          return nullptr;
+        }
+
+        if (field_type == EventFieldValueType::UnsignedInteger &&
+            value_json.IsInt64() && value_json.GetInt64() < 0) {
+          LogComponentErr(ERROR_LEVEL,
+                          ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
+                          audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "field '" + field_name +
+              "' is an unsigned integer field; 'value' must not be negative");
+          return nullptr;
+        }
+
+        if (field_type == EventFieldValueType::SignedInteger &&
+            value_json.IsUint64() &&
+            value_json.GetUint64() >
+                static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+          LogComponentErr(ERROR_LEVEL,
+                          ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
+                          audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "field '" + field_name +
+              "' is a signed integer field; 'value' must not exceed " +
+              std::to_string(std::numeric_limits<int64_t>::max()));
+          return nullptr;
+        }
+      }
+
+      if (value_json.IsString() && !class_name.empty() &&
+          field_name != CONNECTION_TYPE_FIELD_NAME) {
+        auto field_type = get_event_field_value_type(class_name, field_name);
+
+        if (field_type != EventFieldValueType::String) {
+          bool valid = false;
+          try {
+            size_t pos = 0;
+            if (field_type == EventFieldValueType::UnsignedInteger) {
+              if (!field_value.empty() && field_value[0] == '-') {
+                valid = false;
+              } else {
+                (void)std::stoull(field_value, &pos);
+                valid = (pos == field_value.size());
+              }
+            } else if (field_type == EventFieldValueType::SignedInteger) {
+              (void)std::stoll(field_value, &pos);
+              valid = (pos == field_value.size());
+            } else {
+              assert(false);
+            }
+          } catch (...) {
+            valid = false;
+          }
+
+          if (!valid) {
+            LogComponentErr(ERROR_LEVEL,
+                            ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
+                            audit_rule->get_rule_name().c_str());
+            audit_rule->set_parse_error(
+                "field '" + field_name +
+                "' is an integer field; string value '" + field_value +
+                "' is not a valid number");
+            return nullptr;
+          }
+        }
       }
 
       if (field_name == CONNECTION_TYPE_FIELD_NAME) {
@@ -630,6 +724,18 @@ std::shared_ptr<EventFieldConditionBase> AuditRuleParser::parse_condition_json(
          *   5 or "::shared_memory": Shared memory
          */
         update_connection_type_pseudo_to_numeric(field_value);
+
+        if (!is_valid_connection_type_value(field_value)) {
+          LogComponentErr(ERROR_LEVEL,
+                          ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE,
+                          audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "invalid 'connection_type' value '" + field_value +
+              "'; expected integer 0..5 or one of "
+              "\"::undefined\", \"::tcp/ip\", \"::socket\", "
+              "\"::named_pipe\", \"::ssl\", \"::shared_memory\"");
+          return nullptr;
+        }
       }
 
       return std::make_shared<EventFieldConditionField>(std::move(field_name),

--- a/components/audit_log_filter/event_field_condition/field.cc
+++ b/components/audit_log_filter/event_field_condition/field.cc
@@ -24,7 +24,8 @@ EventFieldConditionField::EventFieldConditionField(std::string name,
 bool EventFieldConditionField::check_applies(
     const AuditRecordFieldsList &fields) const noexcept {
   const auto field = fields.find(m_name);
-  return field != fields.cend() && field->second == m_expected_value;
+  return field != fields.cend() &&
+         field_value_matches(field->second, m_expected_value);
 }
 
 }  // namespace audit_log_filter::event_field_condition

--- a/components/audit_log_filter/event_filter_function/base.h
+++ b/components/audit_log_filter/event_filter_function/base.h
@@ -104,7 +104,7 @@ class EventFilterFunctionBase {
     } else if (m_args[arg_index].source_type == FunctionArgSourceType::Field) {
       const auto it = event_fields.find(m_args[arg_index].value);
       if (it != event_fields.cend()) {
-        return it->second;
+        return field_value_to_string(it->second);
       }
     }
 

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_class.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_class.result
@@ -1,0 +1,202 @@
+#
+# Broken: empty "class" array
+SELECT audit_log_filter_set_filter('filter_broken_emptyClassArr', '{"filter": { "class": [] } }');
+audit_log_filter_set_filter('filter_broken_emptyClassArr', '{"filter": { "class": [] } }')
+ERROR: Incorrect rule definition: 'class' must not be an empty array
+#
+# Broken: empty "name" array at class level
+SELECT audit_log_filter_set_filter('filter_broken_emptyNameArr', '{"filter": { "class": [ { "name": [], "log": true } ] } }');
+audit_log_filter_set_filter('filter_broken_emptyNameArr', '{"filter": { "class": [ { "name": [], "log": true } ] } }')
+ERROR: Incorrect rule definition: class 'name' must not be an empty array
+#
+# Broken: empty "event" array
+SELECT audit_log_filter_set_filter('filter_broken_emptyEventArr', '{"filter": { "class": [ { "name": "connection", "event": [] } ] } }');
+audit_log_filter_set_filter('filter_broken_emptyEventArr', '{"filter": { "class": [ { "name": "connection", "event": [] } ] } }')
+ERROR: Incorrect rule definition: 'event' must not be an empty array
+#
+# Broken: empty "name" array at subclass level
+SELECT audit_log_filter_set_filter('filter_broken_emptySubNameArr', '{"filter": { "class": [ { "name": "connection", "event": { "name": [] } } ] } }');
+audit_log_filter_set_filter('filter_broken_emptySubNameArr', '{"filter": { "class": [ { "name": "connection", "event": { "name": [] } } ] } }')
+ERROR: Incorrect rule definition: event subclass 'name' must not be an empty array
+#
+# Broken: unknown key "clss" in filter (typo for "class")
+SELECT audit_log_filter_set_filter('filter_broken_unknownFilterKey', '{"filter": { "clss": [ { "name": "connection" } ] } }');
+audit_log_filter_set_filter('filter_broken_unknownFilterKey', '{"filter": { "clss": [ { "name": "connection" } ] } }')
+ERROR: Incorrect rule definition: unexpected key 'clss' in 'filter' definition
+#
+# Broken: unknown key "evnt" in class (typo for "event")
+SELECT audit_log_filter_set_filter('filter_broken_unknownClassKey', '{"filter": { "class": [ { "name": "connection", "evnt": { "name": "connect" } } ] } }');
+audit_log_filter_set_filter('filter_broken_unknownClassKey', '{"filter": { "class": [ { "name": "connection", "evnt": { "name": "connect" } } ] } }')
+ERROR: Incorrect rule definition: unexpected key 'evnt' in 'class' definition
+#
+# Broken: unknown key "logg" in event (typo for "log")
+SELECT audit_log_filter_set_filter('filter_broken_unknownEventKey', '{"filter": { "class": [ { "name": "connection", "event": { "name": "connect", "logg": true } } ] } }');
+audit_log_filter_set_filter('filter_broken_unknownEventKey', '{"filter": { "class": [ { "name": "connection", "event": { "name": "connect", "logg": true } } ] } }')
+ERROR: Incorrect rule definition: unexpected key 'logg' in 'event' definition
+#
+# Broken class name: "connection1" (typo, no such class)
+SELECT audit_log_filter_set_filter('filter_broken_badClassName', '{"filter": { "class": [
+  { "name": "connection1",
+      "event": { "name": "connect" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_badClassName', '{"filter": { "class": [
+  { "name": "connection1",
+      "event": { "name": "connect" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'connection1'
+#
+# Broken class name: "Table_Access" (wrong case)
+SELECT audit_log_filter_set_filter('filter_broken_wrongCase', '{"filter": { "class": [
+  { "name": "Table_Access",
+      "event": { "name": "read" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_wrongCase', '{"filter": { "class": [
+  { "name": "Table_Access",
+      "event": { "name": "read" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'Table_Access'
+#
+# Broken class name: empty string
+SELECT audit_log_filter_set_filter('filter_broken_emptyClassName', '{"filter": { "class": [
+  { "name": "",
+      "event": { "name": "status" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_emptyClassName', '{"filter": { "class": [
+  { "name": "",
+      "event": { "name": "status" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name ''
+#
+# Broken class name as array element: ["general1"]
+SELECT audit_log_filter_set_filter('filter_broken_badClassNameArr', '{"filter": { "class": [
+  { "name": [ "general1" ], "log": true }
+] } }');
+audit_log_filter_set_filter('filter_broken_badClassNameArr', '{"filter": { "class": [
+  { "name": [ "general1" ], "log": true }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'general1'
+#
+# Broken class name: "authorization" exists in record naming, but is not filterable
+SELECT audit_log_filter_set_filter('filter_broken_authorizationClass', '{"filter": { "class": [
+  { "name": "authorization",
+      "event": { "name": "authid_create" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_authorizationClass', '{"filter": { "class": [
+  { "name": "authorization",
+      "event": { "name": "authid_create" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'authorization'
+#
+# Broken class name: "audit" is written directly, outside the filter pipeline
+SELECT audit_log_filter_set_filter('filter_broken_internalAuditClass', '{"filter": { "class": [
+  { "name": "audit",
+      "event": { "name": "startup" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_internalAuditClass', '{"filter": { "class": [
+  { "name": "audit",
+      "event": { "name": "startup" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'audit'
+#
+# Broken class name: "server_startup" is not supported by filter validation
+SELECT audit_log_filter_set_filter('filter_broken_serverStartupClass', '{"filter": { "class": [
+  { "name": "server_startup",
+      "event": { "name": "startup" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_serverStartupClass', '{"filter": { "class": [
+  { "name": "server_startup",
+      "event": { "name": "startup" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'server_startup'
+#
+# Broken class name: "server_shutdown" is not supported by filter validation
+SELECT audit_log_filter_set_filter('filter_broken_serverShutdownClass', '{"filter": { "class": [
+  { "name": "server_shutdown",
+      "event": { "name": "shutdown" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_serverShutdownClass', '{"filter": { "class": [
+  { "name": "server_shutdown",
+      "event": { "name": "shutdown" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event class name 'server_shutdown'
+#
+# Broken event name: "read1" (typo, no such subclass)
+SELECT audit_log_filter_set_filter('filter_broken_badEventName', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": { "name": "read1" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_badEventName', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": { "name": "read1" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event subclass name 'read1' for class 'table_access'
+#
+# Broken event name: "Connect" (wrong case)
+SELECT audit_log_filter_set_filter('filter_broken_eventWrongCase', '{"filter": { "class": [
+  { "name": "connection",
+      "event": { "name": "Connect" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_eventWrongCase', '{"filter": { "class": [
+  { "name": "connection",
+      "event": { "name": "Connect" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event subclass name 'Connect' for class 'connection'
+#
+# Broken event name: empty string
+SELECT audit_log_filter_set_filter('filter_broken_emptyEventName', '{"filter": { "class": [
+  { "name": "general",
+      "event": { "name": "" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_emptyEventName', '{"filter": { "class": [
+  { "name": "general",
+      "event": { "name": "" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event subclass name '' for class 'general'
+#
+# Broken event name from wrong class: "read" belongs to table_access, not connection
+SELECT audit_log_filter_set_filter('filter_broken_wrongClassEvent', '{"filter": { "class": [
+  { "name": "connection",
+      "event": { "name": "read" }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_wrongClassEvent', '{"filter": { "class": [
+  { "name": "connection",
+      "event": { "name": "read" }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event subclass name 'read' for class 'connection'
+#
+# Broken: event name array with one bad entry
+SELECT audit_log_filter_set_filter('filter_broken_badEventArr', '{"filter": { "class": [
+  { "name": "general",
+      "event": { "name": [ "status", "nonexistent" ] }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_badEventArr', '{"filter": { "class": [
+  { "name": "general",
+      "event": { "name": [ "status", "nonexistent" ] }
+  }
+] } }')
+ERROR: Incorrect rule definition: unknown event subclass name 'nonexistent' for class 'general'
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_connection.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_connection.result
@@ -1,0 +1,1098 @@
+#
+# Valid: status (integer)
+SELECT audit_log_filter_set_filter('filter_con_status', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": 0 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_status', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": 0 }
+        }
+OK
+#
+# Valid: connection_id (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_connId', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": 1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connId', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": 1 }
+  
+OK
+#
+# Valid: user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_userStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": "root" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_userStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": "root" }
+ 
+OK
+#
+# Valid: user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_userLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_userLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": 4 }
+   
+OK
+#
+# Valid: priv_user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_privUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.str", "value": "root" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_privUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.str", "value": "
+OK
+#
+# Valid: priv_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_privUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_privUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.length", "value"
+OK
+#
+# Valid: external_user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_extUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.str", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_extUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.str", "value"
+OK
+#
+# Valid: external_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_extUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.length", "value": 0 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_extUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.length", "val
+OK
+#
+# Valid: proxy_user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_proxyUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.str", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_proxyUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.str", "value":
+OK
+#
+# Valid: proxy_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_proxyUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.length", "value": 0 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_proxyUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.length", "valu
+OK
+#
+# Valid: host.str (string)
+SELECT audit_log_filter_set_filter('filter_con_hostStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.str", "value": "localhost" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_hostStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.str", "value": "localhost
+OK
+#
+# Valid: host.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_hostLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_hostLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": 9 }
+   
+OK
+#
+# Valid: ip.str (string)
+SELECT audit_log_filter_set_filter('filter_con_ipStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.str", "value": "127.0.0.1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_ipStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.str", "value": "127.0.0.1" }
+
+OK
+#
+# Valid: ip.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_ipLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_ipLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.length", "value": 9 }
+       
+OK
+#
+# Valid: database.str (string)
+SELECT audit_log_filter_set_filter('filter_con_dbStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.str", "value": "test" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_dbStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.str", "value": "test" }
+OK
+#
+# Valid: database.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_dbLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_dbLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": 4 }
+ 
+OK
+#
+# Valid: all connection fields combined with "and"
+SELECT audit_log_filter_set_filter('filter_con_allFields', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "user.str", "value": "root" } },
+            { "field": { "name": "user.length", "value": 4 } },
+            { "field": { "name": "priv_user.str", "value": "root" } },
+            { "field": { "name": "priv_user.length", "value": 4 } },
+            { "field": { "name": "external_user.str", "value": "" } },
+            { "field": { "name": "external_user.length", "value": 0 } },
+            { "field": { "name": "proxy_user.str", "value": "" } },
+            { "field": { "name": "proxy_user.length", "value": 0 } },
+            { "field": { "name": "host.str", "value": "localhost" } },
+            { "field": { "name": "host.length", "value": 9 } },
+            { "field": { "name": "ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "ip.length", "value": 9 } },
+            { "field": { "name": "database.str", "value": "test" } },
+            { "field": { "name": "database.length", "value": 4 } },
+            { "field": { "name": "connection_type", "value": 1 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_allFields', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "statu
+OK
+#
+# Valid: all connection fields combined with "or"
+SELECT audit_log_filter_set_filter('filter_con_anyField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "or": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "user.str", "value": "root" } },
+            { "field": { "name": "user.length", "value": 4 } },
+            { "field": { "name": "priv_user.str", "value": "root" } },
+            { "field": { "name": "priv_user.length", "value": 4 } },
+            { "field": { "name": "external_user.str", "value": "" } },
+            { "field": { "name": "external_user.length", "value": 0 } },
+            { "field": { "name": "proxy_user.str", "value": "" } },
+            { "field": { "name": "proxy_user.length", "value": 0 } },
+            { "field": { "name": "host.str", "value": "localhost" } },
+            { "field": { "name": "host.length", "value": 9 } },
+            { "field": { "name": "ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "ip.length", "value": 9 } },
+            { "field": { "name": "database.str", "value": "test" } },
+            { "field": { "name": "database.length", "value": 4 } },
+            { "field": { "name": "connection_type", "value": 1 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_anyField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "or": [
+            { "field": { "name": "status"
+OK
+#
+# Backward compatible: string "0" for integer field status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_status_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": "0
+OK
+#
+# Backward compatible: string "1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connId_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "val
+OK
+#
+# Backward compatible: string "4" for unsigned integer field user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_userLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_userLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "valu
+OK
+#
+# Backward compatible: string "4" for unsigned integer field priv_user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_privUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_privUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.lengt
+OK
+#
+# Backward compatible: string "0" for unsigned integer field external_user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_extUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.length", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_extUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.le
+OK
+#
+# Backward compatible: string "0" for unsigned integer field proxy_user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_proxyUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.length", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_proxyUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.len
+OK
+#
+# Backward compatible: string "9" for unsigned integer field host.length
+SELECT audit_log_filter_set_filter('filter_broken_con_hostLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_hostLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "valu
+OK
+#
+# Backward compatible: string "9" for unsigned integer field ip.length
+SELECT audit_log_filter_set_filter('filter_broken_con_ipLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_ipLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.length", "value": 
+OK
+#
+# Backward compatible: string "4" for unsigned integer field database.length
+SELECT audit_log_filter_set_filter('filter_broken_con_dbLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_dbLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "va
+OK
+#
+# Broken: non-numeric string "abc" for integer field status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_status_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "val
+ERROR: Incorrect rule definition: field 'status' is an integer field; string value 'abc' is not a valid number
+#
+# Broken: non-numeric string "abc" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connId_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id
+ERROR: Incorrect rule definition: field 'connection_id' is an integer field; string value 'abc' is not a valid number
+#
+# Broken: non-numeric string "aa8" for unsigned integer field user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_userLen_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": "aa8" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_userLen_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length"
+ERROR: Incorrect rule definition: field 'user.length' is an integer field; string value 'aa8' is not a valid number
+#
+# Broken: negative string "-1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_negstr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "-1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connId_negstr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "
+ERROR: Incorrect rule definition: field 'connection_id' is an integer field; string value '-1' is not a valid number
+#
+# Broken: empty string "" for unsigned integer field database.length
+SELECT audit_log_filter_set_filter('filter_broken_con_dbLen_empty', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_dbLen_empty', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "
+ERROR: Incorrect rule definition: field 'database.length' is an integer field; string value '' is not a valid number
+#
+# Broken: trailing text "8abc" for unsigned integer field host.length
+SELECT audit_log_filter_set_filter('filter_broken_con_hostLen_trailing', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": "8abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_hostLen_trailing', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", 
+ERROR: Incorrect rule definition: field 'host.length' is an integer field; string value '8abc' is not a valid number
+#
+# Broken: integer value for string field user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_userStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_userStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value":
+ERROR: Incorrect rule definition: field 'user.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field priv_user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_privUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_privUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.str",
+ERROR: Incorrect rule definition: field 'priv_user.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field external_user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_extUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_extUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.st
+ERROR: Incorrect rule definition: field 'external_user.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field proxy_user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_proxyUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_proxyUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.str
+ERROR: Incorrect rule definition: field 'proxy_user.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field host.str
+SELECT audit_log_filter_set_filter('filter_broken_con_hostStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_hostStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.str", "value":
+ERROR: Incorrect rule definition: field 'host.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field ip.str
+SELECT audit_log_filter_set_filter('filter_broken_con_ipStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_ipStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.str", "value": 42 
+ERROR: Incorrect rule definition: field 'ip.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field database.str
+SELECT audit_log_filter_set_filter('filter_broken_con_dbStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.str", "value": 99 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_dbStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.str", "value
+ERROR: Incorrect rule definition: field 'database.str' is not an integer field; 'value' must be a string
+#
+# Broken: nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_con_badField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_badField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "val
+ERROR: Incorrect rule definition: field name 'NONEXISTENT.str' is not valid for event class 'connection'
+#
+# Broken: field from wrong class (general_command.str belongs to "general")
+SELECT audit_log_filter_set_filter('filter_broken_con_wrongClass', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_wrongClass', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "general_command.str"
+ERROR: Incorrect rule definition: field name 'general_command.str' is not valid for event class 'connection'
+#
+# Broken: missing "value" key
+SELECT audit_log_filter_set_filter('filter_broken_con_noValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_noValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str" }
+        }
+ 
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: missing "name" key
+SELECT audit_log_filter_set_filter('filter_broken_con_noName', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "value": "root" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_noName', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "value": "root" }
+        }
+     
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: empty field object
+SELECT audit_log_filter_set_filter('filter_broken_con_emptyField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_emptyField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: null value for string field
+SELECT audit_log_filter_set_filter('filter_broken_con_nullValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": null }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_nullValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": n
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: boolean value for unsigned integer field
+SELECT audit_log_filter_set_filter('filter_broken_con_boolValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": true }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_boolValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "valu
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: negative value for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_neg', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": -1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connId_neg', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "val
+ERROR: Incorrect rule definition: field 'connection_id' is an unsigned integer field; 'value' must not be negative
+#
+# Broken: float value for integer field status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_float', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_status_float', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": 
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: array value for string field
+SELECT audit_log_filter_set_filter('filter_broken_con_arrayValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": ["root", "admin"] }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_arrayValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": 
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: "and" with nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_con_and_badField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "NONEXISTENT.str", "value": "x" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_and_badField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "nam
+ERROR: Incorrect rule definition: field name 'NONEXISTENT.str' is not valid for event class 'connection'
+#
+# Broken: "and" with field from wrong class
+SELECT audit_log_filter_set_filter('filter_broken_con_and_wrongClass', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "general_command.str", "value": "Query" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_and_wrongClass', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "n
+ERROR: Incorrect rule definition: field name 'general_command.str' is not valid for event class 'connection'
+#
+# Broken: "and" with integer value for string field
+SELECT audit_log_filter_set_filter('filter_broken_con_and_strAsInt', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "user.str", "value": 42 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_and_strAsInt', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "nam
+ERROR: Incorrect rule definition: field 'user.str' is not an integer field; 'value' must be a string
+#
+# Broken: "and" with non-numeric string for integer field
+SELECT audit_log_filter_set_filter('filter_broken_con_and_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "connection_id", "value": "xyz" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_and_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "n
+ERROR: Incorrect rule definition: field 'connection_id' is an integer field; string value 'xyz' is not a valid number
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_connection_type.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_connection_type.result
@@ -1,0 +1,496 @@
+#
+# Valid: connection_type integer JSON value
+SELECT audit_log_filter_set_filter('filter_con_connType', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 1 
+OK
+#
+# Valid: connection_type "::undefined" (alias for 0)
+SELECT audit_log_filter_set_filter('filter_con_connType_undefined', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::undefined" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType_undefined', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "
+OK
+#
+# Valid: connection_type "::tcp/ip" (alias for 1)
+SELECT audit_log_filter_set_filter('filter_con_connType_tcpip', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::tcp/ip" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType_tcpip', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "valu
+OK
+#
+# Valid: connection_type "::socket" (alias for 2)
+SELECT audit_log_filter_set_filter('filter_con_connType_socket', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::socket" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType_socket', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "val
+OK
+#
+# Valid: connection_type "::named_pipe" (alias for 3)
+SELECT audit_log_filter_set_filter('filter_con_connType_namedPipe', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::named_pipe" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType_namedPipe', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "
+OK
+#
+# Valid: connection_type "::ssl" (alias for 4)
+SELECT audit_log_filter_set_filter('filter_con_connType_ssl', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::ssl" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType_ssl', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value"
+OK
+#
+# Valid: connection_type "::shared_memory" (alias for 5)
+SELECT audit_log_filter_set_filter('filter_con_connType_sharedMem', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::shared_memory" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_con_connType_sharedMem', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "
+OK
+#
+# Backward compatible: string value "1" for integer field connection_type (OK)
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", 
+OK
+#
+# Backward compatible: string "0" for integer field connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_str0', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_str0', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type",
+OK
+#
+# Invalid: non-numeric string "abc" for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_
+ERROR: Incorrect rule definition: invalid 'connection_type' value 'abc'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: trailing text "1abc" for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_trailing', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "1abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_trailing', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_ty
+ERROR: Incorrect rule definition: invalid 'connection_type' value '1abc'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: empty string for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_empty', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_empty', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type"
+ERROR: Incorrect rule definition: invalid 'connection_type' value ''; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: string "-1" for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_negstr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "-1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_negstr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type
+ERROR: Incorrect rule definition: invalid 'connection_type' value '-1'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: string "6" for connection_type (out of range)
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_str6', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "6" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_str6', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type",
+ERROR: Incorrect rule definition: invalid 'connection_type' value '6'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: unknown "::"-prefixed alias
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_invalidAlias', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::invalid" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_invalidAlias', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connectio
+ERROR: Incorrect rule definition: invalid 'connection_type' value '::invalid'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: "::TCP/IP" wrong case
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_wrongCase', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::TCP/IP" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_wrongCase', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_t
+ERROR: Incorrect rule definition: invalid 'connection_type' value '::TCP/IP'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: "::tcpip" missing slash
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_noSlash', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::tcpip" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_noSlash', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_typ
+ERROR: Incorrect rule definition: invalid 'connection_type' value '::tcpip'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: "::named pipe" space instead of underscore
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_space', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::named pipe" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_space', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type"
+ERROR: Incorrect rule definition: invalid 'connection_type' value '::named pipe'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: "::shared" truncated alias
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_truncated', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::shared" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_truncated', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_t
+ERROR: Incorrect rule definition: invalid 'connection_type' value '::shared'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: "socket" missing "::" prefix
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_noPrefix', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "socket" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_noPrefix', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_ty
+ERROR: Incorrect rule definition: invalid 'connection_type' value 'socket'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: out-of-range integer (6, max valid is 5)
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_outOfRange', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 6 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_outOfRange', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_
+ERROR: Incorrect rule definition: invalid 'connection_type' value '6'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: negative integer
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_neg', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": -1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_neg', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", 
+ERROR: Incorrect rule definition: invalid 'connection_type' value '-1'; expected integer 0..5 or one of "::undefined", "::tcp/ip", "::socket", "::named_pipe", "::ssl", "::shared_memory"
+#
+# Invalid: float value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_float', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_float', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type"
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Invalid: boolean value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_bool', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": true }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_bool', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type",
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Invalid: null value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_null', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": null }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_null', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type",
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Invalid: array value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_array', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": [0, 1] }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_con_connType_array', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type"
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_general.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_general.result
@@ -1,0 +1,1229 @@
+#
+# Valid: general_error_code (integer)
+SELECT audit_log_filter_set_filter('filter_gen_errorCode', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": 0 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_errorCode', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": 0 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_thread_id (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_threadId', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": 1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_threadId', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": 1 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_user.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_userStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_userStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" }
+
+OK
+#
+# Valid: general_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_userLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.length", "value": 33 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_userLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.length", "value": 33 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_command.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_cmdStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_cmdStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }
+OK
+#
+# Valid: general_command.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_cmdLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": 5 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_cmdLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": 5 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_query.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_queryStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.str", "value": "SELECT 1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_queryStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.str", "value": "SELECT 1" }
+        }
+      }
+  }
+] 
+OK
+#
+# Valid: general_query.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_queryLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": 8 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_queryLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": 8 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_host.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_hostStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.str", "value": "localhost" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_hostStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.str", "value": "localhost" }
+        }
+      }
+  }
+] }
+OK
+#
+# Valid: general_host.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_hostLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_hostLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": 9 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_sql_command.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_sqlCmdStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.str", "value": "select" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_sqlCmdStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.str", "value": "select" }
+        }
+      }
+ 
+OK
+#
+# Valid: general_sql_command.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_sqlCmdLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.length", "value": 6 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_sqlCmdLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.length", "value": 6 }
+        }
+      }
+  }
+]
+OK
+#
+# Valid: general_external_user.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_extUserStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.str", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_extUserStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.str", "value": "" }
+        }
+      }
+  }
+
+OK
+#
+# Valid: general_external_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_extUserLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.length", "value": 0 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_extUserLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.length", "value": 0 }
+        }
+      }
+  
+OK
+#
+# Valid: general_ip.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_ipStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.str", "value": "127.0.0.1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_ipStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.str", "value": "127.0.0.1" }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: general_ip.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_ipLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_ipLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.length", "value": 9 }
+        }
+      }
+  }
+] } }')
+OK
+#
+# Valid: all general fields combined with "and"
+SELECT audit_log_filter_set_filter('filter_gen_allFields', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_thread_id", "value": 1 } },
+            { "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" } },
+            { "field": { "name": "general_user.length", "value": 33 } },
+            { "field": { "name": "general_command.str", "value": "Query" } },
+            { "field": { "name": "general_command.length", "value": 5 } },
+            { "field": { "name": "general_query.str", "value": "SELECT 1" } },
+            { "field": { "name": "general_query.length", "value": 8 } },
+            { "field": { "name": "general_host.str", "value": "localhost" } },
+            { "field": { "name": "general_host.length", "value": 9 } },
+            { "field": { "name": "general_sql_command.str", "value": "select" } },
+            { "field": { "name": "general_sql_command.length", "value": 6 } },
+            { "field": { "name": "general_external_user.str", "value": "" } },
+            { "field": { "name": "general_external_user.length", "value": 0 } },
+            { "field": { "name": "general_ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "general_ip.length", "value": 9 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_allFields', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+     
+OK
+#
+# Valid: all general fields combined with "or"
+SELECT audit_log_filter_set_filter('filter_gen_anyField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "or": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_thread_id", "value": 1 } },
+            { "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" } },
+            { "field": { "name": "general_user.length", "value": 33 } },
+            { "field": { "name": "general_command.str", "value": "Query" } },
+            { "field": { "name": "general_command.length", "value": 5 } },
+            { "field": { "name": "general_query.str", "value": "SELECT 1" } },
+            { "field": { "name": "general_query.length", "value": 8 } },
+            { "field": { "name": "general_host.str", "value": "localhost" } },
+            { "field": { "name": "general_host.length", "value": 9 } },
+            { "field": { "name": "general_sql_command.str", "value": "select" } },
+            { "field": { "name": "general_sql_command.length", "value": 6 } },
+            { "field": { "name": "general_external_user.str", "value": "" } },
+            { "field": { "name": "general_external_user.length", "value": 0 } },
+            { "field": { "name": "general_ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "general_ip.length", "value": 9 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_gen_anyField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "or": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+       
+OK
+#
+# Backward compatible: string "0" for integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_errorCode_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": "0" }
+        }
+      }
+
+OK
+#
+# Backward compatible: string "1" for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_threadId_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "1" }
+        }
+      }
+  
+OK
+#
+# Backward compatible: string "33" for unsigned integer field general_user.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_userLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.length", "value": "33" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_userLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.length", "value": "33" }
+        }
+      }
+
+OK
+#
+# Backward compatible: string "5" for unsigned integer field general_command.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_cmdLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": "5" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_cmdLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": "5" }
+        }
+      }
+OK
+#
+# Backward compatible: string "8" for unsigned integer field general_query.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_queryLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": "8" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_queryLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": "8" }
+        }
+      }
+OK
+#
+# Backward compatible: string "9" for unsigned integer field general_host.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_hostLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_hostLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": "9" }
+        }
+      }
+ 
+OK
+#
+# Backward compatible: string "6" for unsigned integer field general_sql_command.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_sqlCmdLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.length", "value": "6" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_sqlCmdLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.length", "value": "6" }
+        }
+
+OK
+#
+# Backward compatible: string "0" for unsigned integer field general_external_user.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_extUserLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.length", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_extUserLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.length", "value": "0" }
+       
+OK
+#
+# Backward compatible: string "9" for unsigned integer field general_ip.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_ipLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_ipLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.length", "value": "9" }
+        }
+      }
+  }
+]
+OK
+#
+# Broken: non-numeric string "abc" for integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_errorCode_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": "abc" }
+        }
+ERROR: Incorrect rule definition: field 'general_error_code' is an integer field; string value 'abc' is not a valid number
+#
+# Broken: non-numeric string "abc" for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_threadId_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "abc" }
+        }
+ 
+ERROR: Incorrect rule definition: field 'general_thread_id' is an integer field; string value 'abc' is not a valid number
+#
+# Broken: non-numeric string "aa8" for unsigned integer field general_query.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_queryLen_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": "aa8" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_queryLen_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": "aa8" }
+        
+ERROR: Incorrect rule definition: field 'general_query.length' is an integer field; string value 'aa8' is not a valid number
+#
+# Broken: negative string "-1" for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_negstr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "-1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_threadId_negstr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "-1" }
+        }
+      
+ERROR: Incorrect rule definition: field 'general_thread_id' is an integer field; string value '-1' is not a valid number
+#
+# Broken: empty string "" for unsigned integer field general_command.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_cmdLen_empty', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_cmdLen_empty', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": "" }
+        }
+      
+ERROR: Incorrect rule definition: field 'general_command.length' is an integer field; string value '' is not a valid number
+#
+# Broken: trailing text "8abc" for unsigned integer field general_host.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_hostLen_trailing', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": "8abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_hostLen_trailing', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": "8abc" }
+        }
+ 
+ERROR: Incorrect rule definition: field 'general_host.length' is an integer field; string value '8abc' is not a valid number
+#
+# Broken: integer value for string field general_user.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_userStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_userStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.str", "value": 42 }
+        }
+      }
+  }
+]
+ERROR: Incorrect rule definition: field 'general_user.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field general_command.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_cmdStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": 99 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_cmdStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": 99 }
+        }
+      }
+  }
+ERROR: Incorrect rule definition: field 'general_command.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field general_query.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_queryStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.str", "value": 77 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_queryStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.str", "value": 77 }
+        }
+      }
+  }
+ERROR: Incorrect rule definition: field 'general_query.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field general_host.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_hostStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_hostStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.str", "value": 42 }
+        }
+      }
+  }
+]
+ERROR: Incorrect rule definition: field 'general_host.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field general_sql_command.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_sqlCmdStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_sqlCmdStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.str", "value": 42 }
+        }
+    
+ERROR: Incorrect rule definition: field 'general_sql_command.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field general_external_user.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_extUserStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_extUserStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.str", "value": 42 }
+        }
+ 
+ERROR: Incorrect rule definition: field 'general_external_user.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field general_ip.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_ipStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_ipStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.str", "value": 42 }
+        }
+      }
+  }
+] } }
+ERROR: Incorrect rule definition: field 'general_ip.str' is not an integer field; 'value' must be a string
+#
+# Broken: nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_gen_badField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_badField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } 
+ERROR: Incorrect rule definition: field name 'NONEXISTENT.str' is not valid for event class 'general'
+#
+# Broken: field from wrong class (connection_type belongs to "connection")
+SELECT audit_log_filter_set_filter('filter_broken_gen_wrongClass', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "connection_type", "value": 1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_wrongClass', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "connection_type", "value": 1 }
+        }
+      }
+  }
+] } 
+ERROR: Incorrect rule definition: field name 'connection_type' is not valid for event class 'general'
+#
+# Broken: missing "value" key
+SELECT audit_log_filter_set_filter('filter_broken_gen_noValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_noValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str" }
+        }
+      }
+  }
+] } }')
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: missing "name" key
+SELECT audit_log_filter_set_filter('filter_broken_gen_noName', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "value": "Query" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_noName', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "value": "Query" }
+        }
+      }
+  }
+] } }')
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: empty field object
+SELECT audit_log_filter_set_filter('filter_broken_gen_emptyField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_emptyField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }')
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: null value for string field
+SELECT audit_log_filter_set_filter('filter_broken_gen_nullValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": null }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_nullValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": null }
+        }
+      }
+  
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: boolean value for unsigned integer field
+SELECT audit_log_filter_set_filter('filter_broken_gen_boolValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": true }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_boolValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": true }
+        }
+      }
+  }
+
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: negative value for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_neg', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": -1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_threadId_neg', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": -1 }
+        }
+      }
+  }
+ERROR: Incorrect rule definition: field 'general_thread_id' is an unsigned integer field; 'value' must not be negative
+#
+# Broken: float value for integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_float', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_errorCode_float', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": 1.5 }
+        }
+      
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: array value for string field
+SELECT audit_log_filter_set_filter('filter_broken_gen_arrayValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": ["Query", "Execute"] }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_arrayValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": ["Query", "Execute"] }
+   
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: "and" with nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_badField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "NONEXISTENT.str", "value": "x" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_and_badField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 
+ERROR: Incorrect rule definition: field name 'NONEXISTENT.str' is not valid for event class 'general'
+#
+# Broken: "and" with field from wrong class
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_wrongClass', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "connection_type", "value": 1 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_and_wrongClass', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 
+ERROR: Incorrect rule definition: field name 'connection_type' is not valid for event class 'general'
+#
+# Broken: "and" with integer value for string field
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_strAsInt', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_command.str", "value": 42 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_and_strAsInt', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 
+ERROR: Incorrect rule definition: field 'general_command.str' is not an integer field; 'value' must be a string
+#
+# Broken: "and" with non-numeric string for integer field
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_thread_id", "value": "xyz" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_gen_and_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 
+ERROR: Incorrect rule definition: field 'general_thread_id' is an integer field; string value 'xyz' is not a valid number
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_signed_integer_range.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_signed_integer_range.result
@@ -1,0 +1,17 @@
+#
+# Broken: Uint64 overflow for signed integer field connection.status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_u64overflow', '{"filter":{"class":[{"name":"connection","event":{"name":["connect","change_user","disconnect"],"log":{"field":{"name":"status","value":18446744073709551615}}}}]}}');
+audit_log_filter_set_filter('filter_broken_con_status_u64overflow', '{"filter":{"class":[{"name":"connection","event":{"name":["connect","change_user","disconnect"],"log":{"field":{"name":"status","value":18446744073709551615}}}}]}}')
+ERROR: Incorrect rule definition: field 'status' is a signed integer field; 'value' must not exceed 9223372036854775807
+#
+# Broken: Uint64 overflow for signed integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_u64overflow', '{"filter":{"class":[{"name":"general","event":{"name":"status","log":{"field":{"name":"general_error_code","value":18446744073709551615}}}}]}}');
+audit_log_filter_set_filter('filter_broken_gen_errorCode_u64overflow', '{"filter":{"class":[{"name":"general","event":{"name":"status","log":{"field":{"name":"general_error_code","value":18446744073709551615}}}}]}}')
+ERROR: Incorrect rule definition: field 'general_error_code' is a signed integer field; 'value' must not exceed 9223372036854775807
+#
+# Broken: Uint64 overflow for signed integer field table_access.sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_tab_sqlCmdId_u64overflow', '{"filter":{"class":[{"name":"table_access","event":{"name":["read"],"log":{"field":{"name":"sql_command_id","value":18446744073709551615}}}}]}}');
+audit_log_filter_set_filter('filter_broken_tab_sqlCmdId_u64overflow', '{"filter":{"class":[{"name":"table_access","event":{"name":["read"],"log":{"field":{"name":"sql_command_id","value":18446744073709551615}}}}]}}')
+ERROR: Incorrect rule definition: field 'sql_command_id' is a signed integer field; 'value' must not exceed 9223372036854775807
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_table_access.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_table_access.result
@@ -1,0 +1,837 @@
+#
+# Valid: connection_id (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_connId', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": 1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_connId', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": 1 }
+  
+OK
+#
+# Valid: sql_command_id (integer)
+SELECT audit_log_filter_set_filter('filter_tab_sqlCmdId', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": 0 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_sqlCmdId', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": 0 }
+OK
+#
+# Valid: query.str (string)
+SELECT audit_log_filter_set_filter('filter_tab_queryStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "query.str", "value": "SELECT 1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_queryStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "query.str", "value": "SELECT 
+OK
+#
+# Valid: query.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_queryLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": 8 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_queryLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": 8 }
+ 
+OK
+#
+# Valid: table_database.str (string)
+SELECT audit_log_filter_set_filter('filter_tab_dbStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_database.str", "value": "test" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_dbStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_database.str", "value": "t
+OK
+#
+# Valid: table_database.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_dbLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_dbLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value":
+OK
+#
+# Valid: table_name.str (string)
+SELECT audit_log_filter_set_filter('filter_tab_tblStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": "t1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_tblStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": "t1" 
+OK
+#
+# Valid: table_name.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_tblLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": 2 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_tblLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": 2 
+OK
+#
+# Valid: all table_access fields combined with "and"
+SELECT audit_log_filter_set_filter('filter_tab_allFields', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "sql_command_id", "value": 0 } },
+            { "field": { "name": "query.str", "value": "SELECT * FROM t1" } },
+            { "field": { "name": "query.length", "value": 16 } },
+            { "field": { "name": "table_database.str", "value": "test" } },
+            { "field": { "name": "table_database.length", "value": 4 } },
+            { "field": { "name": "table_name.str", "value": "t1" } },
+            { "field": { "name": "table_name.length", "value": 2 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_allFields', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "conne
+OK
+#
+# Valid: all table_access fields combined with "or"
+SELECT audit_log_filter_set_filter('filter_tab_anyField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "or": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "sql_command_id", "value": 0 } },
+            { "field": { "name": "query.str", "value": "SELECT * FROM t1" } },
+            { "field": { "name": "query.length", "value": 16 } },
+            { "field": { "name": "table_database.str", "value": "test" } },
+            { "field": { "name": "table_database.length", "value": 4 } },
+            { "field": { "name": "table_name.str", "value": "t1" } },
+            { "field": { "name": "table_name.length", "value": 2 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_tab_anyField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "or": [
+            { "field": { "name": "connect
+OK
+#
+# Backward compatible: string "1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_connId_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "1" }
+        }
+      }
+  }
+]
+OK
+#
+# Backward compatible: string "0" for integer field sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_sqlCmdId_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": "0" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_sqlCmdId_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": "0" }
+        }
+      }
+  
+OK
+#
+# Backward compatible: string "8" for unsigned integer field query.length
+SELECT audit_log_filter_set_filter('filter_broken_queryLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": "8" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_queryLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": "8" }
+        }
+      }
+  }
+
+OK
+#
+# Backward compatible: string "4" for unsigned integer field table_database.length
+SELECT audit_log_filter_set_filter('filter_broken_dbLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_dbLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": "4" }
+        }
+      
+OK
+#
+# Backward compatible: string "2" for unsigned integer field table_name.length
+SELECT audit_log_filter_set_filter('filter_broken_tblLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": "2" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_tblLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": "2" }
+        }
+      }
+ 
+OK
+#
+# Broken: non-numeric string "aa8" for unsigned integer field query.length
+SELECT audit_log_filter_set_filter('filter_broken_queryLen_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": "aa8" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_queryLen_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": "aa8" }
+        }
+   
+ERROR: Incorrect rule definition: field 'query.length' is an integer field; string value 'aa8' is not a valid number
+#
+# Broken: non-numeric string "abc" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_connId_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "abc" }
+        }
+    
+ERROR: Incorrect rule definition: field 'connection_id' is an integer field; string value 'abc' is not a valid number
+#
+# Broken: non-numeric string "abc" for integer field sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_sqlCmdId_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_sqlCmdId_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": "abc" }
+        }
+ 
+ERROR: Incorrect rule definition: field 'sql_command_id' is an integer field; string value 'abc' is not a valid number
+#
+# Broken: negative string "-1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_negstr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "-1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_connId_negstr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "-1" }
+        }
+      }
+ 
+ERROR: Incorrect rule definition: field 'connection_id' is an integer field; string value '-1' is not a valid number
+#
+# Broken: empty string "" for unsigned integer field table_name.length
+SELECT audit_log_filter_set_filter('filter_broken_tblLen_empty', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": "" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_tblLen_empty', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": "" }
+        }
+      }
+
+ERROR: Incorrect rule definition: field 'table_name.length' is an integer field; string value '' is not a valid number
+#
+# Broken: trailing text "8abc" for unsigned integer field table_database.length
+SELECT audit_log_filter_set_filter('filter_broken_dbLen_trailing', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": "8abc" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_dbLen_trailing', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": "8abc" }
+        
+ERROR: Incorrect rule definition: field 'table_database.length' is an integer field; string value '8abc' is not a valid number
+#
+# Broken: integer value for string field query.str
+SELECT audit_log_filter_set_filter('filter_broken_queryStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_queryStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.str", "value": 42 }
+        }
+      }
+  }
+] } 
+ERROR: Incorrect rule definition: field 'query.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field table_database.str
+SELECT audit_log_filter_set_filter('filter_broken_dbStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.str", "value": 99 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_dbStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.str", "value": 99 }
+        }
+      }
+  
+ERROR: Incorrect rule definition: field 'table_database.str' is not an integer field; 'value' must be a string
+#
+# Broken: integer value for string field table_name.str
+SELECT audit_log_filter_set_filter('filter_broken_tblStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": 77 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_tblStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": 77 }
+        }
+      }
+  }
+]
+ERROR: Incorrect rule definition: field 'table_name.str' is not an integer field; 'value' must be a string
+#
+# Broken: nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_badField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_badField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+]
+ERROR: Incorrect rule definition: field name 'NONEXISTENT.str' is not valid for event class 'table_access'
+#
+# Broken: field from wrong class (general_command.str belongs to "general")
+SELECT audit_log_filter_set_filter('filter_broken_wrongClass', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_wrongClass', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+   
+ERROR: Incorrect rule definition: field name 'general_command.str' is not valid for event class 'table_access'
+#
+# Broken: missing "value" key
+SELECT audit_log_filter_set_filter('filter_broken_noValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_noValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str" }
+        }
+      }
+  }
+] } }')
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: missing "name" key
+SELECT audit_log_filter_set_filter('filter_broken_noName', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "value": "t1" }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_noName', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "value": "t1" }
+        }
+      }
+  }
+] } }')
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: empty field object
+SELECT audit_log_filter_set_filter('filter_broken_emptyField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_emptyField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }')
+ERROR: Incorrect rule definition: event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer
+#
+# Broken: null value for string field
+SELECT audit_log_filter_set_filter('filter_broken_nullValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": null }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_nullValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": null }
+        }
+      }
+  }
+
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: boolean value for unsigned integer field
+SELECT audit_log_filter_set_filter('filter_broken_boolValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": true }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_boolValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": true }
+        }
+      }
+  }
+]
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: negative value for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_neg', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": -1 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_connId_neg', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": -1 }
+        }
+      }
+  }
+] 
+ERROR: Incorrect rule definition: field 'connection_id' is an unsigned integer field; 'value' must not be negative
+#
+# Broken: float value for integer field sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_sqlCmdId_float', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_sqlCmdId_float', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": 1.5 }
+        }
+      }
+
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: array value for string field
+SELECT audit_log_filter_set_filter('filter_broken_arrayValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": ["t1", "t2"] }
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_arrayValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": ["t1", "t2"] }
+        }
+   
+ERROR: Incorrect rule definition: event field definition 'field' 'value' must be a string or integer
+#
+# Broken: "and" with nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_and_badField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "NONEXISTENT.str", "value": "x" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_and_badField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } 
+ERROR: Incorrect rule definition: field name 'NONEXISTENT.str' is not valid for event class 'table_access'
+#
+# Broken: "and" with field from wrong class
+SELECT audit_log_filter_set_filter('filter_broken_and_wrongClass', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "general_command.str", "value": "Query" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_and_wrongClass', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 
+ERROR: Incorrect rule definition: field name 'general_command.str' is not valid for event class 'table_access'
+#
+# Broken: "and" with integer value for string field
+SELECT audit_log_filter_set_filter('filter_broken_and_strAsInt', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "query.str", "value": 42 } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_and_strAsInt', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } 
+ERROR: Incorrect rule definition: field 'query.str' is not an integer field; 'value' must be a string
+#
+# Broken: "and" with non-numeric string for integer field
+SELECT audit_log_filter_set_filter('filter_broken_and_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "query.length", "value": "xyz" } }
+          ]
+        }
+      }
+  }
+] } }');
+audit_log_filter_set_filter('filter_broken_and_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 
+ERROR: Incorrect rule definition: field 'query.length' is an integer field; string value 'xyz' is not a valid number
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_class.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_class.test
@@ -1,0 +1,159 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+# ---------------------------------------------------------------
+# Broken: empty arrays (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: empty "class" array
+SELECT audit_log_filter_set_filter('filter_broken_emptyClassArr', '{"filter": { "class": [] } }');
+
+--echo #
+--echo # Broken: empty "name" array at class level
+SELECT audit_log_filter_set_filter('filter_broken_emptyNameArr', '{"filter": { "class": [ { "name": [], "log": true } ] } }');
+
+--echo #
+--echo # Broken: empty "event" array
+SELECT audit_log_filter_set_filter('filter_broken_emptyEventArr', '{"filter": { "class": [ { "name": "connection", "event": [] } ] } }');
+
+--echo #
+--echo # Broken: empty "name" array at subclass level
+SELECT audit_log_filter_set_filter('filter_broken_emptySubNameArr', '{"filter": { "class": [ { "name": "connection", "event": { "name": [] } } ] } }');
+
+# ---------------------------------------------------------------
+# Broken: unknown keys (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: unknown key "clss" in filter (typo for "class")
+SELECT audit_log_filter_set_filter('filter_broken_unknownFilterKey', '{"filter": { "clss": [ { "name": "connection" } ] } }');
+
+--echo #
+--echo # Broken: unknown key "evnt" in class (typo for "event")
+SELECT audit_log_filter_set_filter('filter_broken_unknownClassKey', '{"filter": { "class": [ { "name": "connection", "evnt": { "name": "connect" } } ] } }');
+
+--echo #
+--echo # Broken: unknown key "logg" in event (typo for "log")
+SELECT audit_log_filter_set_filter('filter_broken_unknownEventKey', '{"filter": { "class": [ { "name": "connection", "event": { "name": "connect", "logg": true } } ] } }');
+
+# ---------------------------------------------------------------
+# Broken: invalid class names (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken class name: "connection1" (typo, no such class)
+SELECT audit_log_filter_set_filter('filter_broken_badClassName', '{"filter": { "class": [
+  { "name": "connection1",
+      "event": { "name": "connect" }
+  }
+] } }');
+
+--echo #
+--echo # Broken class name: "Table_Access" (wrong case)
+SELECT audit_log_filter_set_filter('filter_broken_wrongCase', '{"filter": { "class": [
+  { "name": "Table_Access",
+      "event": { "name": "read" }
+  }
+] } }');
+
+--echo #
+--echo # Broken class name: empty string
+SELECT audit_log_filter_set_filter('filter_broken_emptyClassName', '{"filter": { "class": [
+  { "name": "",
+      "event": { "name": "status" }
+  }
+] } }');
+
+--echo #
+--echo # Broken class name as array element: ["general1"]
+SELECT audit_log_filter_set_filter('filter_broken_badClassNameArr', '{"filter": { "class": [
+  { "name": [ "general1" ], "log": true }
+] } }');
+
+--echo #
+--echo # Broken class name: "authorization" exists in record naming, but is not filterable
+SELECT audit_log_filter_set_filter('filter_broken_authorizationClass', '{"filter": { "class": [
+  { "name": "authorization",
+      "event": { "name": "authid_create" }
+  }
+] } }');
+
+--echo #
+--echo # Broken class name: "audit" is written directly, outside the filter pipeline
+SELECT audit_log_filter_set_filter('filter_broken_internalAuditClass', '{"filter": { "class": [
+  { "name": "audit",
+      "event": { "name": "startup" }
+  }
+] } }');
+
+--echo #
+--echo # Broken class name: "server_startup" is not supported by filter validation
+SELECT audit_log_filter_set_filter('filter_broken_serverStartupClass', '{"filter": { "class": [
+  { "name": "server_startup",
+      "event": { "name": "startup" }
+  }
+] } }');
+
+--echo #
+--echo # Broken class name: "server_shutdown" is not supported by filter validation
+SELECT audit_log_filter_set_filter('filter_broken_serverShutdownClass', '{"filter": { "class": [
+  { "name": "server_shutdown",
+      "event": { "name": "shutdown" }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: invalid event names (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken event name: "read1" (typo, no such subclass)
+SELECT audit_log_filter_set_filter('filter_broken_badEventName', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": { "name": "read1" }
+  }
+] } }');
+
+--echo #
+--echo # Broken event name: "Connect" (wrong case)
+SELECT audit_log_filter_set_filter('filter_broken_eventWrongCase', '{"filter": { "class": [
+  { "name": "connection",
+      "event": { "name": "Connect" }
+  }
+] } }');
+
+--echo #
+--echo # Broken event name: empty string
+SELECT audit_log_filter_set_filter('filter_broken_emptyEventName', '{"filter": { "class": [
+  { "name": "general",
+      "event": { "name": "" }
+  }
+] } }');
+
+--echo #
+--echo # Broken event name from wrong class: "read" belongs to table_access, not connection
+SELECT audit_log_filter_set_filter('filter_broken_wrongClassEvent', '{"filter": { "class": [
+  { "name": "connection",
+      "event": { "name": "read" }
+  }
+] } }');
+
+--echo #
+--echo # Broken: event name array with one bad entry
+SELECT audit_log_filter_set_filter('filter_broken_badEventArr', '{"filter": { "class": [
+  { "name": "general",
+      "event": { "name": [ "status", "nonexistent" ] }
+  }
+] } }');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_connection.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_connection.test
@@ -1,0 +1,795 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+# ---------------------------------------------------------------
+# Valid filters: individual connection event fields
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Valid: status (integer)
+SELECT audit_log_filter_set_filter('filter_con_status', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": 0 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_id (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_connId', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": 1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_userStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": "root" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_userLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: priv_user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_privUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.str", "value": "root" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: priv_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_privUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: external_user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_extUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.str", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: external_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_extUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.length", "value": 0 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: proxy_user.str (string)
+SELECT audit_log_filter_set_filter('filter_con_proxyUserStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.str", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: proxy_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_proxyUserLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.length", "value": 0 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: host.str (string)
+SELECT audit_log_filter_set_filter('filter_con_hostStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.str", "value": "localhost" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: host.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_hostLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: ip.str (string)
+SELECT audit_log_filter_set_filter('filter_con_ipStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.str", "value": "127.0.0.1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: ip.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_ipLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: database.str (string)
+SELECT audit_log_filter_set_filter('filter_con_dbStr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.str", "value": "test" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: database.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_con_dbLen', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Valid: combined filters using "and" / "or"
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Valid: all connection fields combined with "and"
+SELECT audit_log_filter_set_filter('filter_con_allFields', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "user.str", "value": "root" } },
+            { "field": { "name": "user.length", "value": 4 } },
+            { "field": { "name": "priv_user.str", "value": "root" } },
+            { "field": { "name": "priv_user.length", "value": 4 } },
+            { "field": { "name": "external_user.str", "value": "" } },
+            { "field": { "name": "external_user.length", "value": 0 } },
+            { "field": { "name": "proxy_user.str", "value": "" } },
+            { "field": { "name": "proxy_user.length", "value": 0 } },
+            { "field": { "name": "host.str", "value": "localhost" } },
+            { "field": { "name": "host.length", "value": 9 } },
+            { "field": { "name": "ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "ip.length", "value": 9 } },
+            { "field": { "name": "database.str", "value": "test" } },
+            { "field": { "name": "database.length", "value": 4 } },
+            { "field": { "name": "connection_type", "value": 1 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: all connection fields combined with "or"
+SELECT audit_log_filter_set_filter('filter_con_anyField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "or": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "user.str", "value": "root" } },
+            { "field": { "name": "user.length", "value": 4 } },
+            { "field": { "name": "priv_user.str", "value": "root" } },
+            { "field": { "name": "priv_user.length", "value": 4 } },
+            { "field": { "name": "external_user.str", "value": "" } },
+            { "field": { "name": "external_user.length", "value": 0 } },
+            { "field": { "name": "proxy_user.str", "value": "" } },
+            { "field": { "name": "proxy_user.length", "value": 0 } },
+            { "field": { "name": "host.str", "value": "localhost" } },
+            { "field": { "name": "host.length", "value": 9 } },
+            { "field": { "name": "ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "ip.length", "value": 9 } },
+            { "field": { "name": "database.str", "value": "test" } },
+            { "field": { "name": "database.length", "value": 4 } },
+            { "field": { "name": "connection_type", "value": 1 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Backward compatible: string values for integer fields (expect OK)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Backward compatible: string "0" for integer field status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "4" for unsigned integer field user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_userLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "4" for unsigned integer field priv_user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_privUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "0" for unsigned integer field external_user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_extUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.length", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "0" for unsigned integer field proxy_user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_proxyUserLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.length", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "9" for unsigned integer field host.length
+SELECT audit_log_filter_set_filter('filter_broken_con_hostLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "9" for unsigned integer field ip.length
+SELECT audit_log_filter_set_filter('filter_broken_con_ipLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "4" for unsigned integer field database.length
+SELECT audit_log_filter_set_filter('filter_broken_con_dbLen_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: non-numeric string value for integer fields (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: non-numeric string "abc" for integer field status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: non-numeric string "abc" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: non-numeric string "aa8" for unsigned integer field user.length
+SELECT audit_log_filter_set_filter('filter_broken_con_userLen_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.length", "value": "aa8" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: negative string "-1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_negstr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "-1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: empty string "" for unsigned integer field database.length
+SELECT audit_log_filter_set_filter('filter_broken_con_dbLen_empty', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.length", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: trailing text "8abc" for unsigned integer field host.length
+SELECT audit_log_filter_set_filter('filter_broken_con_hostLen_trailing', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.length", "value": "8abc" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: integer value for string fields (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: integer value for string field user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_userStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field priv_user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_privUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "priv_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field external_user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_extUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "external_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field proxy_user.str
+SELECT audit_log_filter_set_filter('filter_broken_con_proxyUserStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "proxy_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field host.str
+SELECT audit_log_filter_set_filter('filter_broken_con_hostStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "host.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field ip.str
+SELECT audit_log_filter_set_filter('filter_broken_con_ipStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "ip.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field database.str
+SELECT audit_log_filter_set_filter('filter_broken_con_dbStr_int', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "database.str", "value": 99 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: nonexistent / wrong-class field names (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_con_badField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: field from wrong class (general_command.str belongs to "general")
+SELECT audit_log_filter_set_filter('filter_broken_con_wrongClass', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: structural errors in field definition (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: missing "value" key
+SELECT audit_log_filter_set_filter('filter_broken_con_noValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: missing "name" key
+SELECT audit_log_filter_set_filter('filter_broken_con_noName', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "value": "root" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: empty field object
+SELECT audit_log_filter_set_filter('filter_broken_con_emptyField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: null value for string field
+SELECT audit_log_filter_set_filter('filter_broken_con_nullValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": null }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: boolean value for unsigned integer field
+SELECT audit_log_filter_set_filter('filter_broken_con_boolValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": true }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: negative value for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_con_connId_neg', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_id", "value": -1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: float value for integer field status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_float', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "status", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: array value for string field
+SELECT audit_log_filter_set_filter('filter_broken_con_arrayValue', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "user.str", "value": ["root", "admin"] }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: multi-field "and" with invalid second field (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: "and" with nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_con_and_badField', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "NONEXISTENT.str", "value": "x" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with field from wrong class
+SELECT audit_log_filter_set_filter('filter_broken_con_and_wrongClass', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "general_command.str", "value": "Query" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with integer value for string field
+SELECT audit_log_filter_set_filter('filter_broken_con_and_strAsInt', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "user.str", "value": 42 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with non-numeric string for integer field
+SELECT audit_log_filter_set_filter('filter_broken_con_and_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "and": [
+            { "field": { "name": "status", "value": 0 } },
+            { "field": { "name": "connection_id", "value": "xyz" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_connection_type.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_connection_type.test
@@ -1,0 +1,351 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+--echo #
+--echo # Valid: connection_type integer JSON value
+SELECT audit_log_filter_set_filter('filter_con_connType', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_type "::undefined" (alias for 0)
+SELECT audit_log_filter_set_filter('filter_con_connType_undefined', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::undefined" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_type "::tcp/ip" (alias for 1)
+SELECT audit_log_filter_set_filter('filter_con_connType_tcpip', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::tcp/ip" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_type "::socket" (alias for 2)
+SELECT audit_log_filter_set_filter('filter_con_connType_socket', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::socket" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_type "::named_pipe" (alias for 3)
+SELECT audit_log_filter_set_filter('filter_con_connType_namedPipe', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::named_pipe" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_type "::ssl" (alias for 4)
+SELECT audit_log_filter_set_filter('filter_con_connType_ssl', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::ssl" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: connection_type "::shared_memory" (alias for 5)
+SELECT audit_log_filter_set_filter('filter_con_connType_sharedMem', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::shared_memory" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string value "1" for integer field connection_type (OK)
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_str', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "0" for integer field connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_str0', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: non-numeric string "abc" for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_nonnumeric', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: trailing text "1abc" for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_trailing', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "1abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: empty string for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_empty', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: string "-1" for connection_type
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_negstr', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "-1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: string "6" for connection_type (out of range)
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_str6', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "6" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: unknown "::"-prefixed alias
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_invalidAlias', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::invalid" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: "::TCP/IP" wrong case
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_wrongCase', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::TCP/IP" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: "::tcpip" missing slash
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_noSlash', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::tcpip" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: "::named pipe" space instead of underscore
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_space', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::named pipe" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: "::shared" truncated alias
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_truncated', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "::shared" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: "socket" missing "::" prefix
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_noPrefix', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": "socket" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: out-of-range integer (6, max valid is 5)
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_outOfRange', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 6 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: negative integer
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_neg', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": -1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: float value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_float', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: boolean value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_bool', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": true }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: null value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_null', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": null }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Invalid: array value
+SELECT audit_log_filter_set_filter('filter_broken_con_connType_array', '{"filter": { "class": [
+  { "name": "connection",
+      "event": {
+        "name": [ "connect", "change_user", "disconnect" ],
+        "log": {
+          "field": { "name": "connection_type", "value": [0, 1] }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_general.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_general.test
@@ -1,0 +1,793 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+# ---------------------------------------------------------------
+# Valid filters: individual general event fields
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Valid: general_error_code (integer)
+SELECT audit_log_filter_set_filter('filter_gen_errorCode', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": 0 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_thread_id (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_threadId', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": 1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_user.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_userStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_userLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.length", "value": 33 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_command.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_cmdStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_command.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_cmdLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": 5 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_query.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_queryStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.str", "value": "SELECT 1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_query.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_queryLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": 8 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_host.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_hostStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.str", "value": "localhost" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_host.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_hostLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_sql_command.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_sqlCmdStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.str", "value": "select" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_sql_command.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_sqlCmdLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.length", "value": 6 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_external_user.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_extUserStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.str", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_external_user.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_extUserLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.length", "value": 0 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_ip.str (string)
+SELECT audit_log_filter_set_filter('filter_gen_ipStr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.str", "value": "127.0.0.1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: general_ip.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_gen_ipLen', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.length", "value": 9 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Valid: combined filters using "and" / "or"
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Valid: all general fields combined with "and"
+SELECT audit_log_filter_set_filter('filter_gen_allFields', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_thread_id", "value": 1 } },
+            { "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" } },
+            { "field": { "name": "general_user.length", "value": 33 } },
+            { "field": { "name": "general_command.str", "value": "Query" } },
+            { "field": { "name": "general_command.length", "value": 5 } },
+            { "field": { "name": "general_query.str", "value": "SELECT 1" } },
+            { "field": { "name": "general_query.length", "value": 8 } },
+            { "field": { "name": "general_host.str", "value": "localhost" } },
+            { "field": { "name": "general_host.length", "value": 9 } },
+            { "field": { "name": "general_sql_command.str", "value": "select" } },
+            { "field": { "name": "general_sql_command.length", "value": 6 } },
+            { "field": { "name": "general_external_user.str", "value": "" } },
+            { "field": { "name": "general_external_user.length", "value": 0 } },
+            { "field": { "name": "general_ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "general_ip.length", "value": 9 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: all general fields combined with "or"
+SELECT audit_log_filter_set_filter('filter_gen_anyField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "or": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_thread_id", "value": 1 } },
+            { "field": { "name": "general_user.str", "value": "root[root] @ localhost [127.0.0.1]" } },
+            { "field": { "name": "general_user.length", "value": 33 } },
+            { "field": { "name": "general_command.str", "value": "Query" } },
+            { "field": { "name": "general_command.length", "value": 5 } },
+            { "field": { "name": "general_query.str", "value": "SELECT 1" } },
+            { "field": { "name": "general_query.length", "value": 8 } },
+            { "field": { "name": "general_host.str", "value": "localhost" } },
+            { "field": { "name": "general_host.length", "value": 9 } },
+            { "field": { "name": "general_sql_command.str", "value": "select" } },
+            { "field": { "name": "general_sql_command.length", "value": 6 } },
+            { "field": { "name": "general_external_user.str", "value": "" } },
+            { "field": { "name": "general_external_user.length", "value": 0 } },
+            { "field": { "name": "general_ip.str", "value": "127.0.0.1" } },
+            { "field": { "name": "general_ip.length", "value": 9 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Backward compatible: string values for integer fields (expect OK)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Backward compatible: string "0" for integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "1" for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "33" for unsigned integer field general_user.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_userLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.length", "value": "33" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "5" for unsigned integer field general_command.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_cmdLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": "5" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "8" for unsigned integer field general_query.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_queryLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": "8" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "9" for unsigned integer field general_host.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_hostLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "6" for unsigned integer field general_sql_command.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_sqlCmdLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.length", "value": "6" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "0" for unsigned integer field general_external_user.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_extUserLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.length", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "9" for unsigned integer field general_ip.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_ipLen_str', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.length", "value": "9" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: non-numeric string value for integer fields (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: non-numeric string "abc" for integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: non-numeric string "abc" for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: non-numeric string "aa8" for unsigned integer field general_query.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_queryLen_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.length", "value": "aa8" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: negative string "-1" for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_negstr', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": "-1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: empty string "" for unsigned integer field general_command.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_cmdLen_empty', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.length", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: trailing text "8abc" for unsigned integer field general_host.length
+SELECT audit_log_filter_set_filter('filter_broken_gen_hostLen_trailing', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.length", "value": "8abc" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: integer value for string fields (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: integer value for string field general_user.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_userStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field general_command.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_cmdStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": 99 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field general_query.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_queryStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_query.str", "value": 77 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field general_host.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_hostStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_host.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field general_sql_command.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_sqlCmdStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_sql_command.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field general_external_user.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_extUserStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_external_user.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field general_ip.str
+SELECT audit_log_filter_set_filter('filter_broken_gen_ipStr_int', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_ip.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: nonexistent / wrong-class field names (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_gen_badField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: field from wrong class (connection_type belongs to "connection")
+SELECT audit_log_filter_set_filter('filter_broken_gen_wrongClass', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "connection_type", "value": 1 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: structural errors in field definition (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: missing "value" key
+SELECT audit_log_filter_set_filter('filter_broken_gen_noValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: missing "name" key
+SELECT audit_log_filter_set_filter('filter_broken_gen_noName', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "value": "Query" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: empty field object
+SELECT audit_log_filter_set_filter('filter_broken_gen_emptyField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: null value for string field
+SELECT audit_log_filter_set_filter('filter_broken_gen_nullValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": null }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: boolean value for unsigned integer field
+SELECT audit_log_filter_set_filter('filter_broken_gen_boolValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": true }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: negative value for unsigned integer field general_thread_id
+SELECT audit_log_filter_set_filter('filter_broken_gen_threadId_neg', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_thread_id", "value": -1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: float value for integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_float', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_error_code", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: array value for string field
+SELECT audit_log_filter_set_filter('filter_broken_gen_arrayValue', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": { "name": "general_command.str", "value": ["Query", "Execute"] }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: multi-field "and" with invalid second field (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: "and" with nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_badField', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "NONEXISTENT.str", "value": "x" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with field from wrong class
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_wrongClass', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "connection_type", "value": 1 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with integer value for string field
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_strAsInt', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_command.str", "value": 42 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with non-numeric string for integer field
+SELECT audit_log_filter_set_filter('filter_broken_gen_and_nonnumeric', '{"filter": { "class": [
+  { "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "and": [
+            { "field": { "name": "general_error_code", "value": 0 } },
+            { "field": { "name": "general_thread_id", "value": "xyz" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_signed_integer_range.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_signed_integer_range.test
@@ -1,0 +1,29 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+# ---------------------------------------------------------------
+# Broken: out-of-range unsigned JSON integer for signed fields
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: Uint64 overflow for signed integer field connection.status
+SELECT audit_log_filter_set_filter('filter_broken_con_status_u64overflow', '{"filter":{"class":[{"name":"connection","event":{"name":["connect","change_user","disconnect"],"log":{"field":{"name":"status","value":18446744073709551615}}}}]}}');
+
+--echo #
+--echo # Broken: Uint64 overflow for signed integer field general_error_code
+SELECT audit_log_filter_set_filter('filter_broken_gen_errorCode_u64overflow', '{"filter":{"class":[{"name":"general","event":{"name":"status","log":{"field":{"name":"general_error_code","value":18446744073709551615}}}}]}}');
+
+--echo #
+--echo # Broken: Uint64 overflow for signed integer field table_access.sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_tab_sqlCmdId_u64overflow', '{"filter":{"class":[{"name":"table_access","event":{"name":["read"],"log":{"field":{"name":"sql_command_id","value":18446744073709551615}}}}]}}');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_table_access.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_table_access.test
@@ -1,0 +1,569 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+# ---------------------------------------------------------------
+# Valid filters: individual table_access event fields
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Valid: connection_id (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_connId', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": 1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: sql_command_id (integer)
+SELECT audit_log_filter_set_filter('filter_tab_sqlCmdId', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": 0 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: query.str (string)
+SELECT audit_log_filter_set_filter('filter_tab_queryStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "query.str", "value": "SELECT 1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: query.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_queryLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": 8 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: table_database.str (string)
+SELECT audit_log_filter_set_filter('filter_tab_dbStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_database.str", "value": "test" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: table_database.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_dbLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": 4 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: table_name.str (string)
+SELECT audit_log_filter_set_filter('filter_tab_tblStr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": "t1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: table_name.length (unsigned integer)
+SELECT audit_log_filter_set_filter('filter_tab_tblLen', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": 2 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Valid: combined filters using "and" / "or"
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Valid: all table_access fields combined with "and"
+SELECT audit_log_filter_set_filter('filter_tab_allFields', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "sql_command_id", "value": 0 } },
+            { "field": { "name": "query.str", "value": "SELECT * FROM t1" } },
+            { "field": { "name": "query.length", "value": 16 } },
+            { "field": { "name": "table_database.str", "value": "test" } },
+            { "field": { "name": "table_database.length", "value": 4 } },
+            { "field": { "name": "table_name.str", "value": "t1" } },
+            { "field": { "name": "table_name.length", "value": 2 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Valid: all table_access fields combined with "or"
+SELECT audit_log_filter_set_filter('filter_tab_anyField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "insert", "update", "delete", "read" ],
+        "log": {
+          "or": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "sql_command_id", "value": 0 } },
+            { "field": { "name": "query.str", "value": "SELECT * FROM t1" } },
+            { "field": { "name": "query.length", "value": 16 } },
+            { "field": { "name": "table_database.str", "value": "test" } },
+            { "field": { "name": "table_database.length", "value": 4 } },
+            { "field": { "name": "table_name.str", "value": "t1" } },
+            { "field": { "name": "table_name.length", "value": 2 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Backward compatible: string values for integer fields (expect OK)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Backward compatible: string "1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "0" for integer field sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_sqlCmdId_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": "0" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "8" for unsigned integer field query.length
+SELECT audit_log_filter_set_filter('filter_broken_queryLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": "8" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "4" for unsigned integer field table_database.length
+SELECT audit_log_filter_set_filter('filter_broken_dbLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": "4" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Backward compatible: string "2" for unsigned integer field table_name.length
+SELECT audit_log_filter_set_filter('filter_broken_tblLen_str', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": "2" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: non-numeric string value for integer fields (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: non-numeric string "aa8" for unsigned integer field query.length
+SELECT audit_log_filter_set_filter('filter_broken_queryLen_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.length", "value": "aa8" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: non-numeric string "abc" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: non-numeric string "abc" for integer field sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_sqlCmdId_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": "abc" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: negative string "-1" for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_negstr', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": "-1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: empty string "" for unsigned integer field table_name.length
+SELECT audit_log_filter_set_filter('filter_broken_tblLen_empty', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.length", "value": "" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: trailing text "8abc" for unsigned integer field table_database.length
+SELECT audit_log_filter_set_filter('filter_broken_dbLen_trailing', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.length", "value": "8abc" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: integer value for string fields (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: integer value for string field query.str
+SELECT audit_log_filter_set_filter('filter_broken_queryStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "query.str", "value": 42 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field table_database.str
+SELECT audit_log_filter_set_filter('filter_broken_dbStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_database.str", "value": 99 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: integer value for string field table_name.str
+SELECT audit_log_filter_set_filter('filter_broken_tblStr_int', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": 77 }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: nonexistent / wrong-class field names (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_badField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "NONEXISTENT.str", "value": "x" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: field from wrong class (general_command.str belongs to "general")
+SELECT audit_log_filter_set_filter('filter_broken_wrongClass', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "general_command.str", "value": "Query" }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: structural errors in field definition (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: missing "value" key
+SELECT audit_log_filter_set_filter('filter_broken_noValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: missing "name" key
+SELECT audit_log_filter_set_filter('filter_broken_noName', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "value": "t1" }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: empty field object
+SELECT audit_log_filter_set_filter('filter_broken_emptyField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: null value for string field
+SELECT audit_log_filter_set_filter('filter_broken_nullValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": null }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: boolean value for unsigned integer field
+SELECT audit_log_filter_set_filter('filter_broken_boolValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": true }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: negative value for unsigned integer field connection_id
+SELECT audit_log_filter_set_filter('filter_broken_connId_neg', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "connection_id", "value": -1 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: float value for integer field sql_command_id
+SELECT audit_log_filter_set_filter('filter_broken_sqlCmdId_float', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "sql_command_id", "value": 1.5 }
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: array value for string field
+SELECT audit_log_filter_set_filter('filter_broken_arrayValue', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "field": { "name": "table_name.str", "value": ["t1", "t2"] }
+        }
+      }
+  }
+] } }');
+
+# ---------------------------------------------------------------
+# Broken: multi-field "and" with invalid second field (expect ERROR)
+# ---------------------------------------------------------------
+
+--echo #
+--echo # Broken: "and" with nonexistent field name
+SELECT audit_log_filter_set_filter('filter_broken_and_badField', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "NONEXISTENT.str", "value": "x" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with field from wrong class
+SELECT audit_log_filter_set_filter('filter_broken_and_wrongClass', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "general_command.str", "value": "Query" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with integer value for string field
+SELECT audit_log_filter_set_filter('filter_broken_and_strAsInt', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "query.str", "value": 42 } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Broken: "and" with non-numeric string for integer field
+SELECT audit_log_filter_set_filter('filter_broken_and_nonnumeric', '{"filter": { "class": [
+  { "name": "table_access",
+      "event": {
+        "name": [ "read" ],
+        "log": {
+          "and": [
+            { "field": { "name": "connection_id", "value": 1 } },
+            { "field": { "name": "query.length", "value": "xyz" } }
+          ]
+        }
+      }
+  }
+] } }');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13228,6 +13228,18 @@ ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY
 ER_AUDIT_PARSE_CONDITION_FIELD_NAME_NOT_FOUND
   eng "Wrong JSON filter '%s' format, field name '%s' is not valid for event class '%s'"
 
+ER_AUDIT_PARSE_INVALID_EVENT_CLASS_NAME
+  eng "Wrong JSON filter '%s' format, unknown event class name '%s'"
+
+ER_AUDIT_PARSE_INVALID_EVENT_SUBCLASS_NAME
+  eng "Wrong JSON filter '%s' format, unknown event subclass name '%s' for class '%s'"
+
+ER_AUDIT_PARSE_EMPTY_ARRAY
+  eng "Wrong JSON filter '%s' format, empty array is not allowed"
+
+ER_AUDIT_PARSE_UNEXPECTED_KEY
+  eng "Wrong JSON filter '%s' format, unexpected key '%s'"
+
 #
 # End of Audit Log Filter error log messages
 #

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13133,7 +13133,7 @@ ER_AUDIT_PARSE_CONDITION_BAD_FIELD_TYPE
   eng "Wrong JSON filter '%s' format, condition definition 'field' must be of object type"
 
 ER_AUDIT_PARSE_CONDITION_BAD_FIELD_NAME_AND_VALUE
-  eng "Wrong JSON filter '%s' format, event field definition 'field' must have field 'name' and 'value' provided as strings"
+  eng "Wrong JSON filter '%s' format, event field definition 'field' must have field 'name' provided as a string and 'value' as a string or integer"
 
 ER_AUDIT_PARSE_CONDITION_BAD_AND_COND_TYPE
   eng "Wrong JSON filter '%s' format, condition definition 'and' must be of array type"


### PR DESCRIPTION
Introduce std::variant-based AuditRecordFieldValue (string | int64 | uint64) to preserve native types for integer event fields instead of converting everything to strings.

Changes:
- AuditRecordFieldsList values are now AuditRecordFieldValue variants
- general fields use native types: error_code (int64), connection_id (uint64), *.length (uint64)
- connection fields use native types: status (int64), connection_id (uint64), connection_type (int64), *.length (uint64)
- table_access fields use native types: connection_id (uint64), sql_command_id (int64), *.length (uint64)
- Filter rule parser accepts integer JSON values for integer fields, with signedness validation (rejects negative values for unsigned fields and integer values for string fields)
- Validate connection_type field values at parse time: accept integers 0..5 or pseudo-constants (::undefined, ::tcp/ip, ::socket, ::named_pipe, ::ssl, ::shared_memory), reject anything else
- Add field_value_to_string() and field_value_matches() helpers for variant-aware comparison and conversion
- Add get_event_field_value_type() to query expected field types for general, connection, and table_access event classes
- Add missing general_external_user.str/length to is_valid_event_field_name()
- Backward compatible: string values in filter rules still work for all fields
- Reject audit log filter definitions with invalid class names, invalid event subclass names, empty arrays, and unexpected JSON keys that were previously accepted silently, leading to filters that never matched any events or quietly ignored user typos.
