### PR TITLE
PS-8867 Increase the verbosity of the DataDictionary upgrade process

### DIFF
--- a/mysql-test/r/dd_upgrade_error.result
+++ b/mysql-test/r/dd_upgrade_error.result
@@ -30,7 +30,8 @@ Pattern "Table mismatch_frms/t1_col_name is not found in InnoDB dictionary" foun
 # Upgrade fails for the case where the general tablespace file is removed.
 Pattern "Error in fixing SE data for tablespace.t3" found
 # Upgrade fails for the case where the file per tablespace is removed.
-Pattern "Got error 197 from SE while migrating tablespaces" found
+Pattern "Got error 197\(Tablespace cannot be accessed\) from SE while migrating tablespaces" found
+Pattern "Tablespace file .* is missing" found
 # Remove copied files
 # ------------------------------------------------------------------
 # Check upgrade of tables and stored programs using long enum elements.

--- a/mysql-test/suite/innodb/r/discarded_partition_upgrade_from_57.result
+++ b/mysql-test/suite/innodb/r/discarded_partition_upgrade_from_57.result
@@ -1,1 +1,3 @@
+Pattern "\[ERROR\] \[[^]]*\] \[[^]]*\] Tablespace .* is set as DISCARDED\. Upgrade will stop, please make sure there are no discarded Tables/Partitions before upgrading\." found
+Pattern "\[ERROR\] \[[^]]*\] \[[^]]*\] Tablespace .* Subpartition .* is set as DISCARDED\. Upgrade will stop, please make sure there are no discarded Tables/Partitions before upgrading\." found
 Pattern "\[ERROR\] \[[^]]*\] \[[^]]*\] Upgrade failed because database contains discarded tablespaces\." found

--- a/mysql-test/suite/innodb/t/discarded_partition_upgrade_from_57.test
+++ b/mysql-test/suite/innodb/t/discarded_partition_upgrade_from_57.test
@@ -30,6 +30,15 @@ let $BUGDATADIR = $MYSQL_TMP_DIR/data_upgrade;
 # about impossible upgrade because of discarded Tablespaces
 --error 1
 --exec $MYSQLD_CMD --loose-console --datadir=$BUGDATADIR > $error_log 2>&1
+
+# Search for partitions t1#P#p0, t3#P#p0
+let SEARCH_PATTERN= \[ERROR\] \[[^]]*\] \[[^]]*\] Tablespace .* is set as DISCARDED\. Upgrade will stop, please make sure there are no discarded Tables/Partitions before upgrading\.;
+--source include/search_pattern.inc
+
+# Search for partitions t4#P#p0#SP#p0sp0, t4#P#p0#SP#p0sp1, t4#P#p1#SP#p1sp0, t5#P#p1#SP#p1sp1, t6#P#p0#SP#p0sp0, t6#P#p0#SP#p0sp1, t6#P#p1#SP#p1sp1
+let SEARCH_PATTERN= \[ERROR\] \[[^]]*\] \[[^]]*\] Tablespace .* Subpartition .* is set as DISCARDED\. Upgrade will stop, please make sure there are no discarded Tables/Partitions before upgrading\.;
+--source include/search_pattern.inc
+
 let SEARCH_PATTERN= \[ERROR\] \[[^]]*\] \[[^]]*\] Upgrade failed because database contains discarded tablespaces\.;
 --source include/search_pattern.inc
 

--- a/mysql-test/t/dd_upgrade_error.test
+++ b/mysql-test/t/dd_upgrade_error.test
@@ -90,7 +90,10 @@ let SEARCH_FILE= $MYSQLD_LOG;
 --error 1
 --exec $MYSQLD --no-defaults $extra_args --innodb_dedicated_server=OFF --secure-file-priv="" --log-error=$MYSQLD_LOG --datadir=$MYSQLD_DATADIR1
 
---let SEARCH_PATTERN= Got error 197 from SE while migrating tablespaces
+--let SEARCH_PATTERN= Got error 197\(Tablespace cannot be accessed\) from SE while migrating tablespaces
+--source include/search_pattern.inc
+
+--let SEARCH_PATTERN= Tablespace file .* is missing
 --source include/search_pattern.inc
 
 --echo # Remove copied files

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -3076,7 +3076,7 @@ ER_DD_UPGRADE_INFO_FILE_CLOSE_FAILED
   eng "Could not close the upgrade info file '%s' in the MySQL servers datadir, errno: %d."
 
 ER_DD_UPGRADE_TABLESPACE_MIGRATION_FAILED
-  eng "Got error %d from SE while migrating tablespaces."
+  eng "Got error %d(%s) from SE while migrating tablespaces."
 
 ER_DD_UPGRADE_FAILED_TO_CREATE_TABLE_STATS
   eng "Error in creating TABLE statistics entry. Fix statistics data by using ANALYZE command."
@@ -12504,6 +12504,9 @@ ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH
 
 ER_SSL_FIPS_MODE_ENABLED
   eng "A FIPS-approved version of the OpenSSL cryptographic library has been detected in the operating system with a properly configured FIPS module available for loading. Percona Server for MySQL will load this module and run in FIPS mode."
+
+ER_IB_MISSING_TABLESPACE_FILE
+  eng "Tablespace file %s is missing."
 
 #
 # End of Percona Server 8.0 server error log messages

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -113,8 +113,14 @@ bool update_system_tables(THD *thd) {
   bool exists = false;
 
   if (dd::tables::DD_properties::instance().get(
-          thd, "SYSTEM_TABLES", &system_tables_props, &exists) ||
-      !exists) {
+          thd, "SYSTEM_TABLES", &system_tables_props, &exists)) {
+    LogErr(ERROR_LEVEL, ER_FAILED_GET_DD_PROPERTY, "SYSTEM_TABLES");
+    my_error(ER_DD_INIT_FAILED, MYF(0));
+    return true;
+  }
+  if (!exists) {
+    LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+           "DD property SYSTEM_TABLES is missing during DD upgrade");
     my_error(ER_DD_INIT_FAILED, MYF(0));
     return true;
   }

--- a/sql/dd/upgrade_57/upgrade.cc
+++ b/sql/dd/upgrade_57/upgrade.cc
@@ -729,7 +729,10 @@ static bool ha_migrate_tablespaces(THD *thd, plugin_ref plugin, void *) {
     }
 
     if (error) {
-      LogErr(ERROR_LEVEL, ER_DD_UPGRADE_TABLESPACE_MIGRATION_FAILED, error);
+      char errbuf[MYSYS_STRERROR_SIZE];
+      const char *errtxt = my_strerror(errbuf, sizeof(errbuf), error);
+      LogErr(ERROR_LEVEL, ER_DD_UPGRADE_TABLESPACE_MIGRATION_FAILED, error,
+             errtxt);
       return true;
     }
   }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2582,6 +2582,21 @@ static void mysqld_exit(int exit_code) {
   exit(exit_code); /* purecov: inspected */
 }
 
+static const char *get_exit_code_str(int exit_code) {
+  switch (exit_code) {
+    case MYSQLD_SUCCESS_EXIT:
+      return "MYSQLD_SUCCESS_EXIT";
+    case MYSQLD_ABORT_EXIT:
+      return "MYSQLD_ABORT_EXIT";
+    case MYSQLD_FAILURE_EXIT:
+      return "MYSQLD_FAILURE_EXIT";
+    case MYSQLD_RESTART_EXIT:
+      return "MYSQLD_RESTART_EXIT";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 /**
    GTID cleanup destroys objects and reset their pointer.
    Function is reentrant.
@@ -6851,6 +6866,8 @@ static int init_server_components() {
   if (opt_initialize) {
     if (!is_help_or_validate_option()) {
       if (dd::init(dd::enum_dd_init_type::DD_INITIALIZE)) {
+        LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+               "DD init failed: mode=DD_INITIALIZE");
         LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
         unireg_abort(1);
       }
@@ -6869,16 +6886,31 @@ static int init_server_components() {
     */
     if (!is_help_or_validate_option() &&
         dd::init(dd::enum_dd_init_type::DD_RESTART_OR_UPGRADE)) {
-      LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
-
-      if (!dd::upgrade::no_server_upgrade_required()) {
+      const bool upgrade_required = !dd::upgrade::no_server_upgrade_required();
+      if (upgrade_required) {
         dd_init_failed_during_upgrade = true;
       }
 
       /* If clone recovery fails, we rollback the files to previous
       dataset and attempt to restart server. */
-      int exit_code =
+      const int exit_code =
           clone_recovery_error ? MYSQLD_RESTART_EXIT : MYSQLD_ABORT_EXIT;
+
+      const char *upgrade_mode_str =
+          get_type(&upgrade_mode_typelib, static_cast<uint>(opt_upgrade_mode));
+
+      std::ostringstream err_msg;
+      err_msg << "DD init failed: mode=DD_RESTART_OR_UPGRADE"
+              << ", upgrade_required=" << (upgrade_required ? "yes" : "no")
+              << ", upgrade_mode=" << upgrade_mode_str
+              << ", clone_recovery_error="
+              << (clone_recovery_error ? "yes" : "no")
+              << ", exit_code=" << get_exit_code_str(exit_code) << " ("
+              << exit_code << ")";
+
+      LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.str().c_str());
+
+      LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
       unireg_abort(exit_code);
     }
   }

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -1565,7 +1565,7 @@ static inline space_id_t dict_check_sys_tables(bool validate) {
     }
 
     if (flags2 & DICT_TF2_DISCARDED) {
-      ib::info(ER_IB_MSG_193)
+      ib::error(ER_IB_MSG_193)
           << "Tablespace " << table_name
           << " is set as DISCARDED. Upgrade will stop, please make sure "
              "there are no discarded Tables/Partitions before upgrading.";

--- a/storage/innobase/dict/dict0upgrade.cc
+++ b/storage/innobase/dict/dict0upgrade.cc
@@ -1229,6 +1229,7 @@ int dd_upgrade_tablespace(THD *thd) {
           Datafile df;
           df.set_filepath(orig_name.c_str());
           if (df.open_read_only(false) != DB_SUCCESS) {
+            ib::error(ER_IB_MISSING_TABLESPACE_FILE, orig_name.c_str());
             mem_heap_free(heap);
             pcur.close();
             return HA_ERR_TABLESPACE_MISSING;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-8867

Improved the following error reporting during the Data Dictionary (DD)
upgrade and initialization process to facilitate easier troubleshooting.

- When an upgrade from 5.7 fails due to discarded tablespaces, the notes which list the specific tablespaces that were discarded in the error log, are now updgraded to errors.
- Include storage-engine error text in DD tablespace migration failures: "Got error %d(%s) from SE while migrating tablespaces." and pass my_strerror(...) text from the upgrade path.
- Introduced `ER_IB_MISSING_TABLESPACE_FILE` to explicitly report when a tablespace file is missing during the upgrade.
- Added detailed logging in `mysqld.cc` when `dd::init` fails, providing context such as `upgrade_required`, `upgrade_mode`, and `exit_code`.
- Added error logging in `bootstrapper.cc` if the `SYSTEM_TABLES` DD property is missing or cannot be retrieved.
- Updated relevant MTR tests to match the new or more verbose error output.