### PR TITLE
PS-10312 [9.x]: Audit Log Filter refactoring

### DIFF
--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -27,6 +27,7 @@
 #include "components/audit_log_filter/log_record_formatter/base.h"
 #include "components/audit_log_filter/sys_vars.h"
 
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <numeric>
@@ -44,30 +45,36 @@ FileWriterPtr get_file_writer(FileHandle &file_handle) {
    * SEMISYNCHRONOUS - log directly to file, do not flush and sync every event
    * SYNCHRONOUS - log directly to file, flush and sync every event.
    */
-  auto strategy_type = SysVars::get_file_strategy_type();
-  std::unique_ptr<FileWriterBase> writer = std::make_unique<FileWriter>(
-      file_handle, strategy_type == AuditLogStrategyType::Synchronous);
+  try {
+    auto strategy_type = SysVars::get_file_strategy_type();
+    std::unique_ptr<FileWriterBase> writer = std::make_unique<FileWriter>(
+        file_handle, strategy_type == AuditLogStrategyType::Synchronous);
 
-  if (SysVars::get_log_encryption_enabled()) {
-    writer = std::make_unique<FileWriterEncrypting>(std::move(writer));
+    if (SysVars::get_log_encryption_enabled()) {
+      writer = std::make_unique<FileWriterEncrypting>(std::move(writer));
+    }
+
+    if (SysVars::get_compression_type() == AuditLogCompressionType::Gzip) {
+      writer = std::make_unique<FileWriterCompressing>(std::move(writer));
+    }
+
+    if (strategy_type == AuditLogStrategyType::Asynchronous ||
+        strategy_type == AuditLogStrategyType::Performance) {
+      writer = std::make_unique<FileWriterBuffering>(
+          std::move(writer), SysVars::get_buffer_size(),
+          strategy_type == AuditLogStrategyType::Performance);
+    }
+
+    return writer;
+  } catch (std::exception &e) {
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to create Audit Log Filter file writer (%s)",
+                    e.what());
+  } catch (...) {
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to create Audit Log Filter file writer");
   }
-
-  if (SysVars::get_compression_type() == AuditLogCompressionType::Gzip) {
-    writer = std::make_unique<FileWriterCompressing>(std::move(writer));
-  }
-
-  if (strategy_type == AuditLogStrategyType::Asynchronous ||
-      strategy_type == AuditLogStrategyType::Performance) {
-    writer = std::make_unique<FileWriterBuffering>(
-        std::move(writer), SysVars::get_buffer_size(),
-        strategy_type == AuditLogStrategyType::Performance);
-  }
-
-  if (!writer->init()) {
-    return nullptr;
-  }
-
-  return writer;
+  return nullptr;
 }
 
 }  // namespace

--- a/components/audit_log_filter/log_writer/file_writer.cc
+++ b/components/audit_log_filter/log_writer/file_writer.cc
@@ -23,10 +23,6 @@ namespace audit_log_filter::log_writer {
 FileWriter::FileWriter(FileHandle &file_handle, bool sync_on_write)
     : m_file_handle{file_handle}, m_sync_on_write{sync_on_write} {}
 
-bool FileWriter::init() noexcept {
-  return true;  // nothing to do
-}
-
 bool FileWriter::open() noexcept {
   return true;  // nothing to do
 }

--- a/components/audit_log_filter/log_writer/file_writer.h
+++ b/components/audit_log_filter/log_writer/file_writer.h
@@ -25,13 +25,6 @@ class FileWriter : public FileWriterBase {
   explicit FileWriter(FileHandle &file_handle, bool sync_on_write);
 
   /**
-   * @brief Init file writer.
-   *
-   * @return true in case of success, false otherwise
-   */
-  bool init() noexcept override;
-
-  /**
    * @brief Prepare writer for work with newly opened log file.
    *
    * @return true in case of success, false otherwise

--- a/components/audit_log_filter/log_writer/file_writer_base.h
+++ b/components/audit_log_filter/log_writer/file_writer_base.h
@@ -27,13 +27,6 @@ class FileWriterBase {
   virtual ~FileWriterBase() = default;
 
   /**
-   * @brief Init file writer.
-   *
-   * @return true in case of success, false otherwise
-   */
-  virtual bool init() noexcept = 0;
-
-  /**
    * @brief Prepare writer for work with newly opened log file.
    *
    * @return true in case of success, false otherwise

--- a/components/audit_log_filter/log_writer/file_writer_buffering.cc
+++ b/components/audit_log_filter/log_writer/file_writer_buffering.cc
@@ -23,6 +23,8 @@
 #include "my_systime.h"
 #include "template_utils.h"
 
+#include <stdexcept>
+
 namespace audit_log_filter::log_writer {
 namespace {
 #if defined(HAVE_PSI_INTERFACE)
@@ -39,45 +41,18 @@ PSI_cond_info cond_key_list[] = {
     {&key_log_flushed_cond, "audit_filter_buffer::flushed_cond",
      PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME}};
 #endif
-
-void *buffer_flush_worker(void *arg) {
-  auto *buffer = static_cast<FileWriterBuffering *>(arg);
-
-  my_thread_init();
-  while (!buffer->check_flush_stopped()) {
-    buffer->flush_worker();
-  }
-  my_thread_end();
-
-  return nullptr;
-}
 }  // namespace
 
 FileWriterBuffering::FileWriterBuffering(
     std::unique_ptr<FileWriterBase> file_writer, size_t size, bool drop_if_full)
     : FileWriterDecoratorBase(std::move(file_writer)),
-      m_size{size},
       m_drop_if_full{drop_if_full},
-      m_buf{nullptr},
+      m_buf(size, Malloc_allocator<char>(key_memory_audit_log_filter_buffer)),
       m_write_pos{0},
       m_flush_pos{0},
       m_flush_worker_thread{0},
-      m_stop_flush_worker{false} {}
-
-FileWriterBuffering::~FileWriterBuffering() {
-  if (m_buf != nullptr) {
-    shutdown();
-  }
-}
-
-bool FileWriterBuffering::init() noexcept {
-  m_buf = static_cast<char *>(
-      my_malloc(key_memory_audit_log_filter_buffer, m_size, MY_ZEROFILL));
-
-  if (m_buf == nullptr) {
-    return false;
-  }
-
+      m_flush_worker_running{true},
+      m_state{FileBufferState::COMPLETE} {
 #ifdef HAVE_PSI_INTERFACE
   mysql_mutex_register(AUDIT_LOG_FILTER_PSI_CATEGORY, mutex_key_list,
                        array_elements(mutex_key_list));
@@ -85,18 +60,24 @@ bool FileWriterBuffering::init() noexcept {
                       array_elements(cond_key_list));
 #endif /* HAVE_PSI_INTERFACE */
 
-  m_state = FileBufferState::COMPLETE;
-  m_write_pos = 0;
-  m_flush_pos = 0;
-  m_stop_flush_worker = false;
-
   mysql_mutex_init(key_log_mutex, &m_mutex, MY_MUTEX_INIT_FAST);
   mysql_cond_init(key_log_flushed_cond, &m_flushed_cond);
   mysql_cond_init(key_log_written_cond, &m_written_cond);
-  pthread_create(&m_flush_worker_thread, nullptr, buffer_flush_worker, this);
-
-  return FileWriterDecoratorBase::init();
+  if (pthread_create(
+          &m_flush_worker_thread, nullptr,
+          [](void *arg) -> void * {
+            static_cast<FileWriterBuffering *>(arg)->flush_worker();
+            return nullptr;
+          },
+          this) != 0) {
+    mysql_cond_destroy(&m_written_cond);
+    mysql_cond_destroy(&m_flushed_cond);
+    mysql_mutex_destroy(&m_mutex);
+    throw std::runtime_error("failed to create file writer thread");
+  }
 }
+
+FileWriterBuffering::~FileWriterBuffering() { shutdown(); }
 
 bool FileWriterBuffering::open() noexcept {
   return FileWriterDecoratorBase::open();
@@ -114,17 +95,19 @@ void FileWriterBuffering::close() noexcept {
 }
 
 void FileWriterBuffering::shutdown() noexcept {
-  m_stop_flush_worker = true;
-
-  if (m_buf != nullptr) {
-    pthread_join(m_flush_worker_thread, nullptr);
-    mysql_cond_destroy(&m_flushed_cond);
-    mysql_cond_destroy(&m_written_cond);
-    mysql_mutex_destroy(&m_mutex);
-    my_free(m_buf);
-    m_buf = nullptr;
-    m_flush_worker_thread = 0;
+  mysql_mutex_lock(&m_mutex);
+  if (!m_flush_worker_running) {
+    mysql_mutex_unlock(&m_mutex);
+    return;
   }
+  m_flush_worker_running = false;
+  mysql_cond_signal(&m_written_cond);
+  mysql_mutex_unlock(&m_mutex);
+  pthread_join(m_flush_worker_thread, nullptr);
+  mysql_cond_destroy(&m_flushed_cond);
+  mysql_cond_destroy(&m_written_cond);
+  mysql_mutex_destroy(&m_mutex);
+  m_flush_worker_thread = 0;
 }
 
 void FileWriterBuffering::pause() noexcept {
@@ -136,56 +119,63 @@ void FileWriterBuffering::pause() noexcept {
 
 void FileWriterBuffering::resume() noexcept { mysql_mutex_unlock(&m_mutex); }
 
-bool FileWriterBuffering::check_flush_stopped() const noexcept {
-  return m_stop_flush_worker && m_flush_pos == m_write_pos;
-}
-
 void FileWriterBuffering::flush_worker() noexcept {
-  mysql_mutex_lock(&m_mutex);
+  my_thread_init();
 
-  while (m_flush_pos == m_write_pos) {
-    if (m_stop_flush_worker) {
-      mysql_mutex_unlock(&m_mutex);
-      return;
+  while (true) {
+    mysql_mutex_lock(&m_mutex);
+
+    // Wait for new data or until worker thread is stopped.
+    while (m_flush_worker_running && m_flush_pos == m_write_pos) {
+      timespec abs_time{};
+      set_timespec(&abs_time, 1);
+      mysql_cond_timedwait(&m_written_cond, &m_mutex, &abs_time);
     }
-    timespec abs_time{};
-    set_timespec(&abs_time, 1);
-    mysql_cond_timedwait(&m_written_cond, &m_mutex, &abs_time);
+
+    // End worker thread if it has been stopped and there is no more data to be
+    // flushed.
+    if (!m_flush_worker_running && m_flush_pos == m_write_pos) {
+      mysql_mutex_unlock(&m_mutex);
+      break;
+    }
+
+    if (m_flush_pos >= m_write_pos % m_buf.size()) {
+      m_state = (m_write_pos % m_buf.size() == 0) ? FileBufferState::COMPLETE
+                                                  : FileBufferState::INCOMPLETE;
+      mysql_mutex_unlock(&m_mutex);
+      FileWriterDecoratorBase::write(&m_buf[m_flush_pos],
+                                     m_buf.size() - m_flush_pos);
+      mysql_mutex_lock(&m_mutex);
+      m_flush_pos = 0;
+      m_write_pos %= m_buf.size();
+    } else {
+      const size_t flushlen = m_write_pos - m_flush_pos;
+      mysql_mutex_unlock(&m_mutex);
+      FileWriterDecoratorBase::write(&m_buf[m_flush_pos], flushlen);
+      mysql_mutex_lock(&m_mutex);
+      m_flush_pos += flushlen;
+      m_state = FileBufferState::COMPLETE;
+    }
+
+    assert(m_write_pos >= m_flush_pos);
+
+    mysql_cond_broadcast(&m_flushed_cond);
+    mysql_mutex_unlock(&m_mutex);
   }
 
-  if (m_flush_pos >= m_write_pos % m_size) {
-    m_state = (m_write_pos % m_size == 0) ? FileBufferState::COMPLETE
-                                          : FileBufferState::INCOMPLETE;
-    mysql_mutex_unlock(&m_mutex);
-    FileWriterDecoratorBase::write(m_buf + m_flush_pos, m_size - m_flush_pos);
-    mysql_mutex_lock(&m_mutex);
-    m_flush_pos = 0;
-    m_write_pos %= m_size;
-  } else {
-    const size_t flushlen = m_write_pos - m_flush_pos;
-    mysql_mutex_unlock(&m_mutex);
-    FileWriterDecoratorBase::write(m_buf + m_flush_pos, flushlen);
-    mysql_mutex_lock(&m_mutex);
-    m_flush_pos += flushlen;
-    m_state = FileBufferState::COMPLETE;
-  }
-
-  assert(m_write_pos >= m_flush_pos);
-
-  mysql_cond_broadcast(&m_flushed_cond);
-  mysql_mutex_unlock(&m_mutex);
+  my_thread_end();
 }
 
 void FileWriterBuffering::write(const char *record, size_t size) noexcept {
   DBUG_EXECUTE_IF("audit_log_write_full_buffer", {
-    if (size > m_size) {
-      size = m_size - m_write_pos;
+    if (size > m_buf.size()) {
+      size = m_buf.size() - m_write_pos;
     } else {
       return;
     }
   });
 
-  if (size > m_size) {
+  if (size > m_buf.size()) {
     if (!m_drop_if_full) {
       /* pause flushing thread and write out one record bypassing the buffer */
       pause();
@@ -204,11 +194,12 @@ void FileWriterBuffering::write(const char *record, size_t size) noexcept {
   mysql_mutex_lock(&m_mutex);
 
 loop:
-  if (m_write_pos + size <= m_flush_pos + m_size) {
-    const size_t wrlen = std::min(size, m_size - (m_write_pos % m_size));
-    memcpy(m_buf + (m_write_pos % m_size), record, wrlen);
+  if (m_write_pos + size <= m_flush_pos + m_buf.size()) {
+    const size_t wrlen =
+        std::min(size, m_buf.size() - (m_write_pos % m_buf.size()));
+    memcpy(&m_buf[m_write_pos % m_buf.size()], record, wrlen);
     if (wrlen < size) {
-      memcpy(m_buf, record + wrlen, size - wrlen);
+      memcpy(&m_buf[0], record + wrlen, size - wrlen);
     }
     m_write_pos = m_write_pos + size;
     assert(m_write_pos >= m_flush_pos);
@@ -223,7 +214,7 @@ loop:
     SysVars::update_event_max_drop_size(size);
   }
 
-  if (m_write_pos > m_flush_pos + m_size / 2) {
+  if (m_write_pos > m_flush_pos + m_buf.size() / 2) {
     mysql_cond_signal(&m_written_cond);
   }
 

--- a/components/audit_log_filter/log_writer/file_writer_buffering.h
+++ b/components/audit_log_filter/log_writer/file_writer_buffering.h
@@ -23,10 +23,11 @@
 #include "mysql/psi/psi_cond.h"
 #include "mysql/psi/psi_mutex.h"
 #include "mysql/service_mysql_alloc.h"
+#include "sql/malloc_allocator.h"
 
 #include <cstddef>
-#include <functional>
 #include <memory>
+#include <vector>
 
 namespace audit_log_filter::log_writer {
 
@@ -39,13 +40,6 @@ class FileWriterBuffering final : public FileWriterDecoratorBase {
   FileWriterBuffering(FileWriterBuffering &other) = delete;
   FileWriterBuffering(FileWriterBuffering &&other) = delete;
   ~FileWriterBuffering() final;
-
-  /**
-   * @brief Init file write buffer.
-   *
-   * @return true in case of success, false otherwise
-   */
-  bool init() noexcept override;
 
   /**
    * @brief Prepare writer for work with newly opened log file.
@@ -68,19 +62,12 @@ class FileWriterBuffering final : public FileWriterDecoratorBase {
    */
   void write(const char *record, size_t size) noexcept override;
 
-  /**
-   * @brief Check if flushing thread is stopped.
-   *
-   * @return true in case flushing thread is stopped, false otherwise
-   */
-  [[nodiscard]] inline bool check_flush_stopped() const noexcept;
-
+ private:
   /**
    * @brief Flush worker method used by flush thread.
    */
   void flush_worker() noexcept;
 
- private:
   /**
    * @brief Shutdown file write buffer.
    */
@@ -97,13 +84,12 @@ class FileWriterBuffering final : public FileWriterDecoratorBase {
   void resume() noexcept;
 
  private:
-  const size_t m_size;
   const bool m_drop_if_full;
-  char *m_buf;
+  std::vector<char, Malloc_allocator<char>> m_buf;
   size_t m_write_pos;
   size_t m_flush_pos;
   pthread_t m_flush_worker_thread;
-  bool m_stop_flush_worker;
+  bool m_flush_worker_running;
   mysql_mutex_t m_mutex;
   mysql_cond_t m_flushed_cond;
   mysql_cond_t m_written_cond;

--- a/components/audit_log_filter/log_writer/file_writer_compressing.cc
+++ b/components/audit_log_filter/log_writer/file_writer_compressing.cc
@@ -25,10 +25,6 @@ FileWriterCompressing::FileWriterCompressing(
 
 FileWriterCompressing::~FileWriterCompressing() { deflateEnd(&m_strm); }
 
-bool FileWriterCompressing::init() noexcept {
-  return FileWriterDecoratorBase::init();
-}
-
 bool FileWriterCompressing::open() noexcept {
   m_strm.zalloc = Z_NULL;
   m_strm.zfree = Z_NULL;

--- a/components/audit_log_filter/log_writer/file_writer_compressing.h
+++ b/components/audit_log_filter/log_writer/file_writer_compressing.h
@@ -33,13 +33,6 @@ class FileWriterCompressing final : public FileWriterDecoratorBase {
   ~FileWriterCompressing() override;
 
   /**
-   * @brief Init file writer.
-   *
-   * @return true in case of success, false otherwise
-   */
-  bool init() noexcept override;
-
-  /**
    * @brief Prepare writer for work with newly opened log file.
    *
    * @return true in case of success, false otherwise

--- a/components/audit_log_filter/log_writer/file_writer_decorator_base.cc
+++ b/components/audit_log_filter/log_writer/file_writer_decorator_base.cc
@@ -17,8 +17,6 @@
 
 namespace audit_log_filter::log_writer {
 
-bool FileWriterDecoratorBase::init() noexcept { return m_file_writer->init(); }
-
 bool FileWriterDecoratorBase::open() noexcept { return m_file_writer->open(); }
 
 void FileWriterDecoratorBase::close() noexcept { m_file_writer->close(); }

--- a/components/audit_log_filter/log_writer/file_writer_decorator_base.h
+++ b/components/audit_log_filter/log_writer/file_writer_decorator_base.h
@@ -28,13 +28,6 @@ class FileWriterDecoratorBase : public FileWriterBase {
       : m_file_writer{std::move(file_writer)} {}
 
   /**
-   * @brief Init file writer.
-   *
-   * @return true in case of success, false otherwise
-   */
-  bool init() noexcept override;
-
-  /**
    * @brief Prepare writer for work with newly opened log file.
    *
    * @return true in case of success, false otherwise

--- a/components/audit_log_filter/log_writer/file_writer_encrypting.cc
+++ b/components/audit_log_filter/log_writer/file_writer_encrypting.cc
@@ -23,6 +23,7 @@
 
 #include <include/scope_guard.h>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 
 namespace audit_log_filter::log_writer {
@@ -32,16 +33,25 @@ const size_t kEvpKeyLength = 32;
 const size_t kEncryptChunkSize = 1024 * 1024;
 const char magic[] = "Salted__";
 
+const EVP_CIPHER *make_EVP_aes_256_cbc() {
+  auto cipher = EVP_aes_256_cbc();
+  if (!cipher) {
+    throw std::runtime_error("EVP_aes_256_cbc init failed");
+  }
+  return cipher;
+}
+
 }  // namespace
 
 FileWriterEncrypting::FileWriterEncrypting(
     std::unique_ptr<FileWriterBase> file_writer)
     : FileWriterDecoratorBase(std::move(file_writer)),
-      m_cipher{EVP_aes_256_cbc()},
+      m_cipher{make_EVP_aes_256_cbc()},
       m_ctx{nullptr},
-      m_key{nullptr},
-      m_iv{nullptr},
-      m_out_buff{nullptr} {}
+      m_key{std::make_unique<unsigned char[]>(kEvpKeyLength)},
+      m_iv{std::make_unique<unsigned char[]>(EVP_MAX_IV_LENGTH)},
+      m_out_buff{std::make_unique<unsigned char[]>(
+          kEncryptChunkSize + EVP_CIPHER_block_size(m_cipher))} {}
 
 FileWriterEncrypting::~FileWriterEncrypting() {
   if (m_ctx != nullptr) {
@@ -49,34 +59,6 @@ FileWriterEncrypting::~FileWriterEncrypting() {
     EVP_CIPHER_CTX_free(m_ctx);
     m_ctx = nullptr;
   }
-}
-
-bool FileWriterEncrypting::init() noexcept {
-  if (m_cipher == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "EVP_aes_256_cbc init failed");
-    return false;
-  }
-
-  m_key = std::make_unique<unsigned char[]>(kEvpKeyLength);
-  m_iv = std::make_unique<unsigned char[]>(EVP_MAX_IV_LENGTH);
-
-  if (m_key == nullptr || m_iv == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init key buffer");
-    return false;
-  }
-
-  m_out_buff = std::make_unique<unsigned char[]>(
-      kEncryptChunkSize + EVP_CIPHER_block_size(m_cipher));
-
-  if (m_out_buff == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init out buffer");
-    return false;
-  }
-
-  return FileWriterDecoratorBase::init();
 }
 
 bool FileWriterEncrypting::open() noexcept {

--- a/components/audit_log_filter/log_writer/file_writer_encrypting.h
+++ b/components/audit_log_filter/log_writer/file_writer_encrypting.h
@@ -31,13 +31,6 @@ class FileWriterEncrypting final : public FileWriterDecoratorBase {
   ~FileWriterEncrypting() override;
 
   /**
-   * @brief Init file writer.
-   *
-   * @return true in case of success, false otherwise
-   */
-  bool init() noexcept override;
-
-  /**
    * @brief Prepare writer for work with newly opened log file.
    *
    * @return true in case of success, false otherwise


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10312

While reported issue couldn't be reproduced, some refactoring has been done in the process of analyzing the problem.

- `FileWriterBase::init()` has been removed. It served no real purpose, and only duplicated initialization code from constructors. `init()` methods have been removed from derived classes too.

- `FileWriterBuffering::m_buf` has been changed from a manually managed buffer to a `std::vector<char>`.

- `FileWriterBuffering::m_stop_flush_worker` has been replaced with `FileWriterBuffering::m_flush_worker_running`. This simplifies worker thread logic.

- `FileWriterBuffering::check_flush_stopped()` has been removed. It didn't serve any real purpose because stopping condition had been evaluated without locking the mutex. Even if lock had been acquired, result of this check would be invalidated immediately after leaving the function, making it unusable for controlling program flow. This has been solved by moving looping logic directly into `FileWriterBuffering::flush_worker()`.

- In `FileWriterBuffering::shutdown()`, fixed access to class members without locked mutex.