### PR TITLE
PS-10872 [9.x]: Audit log filter: fix event subclass naming and match upstream JSON format

### DIFF
--- a/components/audit_log_filter/audit_event_class_internal.h
+++ b/components/audit_log_filter/audit_event_class_internal.h
@@ -50,6 +50,7 @@ typedef unsigned long internal_event_tracking_audit_subclass_t;
 struct internal_event_tracking_audit_data {
   internal_event_tracking_audit_subclass_t event_subclass;
   uint32 server_id;
+  unsigned long connection_id;
 };
 
 }  // namespace audit_log_filter

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -555,14 +555,57 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
 
 void AuditLogFilter::send_audit_start_event() noexcept {
   auto event = internal_event_tracking_audit_data{
-      INTERNAL_EVENT_TRACKING_AUDIT_AUDIT, static_cast<uint32>(::server_id)};
-  m_log_writer->write(get_audit_record(
-      audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS, &event));
+      INTERNAL_EVENT_TRACKING_AUDIT_AUDIT, static_cast<uint32>(::server_id), 0};
+
+  MYSQL_THD thd = nullptr;
+  if (mysql_service_mysql_current_thread_reader->get(&thd) == 0 &&
+      thd != nullptr) {
+    event.connection_id = static_cast<unsigned long>(thd->thread_id());
+  }
+
+  auto audit_record =
+      get_audit_record(audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS, &event);
+
+  Security_context_handle sctx{};
+  if (thd != nullptr && m_security_context_srv != nullptr &&
+      m_security_context_opts_srv != nullptr &&
+      m_security_context_srv->get(thd, &sctx) == 0 && sctx != nullptr) {
+    auto load_security_context_option = [this, &sctx](const char *name,
+                                                      std::string &value) {
+      MYSQL_LEX_CSTRING raw_value{"", 0};
+      if (m_security_context_opts_srv->get(sctx, name, &raw_value) == 0 &&
+          raw_value.str != nullptr && raw_value.length > 0) {
+        value.assign(raw_value.str, raw_value.length);
+      } else {
+        value.clear();
+      }
+    };
+
+    if (auto *record = std::get_if<AuditRecordAudit>(&audit_record)) {
+      load_security_context_option("user", record->extended_info.user);
+      load_security_context_option("host", record->extended_info.host);
+      load_security_context_option("ip", record->extended_info.ip);
+      load_security_context_option("external_user",
+                                   record->extended_info.external_user);
+      load_security_context_option("proxy_user",
+                                   record->extended_info.proxy_user);
+    }
+  }
+
+  m_log_writer->write(audit_record);
 }
 
 void AuditLogFilter::send_audit_stop_event() noexcept {
-  auto event = internal_event_tracking_audit_data{
-      INTERNAL_EVENT_TRACKING_AUDIT_NOAUDIT, static_cast<uint32>(::server_id)};
+  auto event =
+      internal_event_tracking_audit_data{INTERNAL_EVENT_TRACKING_AUDIT_NOAUDIT,
+                                         static_cast<uint32>(::server_id), 0};
+
+  MYSQL_THD thd = nullptr;
+  if (mysql_service_mysql_current_thread_reader->get(&thd) == 0 &&
+      thd != nullptr) {
+    event.connection_id = static_cast<unsigned long>(thd->thread_id());
+  }
+
   m_log_writer->write(get_audit_record(
       audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS, &event));
 }

--- a/components/audit_log_filter/audit_log_filter.h
+++ b/components/audit_log_filter/audit_log_filter.h
@@ -85,12 +85,12 @@ class AuditLogFilter {
   AuditLogReader *get_log_reader() noexcept;
 
   /**
-   * @brief Send Audit event to log upon plugin initialization.
+   * @brief Send startup audit event to log upon component initialization.
    */
   void send_audit_start_event() noexcept;
 
   /**
-   * @brief Send NoAudit event to log upon plugin de-initialization.
+   * @brief Send shutdown audit event to log upon component de-initialization.
    */
   void send_audit_stop_event() noexcept;
 

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -81,11 +81,8 @@ constexpr std::string_view kSubclassNamePreAuthenticate{"pre_authenticate"};
 constexpr std::string_view kSubclassNameMessageInternal{"internal"};
 constexpr std::string_view kSubclassNameInternalStartup{"startup"};
 constexpr std::string_view kSubclassNameInternalShutdown{"shutdown"};
-constexpr std::string_view kSubclassNameParseRewriteNone{"rewrite_none"};
-constexpr std::string_view kSubclassNameParseRewriteQueryRewritten{
-    "rewrite_query_rewritten"};
-constexpr std::string_view kSubclassNameParseRewritePreparedStatement{
-    "rewrite_prepared_statement"};
+constexpr std::string_view kSubclassNameParsePreparse{"preparse"};
+constexpr std::string_view kSubclassNameParsePostparse{"postparse"};
 
 template <typename Container>
 bool contains_string_view(std::string_view value,
@@ -307,12 +304,10 @@ std::string_view event_subclass_to_string(
 std::string_view event_subclass_to_string(
     const mysql_event_tracking_parse_data *event) {
   switch (event->event_subclass) {
-    case EVENT_TRACKING_PARSE_REWRITE_NONE:
-      return kSubclassNameParseRewriteNone;
-    case EVENT_TRACKING_PARSE_REWRITE_QUERY_REWRITTEN:
-      return kSubclassNameParseRewriteQueryRewritten;
-    case EVENT_TRACKING_PARSE_REWRITE_IS_PREPARED_STATEMENT:
-      return kSubclassNameParseRewritePreparedStatement;
+    case EVENT_TRACKING_PARSE_PREPARSE:
+      return kSubclassNameParsePreparse;
+    case EVENT_TRACKING_PARSE_POSTPARSE:
+      return kSubclassNameParsePostparse;
     default:
       assert(false);
   }
@@ -879,10 +874,9 @@ bool is_valid_event_subclass_name(std::string_view class_name,
   }
 
   if (class_name == kClassNameParse) {
-    static constexpr std::array<std::string_view, 3> valid_subclasses{{
-        kSubclassNameParseRewriteNone,
-        kSubclassNameParseRewriteQueryRewritten,
-        kSubclassNameParseRewritePreparedStatement,
+    static constexpr std::array<std::string_view, 2> valid_subclasses{{
+        kSubclassNameParsePreparse,
+        kSubclassNameParsePostparse,
     }};
     return contains_string_view(subclass_name, valid_subclasses);
   }

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -79,8 +79,8 @@ constexpr std::string_view kSubclassNameDisconnect{"disconnect"};
 constexpr std::string_view kSubclassNameChangeUser{"change_user"};
 constexpr std::string_view kSubclassNamePreAuthenticate{"pre_authenticate"};
 constexpr std::string_view kSubclassNameMessageInternal{"internal"};
-constexpr std::string_view kSubclassNameInternalAudit{"audit"};
-constexpr std::string_view kSubclassNameInternalNoAudit{"noaudit"};
+constexpr std::string_view kSubclassNameInternalStartup{"startup"};
+constexpr std::string_view kSubclassNameInternalShutdown{"shutdown"};
 constexpr std::string_view kSubclassNameParseRewriteNone{"rewrite_none"};
 constexpr std::string_view kSubclassNameParseRewriteQueryRewritten{
     "rewrite_query_rewritten"};
@@ -324,9 +324,9 @@ std::string_view event_subclass_to_string(
     const internal_event_tracking_audit_data *event) {
   switch (event->event_subclass) {
     case INTERNAL_EVENT_TRACKING_AUDIT_AUDIT:
-      return kSubclassNameInternalAudit;
+      return kSubclassNameInternalStartup;
     case INTERNAL_EVENT_TRACKING_AUDIT_NOAUDIT:
-      return kSubclassNameInternalNoAudit;
+      return kSubclassNameInternalShutdown;
     default:
       assert(false);
   }

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -253,23 +253,7 @@ bool AuditRuleParser::parse_event_class_obj_json(
   }
 
   std::shared_ptr<EventFieldActionBase> replace_field;
-
-  const std::string early_class_name =
-      event_class_json["name"].IsString() ? event_class_json["name"].GetString()
-                                          : std::string{};
-
-  if (event_class_json.HasMember("print")) {
-    replace_field =
-        parse_action_json(EventActionType::ReplaceField, event_class_json,
-                          early_class_name, audit_rule);
-
-    if (replace_field == nullptr) {
-      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
-                      audit_rule->get_rule_name().c_str());
-      audit_rule->set_parse_error("failed to parse 'print' replacement rule");
-      return false;
-    }
-  }
+  const bool has_print = event_class_json.HasMember("print");
 
   if (event_class_json["name"].IsString()) {
     const std::string event_class_name = event_class_json["name"].GetString();
@@ -281,6 +265,19 @@ bool AuditRuleParser::parse_event_class_obj_json(
       audit_rule->set_parse_error("unknown event class name '" +
                                   event_class_name + "'");
       return false;
+    }
+
+    if (has_print) {
+      replace_field =
+          parse_action_json(EventActionType::ReplaceField, event_class_json,
+                            event_class_name, audit_rule);
+
+      if (replace_field == nullptr) {
+        LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
+                        audit_rule->get_rule_name().c_str());
+        audit_rule->set_parse_error("failed to parse 'print' replacement rule");
+        return false;
+      }
     }
 
     if (event_class_json.HasMember("event")) {
@@ -358,8 +355,21 @@ bool AuditRuleParser::parse_event_class_obj_json(
 
       audit_rule->add_action_for_event(log_action, event_class_name);
 
-      if (replace_field != nullptr) {
-        audit_rule->add_action_for_event(replace_field, event_class_name);
+      if (has_print) {
+        auto replace_field_for_class =
+            parse_action_json(EventActionType::ReplaceField, event_class_json,
+                              event_class_name, audit_rule);
+
+        if (replace_field_for_class == nullptr) {
+          LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EVENT_CLASS_BAD_PRINT_DEF,
+                          audit_rule->get_rule_name().c_str());
+          audit_rule->set_parse_error(
+              "failed to parse 'print' replacement rule");
+          return false;
+        }
+
+        audit_rule->add_action_for_event(replace_field_for_class,
+                                         event_class_name);
       }
     }
   } else {
@@ -1348,7 +1358,7 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
       }
 
       auto replacement_rule =
-          make_replacement_rule(action_json["filter"]["class"]);
+          make_replacement_rule(action_json["filter"]["class"], audit_rule);
 
       if (replacement_rule == nullptr) {
         return nullptr;
@@ -1495,7 +1505,7 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
 }
 
 std::shared_ptr<AuditRule> AuditRuleParser::make_replacement_rule(
-    const rapidjson::Value &rule_json) noexcept {
+    const rapidjson::Value &rule_json, AuditRule *audit_rule) noexcept {
   rapidjson::Document d;
   d.SetObject();
   d.AddMember("filter", rapidjson::Value{rapidjson::kObjectType},
@@ -1504,10 +1514,16 @@ std::shared_ptr<AuditRule> AuditRuleParser::make_replacement_rule(
                         d.GetAllocator());
   d["filter"]["class"].CopyFrom(rule_json, d.GetAllocator());
 
-  auto rule = std::make_shared<AuditRule>();
+  const auto rule_name =
+      audit_rule != nullptr ? audit_rule->get_rule_name() : std::string{};
+  auto rule = std::make_shared<AuditRule>(rule_name.c_str());
 
   if (AuditRuleParser::parse(d, rule.get())) {
     return rule;
+  }
+
+  if (audit_rule != nullptr && !rule->get_parse_error().empty()) {
+    audit_rule->set_parse_error(rule->get_parse_error());
   }
 
   return nullptr;

--- a/components/audit_log_filter/audit_rule_parser.h
+++ b/components/audit_log_filter/audit_rule_parser.h
@@ -194,10 +194,11 @@ class AuditRuleParser {
    * @brief Build replacement filtering rule.
    *
    * @param rule_json JSON definition of replacement filtering rule
+   * @param audit_rule Parent filtering rule collecting parse errors
    * @return Replacement filtering rule instance
    */
   [[nodiscard]] static std::shared_ptr<AuditRule> make_replacement_rule(
-      const rapidjson::Value &rule_json) noexcept;
+      const rapidjson::Value &rule_json, AuditRule *audit_rule) noexcept;
 };
 
 }  // namespace audit_log_filter

--- a/components/audit_log_filter/filter_definition_fields.md
+++ b/components/audit_log_filter/filter_definition_fields.md
@@ -1,0 +1,176 @@
+# Audit Log Filter Definition Fields
+
+This reference lists the canonical class, event, and field names accepted by
+filter-definition validation through `audit_log_filter_set_filter()`.
+
+## Notes
+
+- The names below are filter-definition names, not necessarily the names used by
+  the JSON log formatter.
+- `Field Type` reflects the type accepted by the current validator in
+  `get_event_field_value_type()`.
+- Some numeric-looking fields are currently validated as `string` because they
+  are not explicitly typed in `get_event_field_value_type()`.
+- Filter-definition validation only accepts the class names documented below.
+- Lifecycle-related records with class names `audit`, `server_startup`, and
+  `server_shutdown` are not valid filter-definition targets.
+- For `connection.connection_type`, the validator accepts numeric values `0..5`
+  and the pseudo-constants `::undefined`, `::tcp/ip`, `::socket`,
+  `::named_pipe`, `::ssl`, and `::shared_memory`.
+
+## `general`
+
+Supported events: `log`, `error`, `result`, `status`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `general_error_code` | integer | Event error code. |
+| `general_thread_id` | unsigned integer | Event thread ID. Currently an alias of `general_connection_id`. |
+| `general_connection_id` | unsigned integer | Event connection ID. |
+| `general_user.str` | string | User name recorded for the general event. |
+| `general_user.length` | unsigned integer | User name length. |
+| `general_command.str` | string | General command text, for example `Query`. |
+| `general_command.length` | unsigned integer | General command text length. |
+| `general_query.str` | string | SQL statement text associated with the event. |
+| `general_query.length` | unsigned integer | SQL statement text length. |
+| `general_host.str` | string | Client host name. |
+| `general_host.length` | unsigned integer | Client host name length. |
+| `general_sql_command.str` | string | SQL command name associated with the statement, for example `select`. |
+| `general_sql_command.length` | unsigned integer | SQL command name length. |
+| `general_external_user.str` | string | External user or OS login associated with the event. |
+| `general_external_user.length` | unsigned integer | External user or OS login length. |
+| `general_ip.str` | string | Client IP address. |
+| `general_ip.length` | unsigned integer | Client IP address length. |
+
+## `connection`
+
+Supported events: `connect`, `disconnect`, `change_user`, `pre_authenticate`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `status` | integer | Current connection event status. |
+| `connection_id` | unsigned integer | Connection ID. |
+| `user.str` | string | User name of this connection. |
+| `user.length` | unsigned integer | User name length. |
+| `priv_user.str` | string | Privileged user name. |
+| `priv_user.length` | unsigned integer | Privileged user name length. |
+| `external_user.str` | string | External user name or OS login. |
+| `external_user.length` | unsigned integer | External user name length. |
+| `proxy_user.str` | string | Proxy user used for the connection. |
+| `proxy_user.length` | unsigned integer | Proxy user name length. |
+| `host.str` | string | Connection host name. |
+| `host.length` | unsigned integer | Connection host name length. |
+| `ip.str` | string | Connection IP address. |
+| `ip.length` | unsigned integer | Connection IP address length. |
+| `database.str` | string | Default database specified at connection time. |
+| `database.length` | unsigned integer | Default database name length. |
+| `connection_type` | integer | Connection type code. |
+|  |  | `0` or `::undefined`: Undefined |
+|  |  | `1` or `::tcp/ip`: TCP/IP |
+|  |  | `2` or `::socket`: Socket |
+|  |  | `3` or `::named_pipe`: Named pipe |
+|  |  | `4` or `::ssl`: TCP/IP with encryption |
+|  |  | `5` or `::shared_memory`: Shared memory |
+
+## `table_access`
+
+Supported events: `read`, `insert`, `update`, `delete`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `connection_id` | unsigned integer | Event connection ID. |
+| `sql_command_id` | integer | SQL command ID. |
+| `query.str` | string | SQL statement text. |
+| `query.length` | unsigned integer | SQL statement text length. |
+| `table_database.str` | string | Database name associated with event. |
+| `table_database.length` | unsigned integer | Database name length. |
+| `table_name.str` | string | Table name associated with event. |
+| `table_name.length` | unsigned integer | Table name length. |
+
+## `global_variable`
+
+Supported events: `get`, `set`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `connection_id` | string | Event connection ID. |
+| `variable_name.str` | string | Variable name. |
+| `variable_name.length` | string | Variable name length. |
+| `variable_value.str` | string | Variable value. |
+| `variable_value.length` | string | Variable value length. |
+
+## `command`
+
+Supported events: `start`, `end`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `status` | string | Command event status code. |
+| `connection_id` | string | Event connection ID. |
+| `command.str` | string | Command text. |
+| `command.length` | string | Command text length. |
+
+## `query`
+
+Supported events: `start`, `nested_start`, `status_end`, `nested_status_end`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `status` | string | Query event status code. |
+| `connection_id` | string | Event connection ID. |
+| `sql_command_id` | string | SQL command string associated with the query event. The field name is retained as `sql_command_id` for compatibility. |
+| `query.str` | string | SQL query text. |
+| `query.length` | string | SQL query text length. |
+| `query_charset` | string | SQL query character set name. |
+
+## `stored_program`
+
+Supported events: `execute`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `connection_id` | string | Event connection ID. |
+| `database.str` | string | Database where the stored program is defined. |
+| `database.length` | string | Database name length. |
+| `name.str` | string | Stored program name. |
+| `name.length` | string | Stored program name length. |
+
+## `authentication`
+
+Supported events: `flush`, `authid_create`, `credential_change`, `authid_rename`, `authid_drop`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `status` | string | Authentication event status. |
+| `connection_id` | string | Event connection ID. |
+| `user.str` | string | User name. |
+| `user.length` | string | User name length. |
+| `host.str` | string | Host name. |
+| `host.length` | string | Host name length. |
+
+## `message`
+
+Supported events: `internal`, `user`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `connection_id` | string | Event connection ID. |
+| `component.str` | string | Component name. |
+| `component.length` | string | Component name length. |
+| `producer.str` | string | Message producer name. |
+| `producer.length` | string | Message producer name length. |
+| `message.str` | string | Message text. |
+| `message.length` | string | Message text length. |
+
+## `parse`
+
+Supported events: `preparse`, `postparse`
+
+| Field Name | Field Type | Description |
+| --- | --- | --- |
+| `connection_id` | string | Event connection ID. |
+| `flags` | string | Parse rewrite flags value. |
+| `query.str` | string | Original SQL query text. |
+| `query.length` | string | Original SQL query text length. |
+| `rewritten_query.str` | string | Rewritten SQL query text. |
+| `rewritten_query.length` | string | Rewritten SQL query text length. |

--- a/components/audit_log_filter/json_reader/audit_json_handler.cc
+++ b/components/audit_log_filter/json_reader/audit_json_handler.cc
@@ -42,8 +42,7 @@ AuditJsonHandler::AuditJsonHandler(
       m_out_buff_size{out_buff_size},
       m_used_buff_size{0},
       m_printed_events_count{0},
-      m_reading_start_reached{false},
-      m_is_first_field{false} {}
+      m_reading_start_reached{false} {}
 
 char *AuditJsonHandler::get_result_buffer_ptr() noexcept {
   return m_out_buff.get();
@@ -80,38 +79,48 @@ void AuditJsonHandler::iterative_parse_close(bool with_null_tag) noexcept {
 
 // --- Value Handlers ---
 
-bool AuditJsonHandler::Null() { return true; }
+bool AuditJsonHandler::Null() {
+  before_value();
+  m_event_str << "null";
+  return true;
+}
 
 bool AuditJsonHandler::Bool(bool value) {
+  before_value();
   m_event_str << (value ? "true" : "false");
   return true;
 }
 
 bool AuditJsonHandler::Int(int value) {
   update_bookmark(static_cast<uint64_t>(value));
+  before_value();
   m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Uint(unsigned value) {
   update_bookmark(static_cast<uint64_t>(value));
+  before_value();
   m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Int64(int64_t value) {
   update_bookmark(static_cast<uint64_t>(value));
+  before_value();
   m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Uint64(uint64_t value) {
   update_bookmark(value);
+  before_value();
   m_event_str << value;
   return true;
 }
 
 bool AuditJsonHandler::Double(double value) {
+  before_value();
   m_event_str << value;
   return true;
 }
@@ -120,6 +129,7 @@ bool AuditJsonHandler::String(const char *value, rapidjson::SizeType length,
                               bool copy [[maybe_unused]]) {
   std::string s_value(value, length);
   update_bookmark(s_value);
+  before_value();
   m_event_str << "\"" << s_value << "\"";
   return true;
 }
@@ -127,25 +137,26 @@ bool AuditJsonHandler::String(const char *value, rapidjson::SizeType length,
 // --- Structure Handlers ---
 
 bool AuditJsonHandler::StartObject() {
+  before_value();
   ++m_obj_level;
   m_event_str << "{";
-  // Reset flag: the first key encountered will not have a comma separator
-  m_is_first_field = true;
+  m_context_stack.push_back({ContainerType::Object, true});
   return true;
 }
 
 bool AuditJsonHandler::Key(const char *str, rapidjson::SizeType length,
                            bool copy [[maybe_unused]]) {
   m_current_key_name.assign(str, length);
+  assert(!m_context_stack.empty());
+  assert(m_context_stack.back().type == ContainerType::Object);
 
-  // Manage comma separation and state before appending the key.
-  if (m_is_first_field) {
-    m_is_first_field = false;  // This is the first field, so unset the flag
+  auto &context = m_context_stack.back();
+  if (context.is_first_element) {
+    context.is_first_element = false;
   } else {
-    m_event_str << ", ";  // Prepend separator if a previous field exists
+    m_event_str << ", ";
   }
 
-  // Append key and colon
   m_event_str << "\"" << str << "\": ";
   return true;
 }
@@ -156,13 +167,10 @@ bool AuditJsonHandler::EndObject(rapidjson::SizeType memberCount
     --m_obj_level;
   }
 
-  // Append the closing brace.
   m_event_str << "}";
-
-  // If closing an inner object (m_obj_level is now > 0), or the top-level
-  // object, ensure the m_is_first_field is false, so the next Key() call
-  // (if any, in the parent) correctly prepends a comma.
-  m_is_first_field = false;
+  assert(!m_context_stack.empty());
+  assert(m_context_stack.back().type == ContainerType::Object);
+  m_context_stack.pop_back();
 
   // Handle the completed top-level event object.
   if (m_obj_level == 0) {
@@ -195,9 +203,14 @@ bool AuditJsonHandler::EndObject(rapidjson::SizeType memberCount
 }
 
 bool AuditJsonHandler::StartArray() {
-  // If we ever to support such arrays (i.e. non top-level) we need to rethink
-  // and change comma separation logic between arrays and objects elements.
-  assert(m_arr_level == 0);
+  const bool is_top_level_array = (m_arr_level == 0 && m_obj_level == 0);
+
+  if (!is_top_level_array) {
+    before_value();
+    m_event_str << "[";
+    m_context_stack.push_back({ContainerType::Array, true});
+  }
+
   ++m_arr_level;
   return true;
 }
@@ -205,12 +218,41 @@ bool AuditJsonHandler::StartArray() {
 bool AuditJsonHandler::EndArray(rapidjson::SizeType elementCount
                                 [[maybe_unused]]) {
   if (m_arr_level > 0) {
+    if (!(m_arr_level == 1 && m_obj_level == 0)) {
+      m_event_str << "]";
+      assert(!m_context_stack.empty());
+      assert(m_context_stack.back().type == ContainerType::Array);
+      m_context_stack.pop_back();
+    }
+
     --m_arr_level;
   }
   return true;
 }
 
-void AuditJsonHandler::clear_current_event() { m_event_str.str(std::string()); }
+void AuditJsonHandler::before_value() {
+  if (m_context_stack.empty()) {
+    return;
+  }
+
+  auto &context = m_context_stack.back();
+  if (context.type != ContainerType::Array) {
+    return;
+  }
+
+  if (context.is_first_element) {
+    context.is_first_element = false;
+  } else {
+    m_event_str << ", ";
+  }
+}
+
+void AuditJsonHandler::clear_current_event() {
+  m_event_str.str(std::string());
+  m_event_str.clear();
+  m_current_key_name.clear();
+  m_current_event_bookmark = {};
+}
 
 bool AuditJsonHandler::check_reading_start_reached() {
   if (!m_reading_start_reached) {

--- a/components/audit_log_filter/json_reader/audit_json_handler.h
+++ b/components/audit_log_filter/json_reader/audit_json_handler.h
@@ -23,6 +23,7 @@
 #include "rapidjson/reader.h"
 
 #include <sstream>
+#include <vector>
 
 namespace audit_log_filter {
 
@@ -69,6 +70,14 @@ class AuditJsonHandler
   bool EndArray(rapidjson::SizeType elementCount);
 
  private:
+  enum class ContainerType { Object, Array };
+
+  struct ContainerState {
+    ContainerType type;
+    bool is_first_element;
+  };
+
+  void before_value();
   void clear_current_event();
   bool check_reading_start_reached();
   void update_bookmark(uint64_t id);
@@ -83,6 +92,7 @@ class AuditJsonHandler
   std::stringstream m_event_str;
   int m_obj_level;
   int m_arr_level;
+  std::vector<ContainerState> m_context_stack;
 
   std::unique_ptr<char, std::function<void(char *)>> m_out_buff;
   char *m_current_buff;
@@ -90,7 +100,6 @@ class AuditJsonHandler
   ulong m_used_buff_size;
   ulong m_printed_events_count;
   bool m_reading_start_reached;
-  bool m_is_first_field;
 
   LogBookmark m_current_event_bookmark;
 };

--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -106,11 +106,8 @@ const std::string_view kAuditEventNameStoredProgramExecute{"Execute"};
 const std::string_view kAuditEventNameMessageInternal{"Internal"};
 const std::string_view kAuditEventNameMessageUser{"User"};
 
-const std::string_view kAuditEventNameParseRewriteNone{"No Rewrite"};
-const std::string_view kAuditEventNameParseRewriteQueryRewritten{
-    "Query Rewritten"};
-const std::string_view kAuditEventNameParseRewritePreparedStatement{
-    "Prepared Statement"};
+const std::string_view kAuditEventNameParsePreparse{"Preparse"};
+const std::string_view kAuditEventNameParsePostparse{"Postparse"};
 
 const std::string_view kAuditEventNameAuditStart{"Startup"};
 const std::string_view kAuditEventNameAuditStop{"Shutdown"};
@@ -402,12 +399,10 @@ std::string_view LogRecordFormatterBase::event_subclass_to_string(
 std::string_view LogRecordFormatterBase::event_subclass_to_string(
     const mysql_event_tracking_parse_data *event) const noexcept {
   switch (event->event_subclass) {
-    case EVENT_TRACKING_PARSE_REWRITE_NONE:
-      return kAuditEventNameParseRewriteNone;
-    case EVENT_TRACKING_PARSE_REWRITE_QUERY_REWRITTEN:
-      return kAuditEventNameParseRewriteQueryRewritten;
-    case EVENT_TRACKING_PARSE_REWRITE_IS_PREPARED_STATEMENT:
-      return kAuditEventNameParseRewritePreparedStatement;
+    case EVENT_TRACKING_PARSE_PREPARSE:
+      return kAuditEventNameParsePreparse;
+    case EVENT_TRACKING_PARSE_POSTPARSE:
+      return kAuditEventNameParsePostparse;
     default:
       assert(false);
   }

--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -112,8 +112,8 @@ const std::string_view kAuditEventNameParseRewriteQueryRewritten{
 const std::string_view kAuditEventNameParseRewritePreparedStatement{
     "Prepared Statement"};
 
-const std::string_view kAuditEventNameAuditStart{"Audit"};
-const std::string_view kAuditEventNameAuditStop{"NoAudit"};
+const std::string_view kAuditEventNameAuditStart{"Startup"};
+const std::string_view kAuditEventNameAuditStop{"Shutdown"};
 
 const std::string_view kAuditNameUnknown{"unknown"};
 

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -86,11 +86,8 @@ const std::string_view kAuditEventNameStoredProgramExecute{"execute"};
 const std::string_view kAuditEventNameMessageInternal{"internal"};
 const std::string_view kAuditEventNameMessageUser{"user"};
 
-const std::string_view kAuditEventNameParseRewriteNone{"no_rewrite"};
-const std::string_view kAuditEventNameParseRewriteQueryRewritten{
-    "query_rewritten"};
-const std::string_view kAuditEventNameParseRewritePreparedStatement{
-    "prepared_statement"};
+const std::string_view kAuditEventNameParsePreparse{"preparse"};
+const std::string_view kAuditEventNameParsePostparse{"postparse"};
 
 const std::string_view kAuditNameShutdownReasonShutdown{"shutdown"};
 const std::string_view kAuditNameShutdownReasonAbort{"abort"};
@@ -287,12 +284,10 @@ std::string_view LogRecordFormatterJson::event_subclass_to_string(
 std::string_view LogRecordFormatterJson::event_subclass_to_string(
     const mysql_event_tracking_parse_data *event) const noexcept {
   switch (event->event_subclass) {
-    case EVENT_TRACKING_PARSE_REWRITE_NONE:
-      return kAuditEventNameParseRewriteNone;
-    case EVENT_TRACKING_PARSE_REWRITE_QUERY_REWRITTEN:
-      return kAuditEventNameParseRewriteQueryRewritten;
-    case EVENT_TRACKING_PARSE_REWRITE_IS_PREPARED_STATEMENT:
-      return kAuditEventNameParseRewritePreparedStatement;
+    case EVENT_TRACKING_PARSE_PREPARSE:
+      return kAuditEventNameParsePreparse;
+    case EVENT_TRACKING_PARSE_POSTPARSE:
+      return kAuditEventNameParsePostparse;
     default:
       assert(false);
   }

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -16,7 +16,9 @@
 #include "components/audit_log_filter/log_record_formatter/json.h"
 #include "components/audit_log_filter/sys_vars.h"
 
+#define ALLOW_COMPONENT_INCLUDE  // for my_io.h
 #include "my_dbug.h"
+#include "sql/mysqld.h"
 
 #include <mysql/components/services/defs/event_tracking_authentication_defs.h>
 #include <mysql/components/services/defs/event_tracking_command_defs.h>
@@ -100,8 +102,8 @@ const std::string_view kAuditConnectionTypeNamePipe{"named_pipe"};
 const std::string_view kAuditConnectionTypeNameSsl{"ssl"};
 const std::string_view kAuditConnectionTypeNameShared{"shared_memory"};
 
-const std::string_view kAuditEventNameAuditStart{"audit"};
-const std::string_view kAuditEventNameAuditStop{"noaudit"};
+const std::string_view kAuditEventNameAuditStart{"startup"};
+const std::string_view kAuditEventNameAuditStop{"shutdown"};
 
 auto make_unix_timestamp(
     const std::chrono::system_clock::time_point time_point) noexcept {
@@ -799,6 +801,17 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto time_now = std::chrono::system_clock::now();
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
+  const auto escaped_user =
+      make_escaped_string(audit_record.extended_info.user);
+  const auto escaped_host =
+      make_escaped_string(audit_record.extended_info.host);
+  const auto escaped_ip = make_escaped_string(audit_record.extended_info.ip);
+  const auto escaped_external_user =
+      make_escaped_string(audit_record.extended_info.external_user);
+  const auto escaped_proxy_user =
+      make_escaped_string(audit_record.extended_info.proxy_user);
+  const auto escaped_server_version = make_escaped_string(server_version);
+  const auto event_name = event_subclass_to_string(audit_record.event);
 
   /* clang-format off */
   result << "  {\n"
@@ -810,9 +823,42 @@ AuditRecordString LogRecordFormatterJson::apply(
 
   result << R"(    "id": )" << rec_id << ",\n"
          << R"(    "class": "audit",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "server_id": )" << audit_record.event->server_id
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+         << R"(    "event": ")" << event_name << "\"";
+
+  if (audit_record.event->event_subclass == INTERNAL_EVENT_TRACKING_AUDIT_AUDIT) {
+    result << ",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "account": { "user": ")" << escaped_user
+           << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+           << R"(    "login": { "user": ")" << escaped_user
+           << R"(", "os": ")" << escaped_external_user
+           << R"(", "ip": ")" << escaped_ip
+           << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
+           << R"(    "startup_data": {)" << "\n"
+           << R"(      "server_id": )" << audit_record.event->server_id << ",\n"
+           << R"(      "os_version": ")" << MACHINE_TYPE "-" SYSTEM_TYPE << "\",\n"
+           << R"(      "mysql_version": ")" << escaped_server_version << "\",\n"
+           << R"(      "args": [)" << "\n";
+
+    for (int i = 0; i < orig_argc; ++i) {
+      if (orig_argv[i] != nullptr) {
+        result << ((i == 0) ? "" : ",\n") << R"(        ")"
+               << make_escaped_string(orig_argv[i]) << "\"";
+      }
+    }
+
+    result << "\n"
+           << R"(      ])" << "\n"
+           << R"(    })";
+  } else {
+    result << ",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id
+           << ",\n"
+           << R"(    "shutdown_data": { "server_id": )"
+           << audit_record.event->server_id << " }";
+  }
+
+  result << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -843,7 +889,7 @@ const EscapeRulesContainer &LogRecordFormatterJson::get_escape_rules()
       {20, "\\u0014"}, {21, "\\u0015"}, {22, "\\u0016"}, {23, "\\u0017"},
       {24, "\\u0018"}, {25, "\\u0019"}, {26, "\\u001A"}, {27, "\\u001B"},
       {28, "\\u001C"}, {29, "\\u001D"}, {30, "\\u001E"}, {31, "\\u001F"},
-      {'\\', "\\\\"},  {'"', "\\\""},   {'/', "\\/"}};
+      {'\\', "\\\\"},  {'"', "\\\""}};
 
   return escape_rules;
 }

--- a/mysql-test/suite/component_audit_log_filter/r/audit_event_classes_subclasses_json.result
+++ b/mysql-test/suite/component_audit_log_filter/r/audit_event_classes_subclasses_json.result
@@ -1,0 +1,627 @@
+SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}')
+OK
+SELECT audit_log_filter_set_filter('log_pre_auth',
+'{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate","log":true}}}}');
+audit_log_filter_set_filter('log_pre_auth',
+'{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate","log":true}}}}')
+OK
+SELECT audit_log_filter_set_user('%', 'log_pre_auth');
+audit_log_filter_set_user('%', 'log_pre_auth')
+OK
+SELECT audit_log_filter_set_user('audit_user@localhost', 'log_all');
+audit_log_filter_set_user('audit_user@localhost', 'log_all')
+OK
+--- audit/startup ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "audit",
+  "event": "startup",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "root",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "root",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "startup_data": {
+    "args": [
+      "<hidden>"
+    ],
+    "mysql_version": "<hidden>",
+    "os_version": "<hidden>",
+    "server_id": <hidden>
+  }
+}
+
+--- general/log ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "log",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- general/error ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "error",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT * FROM missing_table_for_audit",
+    "status": 1146
+  }
+}
+
+--- general/result ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "result",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- general/status ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "status",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- connection/connect ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "connect",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": "test"
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/disconnect ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "disconnect",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/change_user ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "change_user",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/pre_authenticate ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "pre_authenticate",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  }
+}
+
+--- table_access/read ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "read",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "select",
+    "query": "SELECT * FROM t_events WHERE id = 1",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/insert ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "insert",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "insert",
+    "query": "INSERT INTO t_events VALUES (3, 'three')",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/update ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "update",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "update",
+    "query": "UPDATE t_events SET val = 'THREE' WHERE id = 3",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/delete ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "delete",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "delete",
+    "query": "DELETE FROM t_events WHERE id = 3",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- global_variable/variable_get ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "global_variable",
+  "event": "variable_get",
+  "connection_id": <hidden>,
+  "global_variable_data": {
+    "sql_command": "select",
+    "name": "default_password_lifetime",
+    "value": "100"
+  }
+}
+
+--- global_variable/variable_set ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "global_variable",
+  "event": "variable_set",
+  "connection_id": <hidden>,
+  "global_variable_data": {
+    "sql_command": "set_option",
+    "name": "default_password_lifetime",
+    "value": "101"
+  }
+}
+
+--- command/command_start ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "command",
+  "event": "command_start",
+  "connection_id": <hidden>,
+  "command_data": {
+    "command": "Query",
+    "status": 0,
+    "name": "command_start"
+  }
+}
+
+--- command/command_end ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "command",
+  "event": "command_end",
+  "connection_id": <hidden>,
+  "command_data": {
+    "command": "Query",
+    "status": 0,
+    "name": "command_end"
+  }
+}
+
+--- query/query_start ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_start",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- query/query_nested_start ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_nested_start",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT x",
+    "status": 0
+  }
+}
+
+--- query/query_status_end ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_status_end",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- query/query_nested_status_end ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_nested_status_end",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT x",
+    "status": 0
+  }
+}
+
+--- stored_program/execute ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "stored_program",
+  "event": "execute",
+  "connection_id": <hidden>,
+  "stored_program_data": {
+    "db": "test",
+    "name": "p_nested"
+  }
+}
+
+--- authentication/auth_flush ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_flush",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "",
+    "host": ""
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- authentication/auth_authid_create ---
+MISSING: authentication/auth_authid_create
+
+--- authentication/auth_credential_change ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_credential_change",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "auth_evt_user",
+    "host": "localhost"
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- authentication/auth_authid_rename ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_authid_rename",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "auth_evt_user",
+    "host": "localhost"
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- authentication/auth_authid_drop ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_authid_drop",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "auth_evt_user2",
+    "host": "localhost"
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- message/internal ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "message",
+  "event": "internal",
+  "connection_id": <hidden>,
+  "message_data": {
+    "component": "test_audit_api_message",
+    "producer": "test_audit_api_message",
+    "message": "test_audit_api_message_internal",
+    "message_attributes": {
+      "my_numeric_key": -9223372036854775808
+    }
+  }
+}
+
+--- message/user ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "message",
+  "event": "user",
+  "connection_id": <hidden>,
+  "message_data": {
+    "component": "test_audit_api_message",
+    "producer": "test_audit_api_message",
+    "message": "test_audit_api_message_user",
+    "message_attributes": {
+      "my_string_key": "my_string_value"
+    }
+  }
+}
+
+--- parse/query_rewritten ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "parse",
+  "event": "query_rewritten",
+  "connection_id": <hidden>,
+  "parse_data": {
+    "query": "CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB, ENCRYPTION = 'N'",
+    "rewritten_query": "CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB ",
+    "flags": 1
+  }
+}
+
+--- parse/prepared_statement ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "parse",
+  "event": "prepared_statement",
+  "connection_id": <hidden>,
+  "parse_data": {
+    "query": "CREATE TABLE t_parse_ps (id INT) ENGINE = InnoDB",
+    "rewritten_query": "",
+    "flags": 2
+  }
+}
+
+--- audit/shutdown ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "audit",
+  "event": "shutdown",
+  "connection_id": <hidden>,
+  "shutdown_data": {
+    "server_id": <hidden>
+  }
+}
+

--- a/mysql-test/suite/component_audit_log_filter/r/audit_event_classes_subclasses_json.result
+++ b/mysql-test/suite/component_audit_log_filter/r/audit_event_classes_subclasses_json.result
@@ -585,12 +585,12 @@ MISSING: authentication/auth_authid_create
   }
 }
 
---- parse/query_rewritten ---
+--- parse/preparse ---
 {
   "timestamp": "<hidden>",
   "id": <hidden>,
   "class": "parse",
-  "event": "query_rewritten",
+  "event": "preparse",
   "connection_id": <hidden>,
   "parse_data": {
     "query": "CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB, ENCRYPTION = 'N'",
@@ -599,12 +599,12 @@ MISSING: authentication/auth_authid_create
   }
 }
 
---- parse/prepared_statement ---
+--- parse/postparse ---
 {
   "timestamp": "<hidden>",
   "id": <hidden>,
   "class": "parse",
-  "event": "prepared_statement",
+  "event": "postparse",
   "connection_id": <hidden>,
   "parse_data": {
     "query": "CREATE TABLE t_parse_ps (id INT) ENGINE = InnoDB",

--- a/mysql-test/suite/component_audit_log_filter/r/audit_noaudit_events.result
+++ b/mysql-test/suite/component_audit_log_filter/r/audit_noaudit_events.result
@@ -1,1 +1,1 @@
-Tag <NAME>(?:Audit|NoAudit)</NAME> Ok
+Tag <NAME>(?:Startup|Shutdown)</NAME> Ok

--- a/mysql-test/suite/component_audit_log_filter/r/audit_startup_shutdown_json.result
+++ b/mysql-test/suite/component_audit_log_filter/r/audit_startup_shutdown_json.result
@@ -1,0 +1,5 @@
+Rotated files Ok
+OK: audit/shutdown payload
+OK: audit/startup payload
+
+Lifecycle audit JSON payloads observed.

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
@@ -425,6 +425,48 @@ audit_log_filter_set_filter('incorrect_rule', '{
 }
 }')
 ERROR: Incorrect rule definition: the 'log' field must be of bool or object type
+SELECT audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"class": [
+{
+"name": ["query", "parse"],
+"print": {
+"field": {
+"name": "query.str",
+"print": {
+"field": {
+"name": "query_charset",
+"value": "utf8mb4"
+              }
+},
+"replace": {
+"function": {
+"name": "query_digest"
+              }
+}
+}
+}
+}
+]
+}
+}');
+audit_log_filter_set_filter('incorrect_rule', '{
+"filter": {
+"class": [
+{
+"name": ["query", "parse"],
+"print": {
+"field": {
+"name": "query.str",
+"print": {
+"field": {
+"name": "query_charset",
+"value": "utf8mb4"
+              }
+},
+"replace": {
+"function": 
+ERROR: Incorrect rule definition: field name 'query_charset' is not valid for event class 'parse'
 #
 # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_filter.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_filter.result
@@ -65,6 +65,51 @@ UPDATE temp_1, temp_2 SET temp_1.id=21, temp_2.id=23;
 INSERT INTO temp_3 VALUES (1);
 Tag [<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>.*<SQLTEXT>UPDATE temp_1, temp_2 SET temp_1.id=21, temp_2.id=23</SQLTEXT>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>temp_3</TABLE>] Ok
 #
+# Invalid nested replacement rule returns inner parse error
+SELECT audit_log_filter_set_filter('filter_replace_invalid', '{
+"filter": {
+"id": "main",
+"class": {
+"name": "table_access",
+"event": {
+"name": "update",
+"log": false,
+"filter": {
+"class": {
+"name": "general",
+"event": {
+"name": "status",
+"log": {
+"field": { "name": "connection_id", "value": "1" }
+},
+"filter": { "ref": "main" }
+}
+},
+"activate": {
+"field": { "name": "table_name.str", "value": "temp_1" }
+}
+}
+}
+}
+}
+}');
+audit_log_filter_set_filter('filter_replace_invalid', '{
+"filter": {
+"id": "main",
+"class": {
+"name": "table_access",
+"event": {
+"name": "update",
+"log": false,
+"filter": {
+"class": {
+"name": "general",
+"event": {
+"name": "status",
+"log": {
+"field": { "na
+ERROR: Incorrect rule definition: field name 'connection_id' is not valid for event class 'general'
+#
 # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='-d,audit_log_filter_rotate_after_audit_rules_flush';

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_class.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_class.result
@@ -199,4 +199,14 @@ audit_log_filter_set_filter('filter_broken_badEventArr', '{"filter": { "class": 
 ] } }')
 ERROR: Incorrect rule definition: unknown event subclass name 'nonexistent' for class 'general'
 #
+# Broken parse event name: rewrite flag name is not an event subclass
+SELECT audit_log_filter_set_filter('filter_broken_parseRewriteNone', '{"filter": { "class": [ { "name": "parse", "event": { "name": "rewrite_none" } } ] } }');
+audit_log_filter_set_filter('filter_broken_parseRewriteNone', '{"filter": { "class": [ { "name": "parse", "event": { "name": "rewrite_none" } } ] } }')
+ERROR: Incorrect rule definition: unknown event subclass name 'rewrite_none' for class 'parse'
+#
+# Broken parse event name: rewrite flag name is not an event subclass
+SELECT audit_log_filter_set_filter('filter_broken_parseRewritePreparedStmt', '{"filter": { "class": [ { "name": "parse", "event": { "name": "rewrite_prepared_statement" } } ] } }');
+audit_log_filter_set_filter('filter_broken_parseRewritePreparedStmt', '{"filter": { "class": [ { "name": "parse", "event": { "name": "rewrite_prepared_statement" } } ] } }')
+ERROR: Incorrect rule definition: unknown event subclass name 'rewrite_prepared_statement' for class 'parse'
+#
 # Cleanup

--- a/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json-master.opt
@@ -1,0 +1,3 @@
+--loose-audit_log_filter.file=audit_event_classes_subclasses_json.log
+--loose-audit_log_filter.format=JSON
+$DDL_REWRITER_OPT

--- a/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json.test
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json.test
@@ -1,0 +1,400 @@
+#
+# Verify that the audit_log_filter component can observe audit event
+# classes and subclasses by logging all events in one pass and then
+# printing one pretty sample record per observed event type.
+#
+# Covered here:
+#   audit: startup, shutdown
+#   general: log, error, result, status
+#   connection: connect, disconnect, change_user, pre_authenticate
+#   table_access: read, insert, update, delete
+#   global_variable: get, set
+#   command: start, end
+#   query: start, nested_start, status_end, nested_status_end
+#   stored_program: execute
+#   authentication: flush, authid_create (currently missing),
+#                   credential_change, authid_rename, authid_drop
+#   message: internal, user
+#   parse: query_rewritten, prepared_statement
+#
+--source suite/query_rewrite_plugins/include/have_ddl_rewriter.inc
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--remove_files_wildcard $audit_filter_log_path audit_event_classes_subclasses_json*
+--source ../inc/audit_comp_install.inc
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let audit_filter_log_path = $audit_filter_log_path
+--let audit_filter_log_name = $audit_filter_log_name
+
+--disable_query_log
+--disable_result_log
+
+SET @saved_default_password_lifetime := @@global.default_password_lifetime;
+SET GLOBAL default_password_lifetime = 100;
+
+CREATE USER audit_user@localhost IDENTIFIED BY 'pass';
+GRANT ALL PRIVILEGES ON *.* TO audit_user@localhost WITH GRANT OPTION;
+
+INSTALL COMPONENT "file://component_test_audit_api_message";
+
+--source suite/query_rewrite_plugins/include/install_ddl_rewriter.inc
+
+connect (setup_conn,localhost,audit_user,pass,test);
+connection setup_conn;
+
+CREATE TABLE t_events (id INT PRIMARY KEY, val VARCHAR(20));
+INSERT INTO t_events VALUES (1, 'one'), (2, 'two');
+
+DELIMITER //;
+CREATE PROCEDURE p_nested()
+BEGIN
+  DECLARE x INT DEFAULT 0;
+  SET x = 1;
+  SELECT x;
+END//
+DELIMITER ;//
+
+CREATE TABLE trg_src (id INT);
+CREATE TABLE trg_log (id INT, msg VARCHAR(50));
+
+DELIMITER //;
+CREATE TRIGGER trg_after_insert AFTER INSERT ON trg_src
+FOR EACH ROW
+BEGIN
+  INSERT INTO trg_log VALUES (NEW.id, 'inserted');
+END//
+DELIMITER ;//
+
+disconnect setup_conn;
+--enable_query_log
+--enable_result_log
+connection default;
+
+SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+SELECT audit_log_filter_set_filter('log_pre_auth',
+  '{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate","log":true}}}}');
+SELECT audit_log_filter_set_user('%', 'log_pre_auth');
+SELECT audit_log_filter_set_user('audit_user@localhost', 'log_all');
+
+--disable_query_log
+--disable_result_log
+
+connect (user_conn,localhost,audit_user,pass,test);
+
+connection user_conn;
+SELECT 1;
+--error ER_NO_SUCH_TABLE
+SELECT * FROM missing_table_for_audit;
+SELECT * FROM t_events WHERE id = 1;
+INSERT INTO t_events VALUES (3, 'three');
+UPDATE t_events SET val = 'THREE' WHERE id = 3;
+DELETE FROM t_events WHERE id = 3;
+CALL p_nested();
+INSERT INTO trg_src VALUES (1);
+SELECT test_audit_api_message_internal();
+SELECT test_audit_api_message_user();
+# ddl_rewriter fills rewritten_query for query_rewritten. The paired
+# prepared_statement record still exposes the rewritten SQL via query.
+CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB, ENCRYPTION = 'N';
+DROP TABLE t_parse_rewrite;
+PREPARE stmt_parse_ddl
+  FROM 'CREATE TABLE t_parse_ps (id INT) ENGINE = InnoDB, ENCRYPTION = ''N''';
+EXECUTE stmt_parse_ddl;
+DEALLOCATE PREPARE stmt_parse_ddl;
+DROP TABLE t_parse_ps;
+SELECT @@global.default_password_lifetime;
+SET GLOBAL default_password_lifetime = 101;
+CREATE USER auth_evt_user@localhost IDENTIFIED BY 'pass';
+ALTER USER auth_evt_user@localhost IDENTIFIED BY 'pass2';
+RENAME USER auth_evt_user@localhost TO auth_evt_user2@localhost;
+DROP USER auth_evt_user2@localhost;
+FLUSH PRIVILEGES;
+
+connection default;
+--source include/count_sessions.inc
+connect (change_conn,localhost,audit_user,pass,test);
+connection change_conn;
+--change_user audit_user,pass
+connection default;
+disconnect change_conn;
+--source include/wait_until_count_sessions.inc
+
+SELECT audit_log_filter_flush();
+
+connection default;
+SET GLOBAL default_password_lifetime = @saved_default_password_lifetime;
+UNINSTALL PLUGIN ddl_rewriter;
+UNINSTALL COMPONENT "file://component_test_audit_api_message";
+disconnect user_conn;
+DROP TRIGGER trg_after_insert;
+DROP PROCEDURE p_nested;
+DROP TABLE trg_log;
+DROP TABLE trg_src;
+DROP TABLE t_events;
+DROP USER audit_user@localhost;
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc
+
+--enable_result_log
+--enable_query_log
+
+perl;
+  use strict;
+  use warnings;
+
+  use B ();
+  use JSON::PP ();
+
+  die "Log path is not set\n" if (!$ENV{audit_filter_log_path});
+  die "Log name is not set\n" if (!$ENV{audit_filter_log_name});
+
+  my $log_dir = $ENV{audit_filter_log_path};
+  my $log_name = $ENV{audit_filter_log_name};
+  my $full_log_name = "$log_dir/$log_name";
+
+  if (!-e $full_log_name) {
+    my ($log_prefix, $log_suffix) = split(/\./, $log_name, 2);
+    $log_suffix = ".$log_suffix";
+
+    opendir(my $dh, $log_dir) or die "Can't opendir '$log_dir': $!";
+    my @log_files = sort grep {
+      $_ eq $log_name ||
+      /^\Q$log_prefix\E\.\d{8}T\d{6}\Q$log_suffix\E$/
+    } readdir($dh);
+    closedir($dh);
+
+    die "No audit log files found\n" if !@log_files;
+    $full_log_name = "$log_dir/$log_files[-1]";
+  }
+
+  open(my $fh, '<:encoding(UTF-8)', $full_log_name)
+    or die "Could not open '$full_log_name': $!";
+
+  local $/;
+  my $json_text = <$fh>;
+  close($fh);
+
+  $json_text =~ s/\s+$//;
+  unless ($json_text =~ /\]\s*$/) {
+    $json_text =~ s/,\s*$//;
+    $json_text .= "\n]\n";
+  }
+
+  my $events = JSON::PP::decode_json($json_text);
+
+  sub is_number {
+    my ($val) = @_;
+    return 0 unless defined $val;
+    return 0 if ref $val;
+    my $flags = B::svref_2object(\$val)->FLAGS;
+    return ($flags & (B::SVf_IOK | B::SVf_NOK)) ? 1 : 0;
+  }
+
+  sub hidden_raw { return bless {}, 'MtrHiddenRaw'; }
+  sub hidden_str { return bless {}, 'MtrHiddenStr'; }
+  sub is_hidden_raw { return ref($_[0]) eq 'MtrHiddenRaw'; }
+  sub is_hidden_str { return ref($_[0]) eq 'MtrHiddenStr'; }
+
+  sub clone_and_mask {
+    my ($value, $path) = @_;
+
+    if (!ref $value) {
+      return hidden_str() if $path eq 'timestamp';
+      return hidden_raw() if $path eq 'time' ||
+                              $path eq 'id' ||
+                              $path eq 'connection_id' ||
+                              $path eq 'startup_data.server_id' ||
+                              $path eq 'shutdown_data.server_id';
+      return hidden_str() if $path eq 'startup_data.os_version' ||
+                              $path eq 'startup_data.mysql_version';
+      return $value;
+    }
+
+    if (ref $value eq 'HASH') {
+      if ($path eq 'connection_attributes') {
+        my %hidden = map { $_ => hidden_str() } keys %{$value};
+        return \%hidden;
+      }
+
+      my %copy;
+      for my $key (keys %{$value}) {
+        my $child_path = $path eq '' ? $key : "$path.$key";
+
+        if ($child_path eq 'startup_data.args' &&
+            ref $value->{$key} eq 'ARRAY' &&
+            @{$value->{$key}} > 0) {
+          $copy{$key} = ['<hidden>'];
+          next;
+        }
+
+        $copy{$key} = clone_and_mask($value->{$key}, $child_path);
+      }
+
+      return \%copy;
+    }
+
+    if (ref $value eq 'ARRAY') {
+      return [map { clone_and_mask($_, $path) } @{$value}];
+    }
+
+    return $value;
+  }
+
+  my @key_priority = qw(
+    timestamp time id class event connection_id
+    account login
+    user host os ip proxy
+    general_data connection_data table_access_data global_variable_data
+    command_data query_data stored_program_data authentication_data
+    message_data parse_data startup_data shutdown_data
+    connection_attributes
+    command sql_command query status
+    connection_type db table name value rewritten_query flags
+    component producer message message_attributes
+    args
+    _pid _platform _os _client_name _client_version program_name
+  );
+
+  sub ordered_keys {
+    my ($hashref) = @_;
+    my %seen;
+    my @keys = grep { exists $hashref->{$_} && !$seen{$_}++ } @key_priority;
+    push @keys, grep { !$seen{$_}++ } sort keys %{$hashref};
+    return @keys;
+  }
+
+  sub fmt {
+    my ($val, $depth) = @_;
+    $depth //= 0;
+
+    return '<hidden>' if is_hidden_raw($val);
+    return '"<hidden>"' if is_hidden_str($val);
+    return 'null' if !defined $val;
+
+    if (!ref $val) {
+      return "$val" if is_number($val);
+
+      my $str = $val;
+      $str =~ s/\\/\\\\/g;
+      $str =~ s/"/\\"/g;
+      $str =~ s/\n/\\n/g;
+      return qq("$str");
+    }
+
+    my $indent = "  " x $depth;
+    my $next_indent = "  " x ($depth + 1);
+
+    if (ref $val eq 'ARRAY') {
+      return "[]" if !@{$val};
+
+      return "[\n" .
+             join(",\n", map { $next_indent . fmt($_, $depth + 1) } @{$val}) .
+             "\n$indent]";
+    }
+
+    if (ref $val eq 'HASH') {
+      my @keys = ordered_keys($val);
+      return "{}" if !@keys;
+
+      return "{\n" .
+             join(",\n",
+                  map { $next_indent . qq("$_": ) . fmt($val->{$_}, $depth + 1) }
+                  @keys) .
+             "\n$indent}";
+    }
+
+    return 'null';
+  }
+
+  my %samples;
+
+  sub sample_score {
+    my ($key, $event) = @_;
+    return 0 if !defined $event;
+    return 0 if $key ne 'parse/query_rewritten' &&
+                $key ne 'parse/prepared_statement';
+
+    my $parse_data = $event->{parse_data};
+    return 0 if ref $parse_data ne 'HASH';
+
+    my $score = 0;
+    my $rewritten_query = $parse_data->{rewritten_query} // '';
+    my $query = $parse_data->{query} // '';
+    my $flags = $parse_data->{flags};
+
+    $score += 100 if $rewritten_query ne '';
+    $score += 10 if $query =~ /^CREATE TABLE /i;
+    $score += 5 if $query !~ /^PREPARE /i;
+    $score += $flags if defined $flags && !ref $flags;
+
+    return $score;
+  }
+
+  for my $ev (@{$events}) {
+    next if !exists $ev->{class} || !exists $ev->{event};
+
+    my $key = "$ev->{class}/$ev->{event}";
+    next if exists $samples{$key} &&
+            sample_score($key, $ev) <= sample_score($key, $samples{$key});
+
+    $samples{$key} = clone_and_mask($ev, '');
+  }
+
+  my @expected = (
+    'audit/startup',
+    'general/log',
+    'general/error',
+    'general/result',
+    'general/status',
+    'connection/connect',
+    'connection/disconnect',
+    'connection/change_user',
+    'connection/pre_authenticate',
+    'table_access/read',
+    'table_access/insert',
+    'table_access/update',
+    'table_access/delete',
+    'global_variable/variable_get',
+    'global_variable/variable_set',
+    'command/command_start',
+    'command/command_end',
+    'query/query_start',
+    'query/query_nested_start',
+    'query/query_status_end',
+    'query/query_nested_status_end',
+    'stored_program/execute',
+    'authentication/auth_flush',
+    'authentication/auth_authid_create',
+    'authentication/auth_credential_change',
+    'authentication/auth_authid_rename',
+    'authentication/auth_authid_drop',
+    'message/internal',
+    'message/user',
+    'parse/query_rewritten',
+    'parse/prepared_statement',
+    'audit/shutdown',
+  );
+
+  # Keep auth_authid_create visible in the report even though the
+  # current tree does not emit it for CREATE USER.
+  my %known_missing = map { $_ => 1 } (
+    'authentication/auth_authid_create',
+  );
+
+  my $all_ok = 1;
+
+  for my $key (@expected) {
+    print "--- $key ---\n";
+    if (exists $samples{$key}) {
+      print fmt($samples{$key}), "\n";
+    } else {
+      print "MISSING: $key\n";
+      $all_ok = 0 if !$known_missing{$key};
+    }
+    print "\n";
+  }
+
+  die "Some expected event classes/subclasses were not observed\n"
+    if !$all_ok;
+EOF

--- a/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json.test
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json.test
@@ -15,7 +15,7 @@
 #   authentication: flush, authid_create (currently missing),
 #                   credential_change, authid_rename, authid_drop
 #   message: internal, user
-#   parse: query_rewritten, prepared_statement
+#   parse: preparse, postparse
 #
 --source suite/query_rewrite_plugins/include/have_ddl_rewriter.inc
 --source include/have_component_audit_log.inc
@@ -94,8 +94,8 @@ CALL p_nested();
 INSERT INTO trg_src VALUES (1);
 SELECT test_audit_api_message_internal();
 SELECT test_audit_api_message_user();
-# ddl_rewriter fills rewritten_query for query_rewritten. The paired
-# prepared_statement record still exposes the rewritten SQL via query.
+# Keep an interesting preparse sample with rewritten_query populated.
+# Keep an interesting postparse sample with the prepared-statement flag set.
 CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB, ENCRYPTION = 'N';
 DROP TABLE t_parse_rewrite;
 PREPARE stmt_parse_ddl
@@ -312,8 +312,8 @@ perl;
   sub sample_score {
     my ($key, $event) = @_;
     return 0 if !defined $event;
-    return 0 if $key ne 'parse/query_rewritten' &&
-                $key ne 'parse/prepared_statement';
+    return 0 if $key ne 'parse/preparse' &&
+                $key ne 'parse/postparse';
 
     my $parse_data = $event->{parse_data};
     return 0 if ref $parse_data ne 'HASH';
@@ -371,8 +371,8 @@ perl;
     'authentication/auth_authid_drop',
     'message/internal',
     'message/user',
-    'parse/query_rewritten',
-    'parse/prepared_statement',
+    'parse/preparse',
+    'parse/postparse',
     'audit/shutdown',
   );
 

--- a/mysql-test/suite/component_audit_log_filter/t/audit_noaudit_events.test
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_noaudit_events.test
@@ -10,7 +10,7 @@
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_comp_install.inc
 
---let $search_tag=<NAME>(?:Audit|NoAudit)</NAME>
+--let $search_tag=<NAME>(?:Startup|Shutdown)</NAME>
 --source check_all_events_with_tag.inc
 
 --source ../inc/audit_comp_uninstall.inc

--- a/mysql-test/suite/component_audit_log_filter/t/audit_startup_shutdown_json-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_startup_shutdown_json-master.opt
@@ -1,0 +1,2 @@
+--loose-audit_log_filter.file=audit_filter.json.log
+--loose-audit_log_filter.format=JSON

--- a/mysql-test/suite/component_audit_log_filter/t/audit_startup_shutdown_json.test
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_startup_shutdown_json.test
@@ -1,0 +1,62 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+
+--source clean_current_audit_log.inc
+
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_comp_install.inc
+--let $audit_filter_rotate_name = `SELECT audit_log_rotate()`
+
+--let $audit_filter_log_check_one =
+--let $audit_filter_log_format = json
+--source validate_logs_format.inc
+
+perl;
+  use strict;
+  use warnings;
+  use File::Spec;
+
+  my $log_path = $ENV{'audit_filter_log_path'};
+  my $log_name = $ENV{'audit_filter_log_name'};
+  my $base_file_name = $log_name =~ s/\..*$//r;
+
+  opendir(my $dh, $log_path)
+    or die "Could not open '$log_path': $!";
+
+  my @log_files = sort grep { /$base_file_name\.\d{8}T\d{6}/ } readdir($dh);
+  closedir($dh);
+
+  die "Could not find rotated audit logs in '$log_path'\n" if (!@log_files);
+
+  my $content = '';
+  for my $file_name (@log_files) {
+    my $file_path = File::Spec->catfile($log_path, $file_name);
+    open(my $fh, '<:encoding(UTF-8)', $file_path)
+      or die "Could not open '$file_path': $!";
+
+    local $/;
+    $content .= <$fh>;
+    close($fh);
+  }
+
+  if ($content =~ /"class": "audit".*?"event": "shutdown".*?"connection_id": \d+.*?"shutdown_data": \{ "server_id": \d+ \}/s) {
+    print "OK: audit/shutdown payload\n";
+  } else {
+    die "MISSING: audit/shutdown payload\n";
+  }
+
+  if ($content =~ /"class": "audit".*?"event": "startup".*?"connection_id": \d+.*?"account": \{ "user": ".*?", "host": ".*?" \}.*?"login": \{ "user": ".*?", "os": ".*?", "ip": ".*?", "proxy": ".*?" \}.*?"startup_data": \{.*?"server_id": \d+.*?"os_version": ".*?".*?"mysql_version": ".*?".*?"args": \[.*?\]\s*\}/s) {
+    print "OK: audit/startup payload\n";
+  } else {
+    die "MISSING: audit/startup payload\n";
+  }
+
+  print "\nLifecycle audit JSON payloads observed.\n";
+EOF
+
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
@@ -247,6 +247,7 @@ call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filte
 call mtr.add_suppression("Component audit_log_filter reported: 'Event field 'status' cannot be replaced'");
 call mtr.add_suppression("Component audit_log_filter reported: 'Event field 'connection_id' cannot be replaced'");
 call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, the 'log' field must be of bool or object type'");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'incorrect_rule' format, field name 'query_charset' is not valid for event class 'parse''");
 #call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'wrong_field_type' format, wrong function args format provided'");
 --enable_query_log
 
@@ -310,6 +311,34 @@ let $filter = {
           "field": {
             "name": "query.str",
             "print": [],
+            "replace": {
+              "function": {
+                "name": "query_digest"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+};
+eval SELECT audit_log_filter_set_filter('incorrect_rule', '$filter');
+
+# Invalid replacement condition for one class in class-name array
+let $filter = {
+  "filter": {
+    "class": [
+      {
+        "name": ["query", "parse"],
+        "print": {
+          "field": {
+            "name": "query.str",
+            "print": {
+              "field": {
+                "name": "query_charset",
+                "value": "utf8mb4"
+              }
+            },
             "replace": {
               "function": {
                 "name": "query_digest"

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_filter.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_filter.test
@@ -65,6 +65,44 @@ INSERT INTO temp_3 VALUES (1);
 --source check_all_events_with_tag.inc
 
 --echo #
+--echo # Invalid nested replacement rule returns inner parse error
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'filter_replace_invalid' format, failed to parse 'filter' replacement rule'");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter 'filter_replace_invalid' format, field name 'connection_id' is not valid for event class 'general''");
+--enable_query_log
+
+let $filter = {
+  "filter": {
+    "id": "main",
+    "class": {
+      "name": "table_access",
+      "event": {
+        "name": "update",
+        "log": false,
+        "filter": {
+          "class": {
+            "name": "general",
+            "event": {
+              "name": "status",
+              "log": {
+                "field": { "name": "connection_id", "value": "1" }
+              },
+              "filter": { "ref": "main" }
+            }
+          },
+          "activate": {
+            "field": { "name": "table_name.str", "value": "temp_1" }
+          }
+        }
+      }
+    }
+  }
+};
+
+eval SELECT audit_log_filter_set_filter('filter_replace_invalid', '$filter');
+
+--echo #
 --echo # Cleanup
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='-d,audit_log_filter_rotate_after_audit_rules_flush';

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_class.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_class.test
@@ -154,6 +154,14 @@ SELECT audit_log_filter_set_filter('filter_broken_badEventArr', '{"filter": { "c
 ] } }');
 
 --echo #
+--echo # Broken parse event name: rewrite flag name is not an event subclass
+SELECT audit_log_filter_set_filter('filter_broken_parseRewriteNone', '{"filter": { "class": [ { "name": "parse", "event": { "name": "rewrite_none" } } ] } }');
+
+--echo #
+--echo # Broken parse event name: rewrite flag name is not an event subclass
+SELECT audit_log_filter_set_filter('filter_broken_parseRewritePreparedStmt', '{"filter": { "class": [ { "name": "parse", "event": { "name": "rewrite_prepared_statement" } } ] } }');
+
+--echo #
 --echo # Cleanup
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_tables_cleanup.inc


### PR DESCRIPTION
Summary
- Fix filter parser gaps: validate class-level print rules against every class in a class-name array so invalid field references are rejected consistently; propagate nested replacement-rule parse errors back to the UDF result instead of silently succeeding.
- Align startup/shutdown JSON payloads with upstream: rename internal audit/noaudit lifecycle events to startup/shutdown; expand startup records to include connection_id, account/login data, and startup_data (server_id, OS version, server version, argv); fix audit_log_read JSON handler to correctly stream nested arrays and scalar values.
- Correct parse event subclass names: replace the misleading rewrite-based names (REWRITE_*) in audit record generation and both formatters with the real PREPARSE/POSTPARSE subclass names exposed by the parse event tracking API.
- Add comprehensive MTR test coverage: new audit_event_classes_subclasses_json test exercises every audit event class/subclass and validates the JSON output via a Perl post-processor; new audit_startup_shutdown_json test covers lifecycle payloads on rotated logs; new filter_definition_replace_field and filter_definition_replace_filter regression tests cover the parser edge cases; extend filter_definition_validate_class to reject obsolete parse event names.