### PR TITLE
PS-10853 [8.4]: Ignore audit lifecycle startup and shutdown events

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -466,6 +466,11 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
     return 0;
   }
 
+  if (event_class == audit_event_class_t::AUDIT_SERVER_STARTUP_CLASS ||
+      event_class == audit_event_class_t::AUDIT_SERVER_SHUTDOWN_CLASS) {
+    return 0;
+  }
+
   MYSQL_THD thd = nullptr;
   if (mysql_service_mysql_current_thread_reader->get(&thd) == 1 ||
       thd == nullptr) {
@@ -503,26 +508,30 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   SysVars::set_session_filter_id(thd, filter_rule->get_filter_id());
 
   // Get actual event info based on event class
-  AuditRecordVariant audit_record = get_audit_record(event_class, event_data);
+  auto audit_record = get_audit_record(event_class, event_data);
+  if (!audit_record.has_value()) {
+    return 0;
+  }
+  auto &record = *audit_record;
 
-  if (std::holds_alternative<AuditRecordUnknown>(audit_record)) {
+  if (std::holds_alternative<AuditRecordUnknown>(record)) {
     LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
                     "Unsupported audit event class with ID %i received",
                     event_class);
     return 0;
   }
 
-  if (auto rec = std::get_if<AuditRecordGeneral>(&audit_record)) {
+  if (auto rec = std::get_if<AuditRecordGeneral>(&record)) {
     set_extended_info(thd, sctx, *rec);
   }
 
-  if (auto rec = std::get_if<AuditRecordTableAccess>(&audit_record)) {
+  if (auto rec = std::get_if<AuditRecordTableAccess>(&record)) {
     set_extended_info(thd, sctx, *rec);
   }
 
   // Apply filtering rule
   AuditAction filter_result =
-      AuditEventFilter::apply(filter_rule.get(), audit_record);
+      AuditEventFilter::apply(filter_rule.get(), record);
 
   if (filter_result == AuditAction::Skip) {
     SysVars::inc_events_filtered();
@@ -535,7 +544,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
         [](const auto &rec) -> std::string_view {
           return rec.event_class_name;
         },
-        audit_record);
+        record);
     LogComponentErr(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
                     "Blocked audit event '%s' with class %i", ev_name.data(),
                     event_class);
@@ -543,10 +552,10 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   }
 
   if (event_class == audit_event_class_t::AUDIT_CONNECTION_CLASS) {
-    get_connection_attrs(thd, audit_record);
+    get_connection_attrs(thd, record);
   }
 
-  m_log_writer->write(audit_record);
+  m_log_writer->write(record);
   SysVars::inc_events_written();
 
   return 0;
@@ -564,6 +573,9 @@ void AuditLogFilter::send_audit_start_event() noexcept {
 
   auto audit_record =
       get_audit_record(audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS, &event);
+  if (!audit_record.has_value()) {
+    return;
+  }
 
   Security_context_handle sctx{};
   if (thd != nullptr && m_security_context_srv != nullptr &&
@@ -580,7 +592,7 @@ void AuditLogFilter::send_audit_start_event() noexcept {
       }
     };
 
-    if (auto *record = std::get_if<AuditRecordAudit>(&audit_record)) {
+    if (auto *record = std::get_if<AuditRecordAudit>(&*audit_record)) {
       load_security_context_option("user", record->extended_info.user);
       load_security_context_option("host", record->extended_info.host);
       load_security_context_option("ip", record->extended_info.ip);
@@ -591,7 +603,7 @@ void AuditLogFilter::send_audit_start_event() noexcept {
     }
   }
 
-  m_log_writer->write(audit_record);
+  m_log_writer->write(*audit_record);
 }
 
 void AuditLogFilter::send_audit_stop_event() noexcept {
@@ -605,8 +617,13 @@ void AuditLogFilter::send_audit_stop_event() noexcept {
     event.connection_id = static_cast<unsigned long>(thd->thread_id());
   }
 
-  m_log_writer->write(get_audit_record(
-      audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS, &event));
+  auto audit_record =
+      get_audit_record(audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS, &event);
+  if (!audit_record.has_value()) {
+    return;
+  }
+
+  m_log_writer->write(*audit_record);
 }
 
 bool AuditLogFilter::on_audit_rule_flush_requested() noexcept {

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -21,7 +21,6 @@
 #include <mysql/components/services/event_tracking_connection_service.h>
 #include <mysql/components/services/event_tracking_general_service.h>
 #include <mysql/components/services/event_tracking_global_variable_service.h>
-#include <mysql/components/services/event_tracking_lifecycle_service.h>
 #include <mysql/components/services/event_tracking_message_service.h>
 #include <mysql/components/services/event_tracking_parse_service.h>
 #include <mysql/components/services/event_tracking_query_service.h>
@@ -40,8 +39,6 @@ constexpr std::string_view kClassNameConnection{"connection"};
 constexpr std::string_view kClassNameAuthorization{"authorization"};
 constexpr std::string_view kClassNameTableAccess{"table_access"};
 constexpr std::string_view kClassNameGlobalVariable{"global_variable"};
-constexpr std::string_view kClassNameServerStartup{"server_startup"};
-constexpr std::string_view kClassNameServerShutdown{"server_shutdown"};
 constexpr std::string_view kClassNameCommand{"command"};
 constexpr std::string_view kClassNameQuery{"query"};
 constexpr std::string_view kClassNameStoredProgram{"stored_program"};
@@ -61,8 +58,6 @@ constexpr std::string_view kSubclassNameUpdate{"update"};
 constexpr std::string_view kSubclassNameDelete{"delete"};
 constexpr std::string_view kSubclassNameGet{"get"};
 constexpr std::string_view kSubclassNameSet{"set"};
-constexpr std::string_view kSubclassNameStartup{"startup"};
-constexpr std::string_view kSubclassNameShutdown{"shutdown"};
 constexpr std::string_view kSubclassNameEnd{"end"};
 constexpr std::string_view kSubclassNameStart{"start"};
 constexpr std::string_view kSubclassNameNestedStart{"nested_start"};
@@ -108,10 +103,6 @@ std::string_view event_class_to_string(audit_event_class_t event_class) {
       return kClassNameTableAccess;
     case audit_event_class_t::AUDIT_GLOBAL_VARIABLE_CLASS:
       return kClassNameGlobalVariable;
-    case audit_event_class_t::AUDIT_SERVER_STARTUP_CLASS:
-      return kClassNameServerStartup;
-    case audit_event_class_t::AUDIT_SERVER_SHUTDOWN_CLASS:
-      return kClassNameServerShutdown;
     case audit_event_class_t::AUDIT_COMMAND_CLASS:
       return kClassNameCommand;
     case audit_event_class_t::AUDIT_QUERY_CLASS:
@@ -192,30 +183,6 @@ std::string_view event_subclass_to_string(
       return kSubclassNameGet;
     case EVENT_TRACKING_GLOBAL_VARIABLE_SET:
       return kSubclassNameSet;
-    default:
-      assert(false);
-  }
-
-  return kNameUnknown;
-}
-
-std::string_view event_subclass_to_string(
-    const mysql_event_tracking_startup_data *event) {
-  switch (event->event_subclass) {
-    case EVENT_TRACKING_STARTUP_STARTUP:
-      return kSubclassNameStartup;
-    default:
-      assert(false);
-  }
-
-  return kNameUnknown;
-}
-
-std::string_view event_subclass_to_string(
-    const mysql_event_tracking_shutdown_data *event) {
-  switch (event->event_subclass) {
-    case EVENT_TRACKING_SHUTDOWN_SHUTDOWN:
-      return kSubclassNameShutdown;
     default:
       assert(false);
   }
@@ -391,166 +358,114 @@ bool field_value_matches(const AuditRecordFieldValue &value,
       value);
 }
 
-AuditRecordVariant get_audit_record(audit_event_class_t event_class,
-                                    const void *event) {
+std::optional<AuditRecordVariant> get_audit_record(
+    audit_event_class_t event_class, const void *event) {
   switch (event_class) {
+    case audit_event_class_t::AUDIT_SERVER_STARTUP_CLASS:
+    case audit_event_class_t::AUDIT_SERVER_SHUTDOWN_CLASS:
+      return std::nullopt;
     case audit_event_class_t::AUDIT_GENERAL_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<0>,
-          AuditRecordGeneral{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_general_data *>(
-                      event)),
-              event_class,
-              static_cast<const mysql_event_tracking_general_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordGeneral{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
+              static_cast<const mysql_event_tracking_general_data *>(event)),
+          event_class,
+          static_cast<const mysql_event_tracking_general_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_CONNECTION_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<1>,
-          AuditRecordConnection{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_connection_data *>(
-                      event)),
-              event_class,
-              static_cast<const mysql_event_tracking_connection_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordConnection{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
+              static_cast<const mysql_event_tracking_connection_data *>(event)),
+          event_class,
+          static_cast<const mysql_event_tracking_connection_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_TABLE_ACCESS_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<2>,
-          AuditRecordTableAccess{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_table_access_data *>(
-                      event)),
-              event_class,
+      return AuditRecordVariant{AuditRecordTableAccess{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
               static_cast<const mysql_event_tracking_table_access_data *>(
-                  event),
-              {}}};
+                  event)),
+          event_class,
+          static_cast<const mysql_event_tracking_table_access_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_GLOBAL_VARIABLE_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<3>,
-          AuditRecordGlobalVariable{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_global_variable_data
-                                  *>(event)),
-              event_class,
+      return AuditRecordVariant{AuditRecordGlobalVariable{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
               static_cast<const mysql_event_tracking_global_variable_data *>(
-                  event),
-              {}}};
-    }
-    case audit_event_class_t::AUDIT_SERVER_STARTUP_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<4>,
-          AuditRecordServerStartup{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_startup_data *>(
-                      event)),
-              event_class,
-              static_cast<const mysql_event_tracking_startup_data *>(event),
-              {}}};
-    }
-    case audit_event_class_t::AUDIT_SERVER_SHUTDOWN_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<5>,
-          AuditRecordServerShutdown{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_shutdown_data *>(
-                      event)),
-              event_class,
-              static_cast<const mysql_event_tracking_shutdown_data *>(event),
-              {}}};
+                  event)),
+          event_class,
+          static_cast<const mysql_event_tracking_global_variable_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_COMMAND_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<6>,
-          AuditRecordCommand{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_command_data *>(
-                      event)),
-              event_class,
-              static_cast<const mysql_event_tracking_command_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordCommand{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
+              static_cast<const mysql_event_tracking_command_data *>(event)),
+          event_class,
+          static_cast<const mysql_event_tracking_command_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_QUERY_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<7>,
-          AuditRecordQuery{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_query_data *>(event)),
-              event_class,
-              static_cast<const mysql_event_tracking_query_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordQuery{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
+              static_cast<const mysql_event_tracking_query_data *>(event)),
+          event_class,
+          static_cast<const mysql_event_tracking_query_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_STORED_PROGRAM_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<8>,
-          AuditRecordStoredProgram{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_stored_program_data *>(
-                      event)),
-              event_class,
+      return AuditRecordVariant{AuditRecordStoredProgram{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
               static_cast<const mysql_event_tracking_stored_program_data *>(
-                  event),
-              {}}};
+                  event)),
+          event_class,
+          static_cast<const mysql_event_tracking_stored_program_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_AUTHENTICATION_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<9>,
-          AuditRecordAuthentication{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_authentication_data *>(
-                      event)),
-              event_class,
+      return AuditRecordVariant{AuditRecordAuthentication{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
               static_cast<const mysql_event_tracking_authentication_data *>(
-                  event),
-              {}}};
+                  event)),
+          event_class,
+          static_cast<const mysql_event_tracking_authentication_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_MESSAGE_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<10>,
-          AuditRecordMessage{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_message_data *>(
-                      event)),
-              event_class,
-              static_cast<const mysql_event_tracking_message_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordMessage{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
+              static_cast<const mysql_event_tracking_message_data *>(event)),
+          event_class,
+          static_cast<const mysql_event_tracking_message_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_PARSE_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<11>,
-          AuditRecordParse{
-              event_class_to_string(event_class),
-              event_subclass_to_string(
-                  static_cast<const mysql_event_tracking_parse_data *>(event)),
-              event_class,
-              static_cast<const mysql_event_tracking_parse_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordParse{
+          event_class_to_string(event_class),
+          event_subclass_to_string(
+              static_cast<const mysql_event_tracking_parse_data *>(event)),
+          event_class,
+          static_cast<const mysql_event_tracking_parse_data *>(event),
+          {}}};
     }
     case audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS: {
-      return AuditRecordVariant{
-          std::in_place_index<12>,
-          AuditRecordAudit{
-              kClassNameInternalAudit,
-              event_subclass_to_string(
-                  static_cast<const internal_event_tracking_audit_data *>(
-                      event)),
-              audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS,
-              static_cast<const internal_event_tracking_audit_data *>(event),
-              {}}};
+      return AuditRecordVariant{AuditRecordAudit{
+          kClassNameInternalAudit,
+          event_subclass_to_string(
+              static_cast<const internal_event_tracking_audit_data *>(event)),
+          audit_event_class_t::AUDIT_INTERNAL_AUDIT_CLASS,
+          static_cast<const internal_event_tracking_audit_data *>(event),
+          {}}};
     }
     default:
       break;
@@ -559,7 +474,6 @@ AuditRecordVariant get_audit_record(audit_event_class_t event_class,
   assert(false);
 
   return AuditRecordVariant{
-      std::in_place_index<13>,
       AuditRecordUnknown{kNameUnknown,
                          kNameUnknown,
                          audit_event_class_t::AUDIT_INTERNAL_UNKNOWN_CLASS,
@@ -667,20 +581,6 @@ AuditRecordFieldsList get_audit_record_fields(
       {"variable_value.str", mysql_cstring_to_string(&event->variable_value)},
       {"variable_value.length",
        mysql_cstring_len_to_string(&event->variable_value)},
-  };
-}
-
-AuditRecordFieldsList get_audit_record_fields(
-    const AuditRecordServerStartup &record [[maybe_unused]]) {
-  return {};
-}
-
-AuditRecordFieldsList get_audit_record_fields(
-    const AuditRecordServerShutdown &record) {
-  const auto *event = record.event;
-  return {
-      {"exit_code", std::to_string(event->exit_code)},
-      {"reason", std::to_string(event->reason)},
   };
 }
 

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -31,8 +32,6 @@ struct mysql_event_tracking_general_data;
 struct mysql_event_tracking_connection_data;
 struct mysql_event_tracking_table_access_data;
 struct mysql_event_tracking_global_variable_data;
-struct mysql_event_tracking_startup_data;
-struct mysql_event_tracking_shutdown_data;
 struct mysql_event_tracking_command_data;
 struct mysql_event_tracking_query_data;
 struct mysql_event_tracking_stored_program_data;
@@ -92,22 +91,6 @@ struct AuditRecordGlobalVariable {
   std::string_view event_subclass_name;
   audit_event_class_t event_class;
   const mysql_event_tracking_global_variable_data *event;
-  ExtendedInfo extended_info;
-};
-
-struct AuditRecordServerStartup {
-  std::string_view event_class_name;
-  std::string_view event_subclass_name;
-  audit_event_class_t event_class;
-  const mysql_event_tracking_startup_data *event;
-  ExtendedInfo extended_info;
-};
-
-struct AuditRecordServerShutdown {
-  std::string_view event_class_name;
-  std::string_view event_subclass_name;
-  audit_event_class_t event_class;
-  const mysql_event_tracking_shutdown_data *event;
   ExtendedInfo extended_info;
 };
 
@@ -178,7 +161,6 @@ struct AuditRecordUnknown {
 using AuditRecordVariant =
     std::variant<AuditRecordGeneral, AuditRecordConnection,
                  AuditRecordTableAccess, AuditRecordGlobalVariable,
-                 AuditRecordServerStartup, AuditRecordServerShutdown,
                  AuditRecordCommand, AuditRecordQuery, AuditRecordStoredProgram,
                  AuditRecordAuthentication, AuditRecordMessage,
                  AuditRecordParse, AuditRecordAudit, AuditRecordUnknown>;
@@ -188,10 +170,11 @@ using AuditRecordVariant =
  *
  * @param event_class Received audit event class
  * @param event Received audit event
- * @return An instance of AuditRecordVariant representing audit event
+ * @return An instance of AuditRecordVariant representing audit event,
+ *         or std::nullopt when the event should be ignored
  */
-AuditRecordVariant get_audit_record(audit_event_class_t event_class,
-                                    const void *event);
+std::optional<AuditRecordVariant> get_audit_record(
+    audit_event_class_t event_class, const void *event);
 
 /**
  * @brief Convert connection_type pseudo-constant to numeric value.
@@ -244,24 +227,6 @@ AuditRecordFieldsList get_audit_record_fields(
  */
 AuditRecordFieldsList get_audit_record_fields(
     const AuditRecordGlobalVariable &record);
-
-/**
- * @brief Get fields list from AuditRecordServerStartup event record.
- *
- * @param record Audit event record
- * @return Fields list, @ref AuditRecordFieldsList
- */
-AuditRecordFieldsList get_audit_record_fields(
-    const AuditRecordServerStartup &record);
-
-/**
- * @brief Get fields list from AuditRecordServerShutdown event record.
- *
- * @param record Audit event record
- * @return Fields list, @ref AuditRecordFieldsList
- */
-AuditRecordFieldsList get_audit_record_fields(
-    const AuditRecordServerShutdown &record);
 
 /**
  * @brief Get fields list from AuditRecordCommand event record.

--- a/components/audit_log_filter/filter_definition_fields.md
+++ b/components/audit_log_filter/filter_definition_fields.md
@@ -13,7 +13,9 @@ filter-definition validation through `audit_log_filter_set_filter()`.
   are not explicitly typed in `get_event_field_value_type()`.
 - Filter-definition validation only accepts the class names documented below.
 - Lifecycle-related records with class names `audit`, `server_startup`, and
-  `server_shutdown` are not valid filter-definition targets.
+  `server_shutdown` are not valid filter-definition targets. Startup and
+  shutdown lifecycle events are ignored by the audit log filter if they are
+  received.
 - For `connection.connection_type`, the validator accepts numeric values `0..5`
   and the pseudo-constants `::undefined`, `::tcp/ip`, `::socket`,
   `::named_pipe`, `::ssl`, and `::shared_memory`.

--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -43,8 +43,6 @@ const std::string_view kAuditEventNameConnection{"Connection"};
 const std::string_view kAuditEventNameAuthorization{"Authorization"};
 const std::string_view kAuditEventNameTableAccess{"Table Access"};
 const std::string_view kAuditEventNameGlobalVariable{"Global Variable"};
-const std::string_view kAuditEventNameServerStartup{"Server Startup"};
-const std::string_view kAuditEventNameServerShutdown{"Server Shutdown"};
 const std::string_view kAuditEventNameCommand{"Command"};
 const std::string_view kAuditEventNameQuery{"Query"};
 const std::string_view kAuditEventNameStoredProgram{"Stored Program"};
@@ -78,9 +76,6 @@ const std::string_view kAuditEventNameAccessDelete{"TableDelete"};
 const std::string_view kAuditEventNameGlobalVariableGet{"Variable Get"};
 const std::string_view kAuditEventNameGlobalVariableSet{"Variable Set"};
 
-const std::string_view kAuditNameShutdownReasonShutdown{"Shutdown"};
-const std::string_view kAuditNameShutdownReasonAbort{"Abort"};
-
 const std::string_view kAuditEventNameCommandStart{"Command Start"};
 const std::string_view kAuditEventNameCommandEnd{"Command End"};
 
@@ -96,10 +91,6 @@ const std::string_view kAuditEventNameAuthCredentialChange{
     "Auth Credential Change"};
 const std::string_view kAuditEventNameAuthAuthidRename{"Auth Authid Rename"};
 const std::string_view kAuditEventNameAuthAuthidDrop{"Auth Authid Drop"};
-
-const std::string_view kAuditEventNameServerStartupStartup{"Startup"};
-
-const std::string_view kAuditEventNameServerShutdownShutdown{"Shutdown"};
 
 const std::string_view kAuditEventNameStoredProgramExecute{"Execute"};
 
@@ -187,10 +178,6 @@ std::string_view LogRecordFormatterBase::event_class_to_string(
       return kAuditEventNameTableAccess;
     case audit_event_class_t::AUDIT_GLOBAL_VARIABLE_CLASS:
       return kAuditEventNameGlobalVariable;
-    case audit_event_class_t::AUDIT_SERVER_STARTUP_CLASS:
-      return kAuditEventNameServerStartup;
-    case audit_event_class_t::AUDIT_SERVER_SHUTDOWN_CLASS:
-      return kAuditEventNameServerShutdown;
     case audit_event_class_t::AUDIT_COMMAND_CLASS:
       return kAuditEventNameCommand;
     case audit_event_class_t::AUDIT_QUERY_CLASS:
@@ -347,30 +334,6 @@ std::string_view LogRecordFormatterBase::event_subclass_to_string(
 }
 
 std::string_view LogRecordFormatterBase::event_subclass_to_string(
-    const mysql_event_tracking_startup_data *event) const noexcept {
-  switch (event->event_subclass) {
-    case EVENT_TRACKING_STARTUP_STARTUP:
-      return kAuditEventNameServerStartupStartup;
-    default:
-      assert(false);
-  }
-
-  return kAuditNameUnknown;
-}
-
-std::string_view LogRecordFormatterBase::event_subclass_to_string(
-    const mysql_event_tracking_shutdown_data *event) const noexcept {
-  switch (event->event_subclass) {
-    case EVENT_TRACKING_SHUTDOWN_SHUTDOWN:
-      return kAuditEventNameServerShutdownShutdown;
-    default:
-      assert(false);
-  }
-
-  return kAuditNameUnknown;
-}
-
-std::string_view LogRecordFormatterBase::event_subclass_to_string(
     const mysql_event_tracking_stored_program_data *event) const noexcept {
   switch (event->event_subclass) {
     case EVENT_TRACKING_STORED_PROGRAM_EXECUTE:
@@ -425,20 +388,6 @@ std::string_view LogRecordFormatterBase::connection_type_name_to_string(
       return kAuditConnectionTypeNameSsl;
     case 5:
       return kAuditConnectionTypeNameShared;
-    default:
-      assert(false);
-  }
-
-  return kAuditNameUnknown;
-}
-
-std::string_view LogRecordFormatterBase::shutdown_reason_to_string(
-    mysql_event_tracking_shutdown_reason_t reason) const noexcept {
-  switch (reason) {
-    case EVENT_TRACKING_SHUTDOWN_REASON_SHUTDOWN:
-      return kAuditNameShutdownReasonShutdown;
-    case EVENT_TRACKING_SHUTDOWN_REASON_ABORT:
-      return kAuditNameShutdownReasonAbort;
     default:
       assert(false);
   }

--- a/components/audit_log_filter/log_record_formatter/base.h
+++ b/components/audit_log_filter/log_record_formatter/base.h
@@ -18,8 +18,6 @@
 
 #include "components/audit_log_filter/audit_event_class_internal.h"
 
-#include <mysql/components/services/defs/event_tracking_lifecycle_defs.h>
-
 #include <atomic>
 #include <chrono>
 #include <sstream>
@@ -31,8 +29,6 @@ struct mysql_event_tracking_general_data;
 struct mysql_event_tracking_connection_data;
 struct mysql_event_tracking_table_access_data;
 struct mysql_event_tracking_global_variable_data;
-struct mysql_event_tracking_startup_data;
-struct mysql_event_tracking_shutdown_data;
 struct mysql_event_tracking_command_data;
 struct mysql_event_tracking_query_data;
 struct mysql_event_tracking_stored_program_data;
@@ -47,8 +43,6 @@ struct AuditRecordGeneral;
 struct AuditRecordConnection;
 struct AuditRecordTableAccess;
 struct AuditRecordGlobalVariable;
-struct AuditRecordServerStartup;
-struct AuditRecordServerShutdown;
 struct AuditRecordCommand;
 struct AuditRecordQuery;
 struct AuditRecordStoredProgram;
@@ -110,24 +104,6 @@ class LogRecordFormatterBase {
    */
   [[nodiscard]] virtual AuditRecordString apply(
       const AuditRecordGlobalVariable &audit_record) const noexcept = 0;
-
-  /**
-   * @brief Apply formatting to AuditRecordServerStartup audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] virtual AuditRecordString apply(
-      const AuditRecordServerStartup &audit_record) const noexcept = 0;
-
-  /**
-   * @brief Apply formatting to AuditRecordServerShutdown audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] virtual AuditRecordString apply(
-      const AuditRecordServerShutdown &audit_record) const noexcept = 0;
 
   /**
    * @brief Apply formatting to AuditRecordCommand audit record.
@@ -374,24 +350,6 @@ class LogRecordFormatterBase {
    * @return String representation of audit event subclass name
    */
   [[nodiscard]] virtual std::string_view event_subclass_to_string(
-      const mysql_event_tracking_startup_data *event) const noexcept;
-
-  /**
-   * @brief Get string representation of audit event subclass name.
-   *
-   * @param event Audit event
-   * @return String representation of audit event subclass name
-   */
-  [[nodiscard]] virtual std::string_view event_subclass_to_string(
-      const mysql_event_tracking_shutdown_data *event) const noexcept;
-
-  /**
-   * @brief Get string representation of audit event subclass name.
-   *
-   * @param event Audit event
-   * @return String representation of audit event subclass name
-   */
-  [[nodiscard]] virtual std::string_view event_subclass_to_string(
       const mysql_event_tracking_stored_program_data *event) const noexcept;
 
   /**
@@ -420,15 +378,6 @@ class LogRecordFormatterBase {
    */
   [[nodiscard]] virtual std::string_view connection_type_name_to_string(
       int connection_type) const noexcept;
-
-  /**
-   * @brief Get string representation of shutdown reason.
-   *
-   * @param reason Shutdown reason
-   * @return String representation of shutdown reason
-   */
-  [[nodiscard]] virtual std::string_view shutdown_reason_to_string(
-      mysql_event_tracking_shutdown_reason_t reason) const noexcept;
 
  private:
   /**

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -76,10 +76,6 @@ const std::string_view kAuditEventNameAuthCredentialChange{
 const std::string_view kAuditEventNameAuthAuthidRename{"auth_authid_rename"};
 const std::string_view kAuditEventNameAuthAuthidDrop{"auth_authid_drop"};
 
-const std::string_view kAuditEventNameServerStartupStartup{"startup"};
-
-const std::string_view kAuditEventNameServerShutdownShutdown{"shutdown"};
-
 const std::string_view kAuditEventNameStoredProgramExecute{"execute"};
 
 const std::string_view kAuditEventNameMessageInternal{"internal"};
@@ -87,9 +83,6 @@ const std::string_view kAuditEventNameMessageUser{"user"};
 
 const std::string_view kAuditEventNameParsePreparse{"preparse"};
 const std::string_view kAuditEventNameParsePostparse{"postparse"};
-
-const std::string_view kAuditNameShutdownReasonShutdown{"shutdown"};
-const std::string_view kAuditNameShutdownReasonAbort{"abort"};
 
 const std::string_view kAuditConnectionTypeNameUndef{"undefined"};
 const std::string_view kAuditConnectionTypeNameTcpip{"tcp/ip"};
@@ -231,30 +224,6 @@ std::string_view LogRecordFormatterJson::event_subclass_to_string(
 }
 
 std::string_view LogRecordFormatterJson::event_subclass_to_string(
-    const mysql_event_tracking_startup_data *event) const noexcept {
-  switch (event->event_subclass) {
-    case EVENT_TRACKING_STARTUP_STARTUP:
-      return kAuditEventNameServerStartupStartup;
-    default:
-      assert(false);
-  }
-
-  return kAuditNameUnknown;
-}
-
-std::string_view LogRecordFormatterJson::event_subclass_to_string(
-    const mysql_event_tracking_shutdown_data *event) const noexcept {
-  switch (event->event_subclass) {
-    case EVENT_TRACKING_SHUTDOWN_SHUTDOWN:
-      return kAuditEventNameServerShutdownShutdown;
-    default:
-      assert(false);
-  }
-
-  return kAuditNameUnknown;
-}
-
-std::string_view LogRecordFormatterJson::event_subclass_to_string(
     const mysql_event_tracking_stored_program_data *event) const noexcept {
   switch (event->event_subclass) {
     case EVENT_TRACKING_STORED_PROGRAM_EXECUTE:
@@ -323,20 +292,6 @@ std::string_view LogRecordFormatterJson::connection_type_name_to_string(
       return kAuditConnectionTypeNameSsl;
     case 5:
       return kAuditConnectionTypeNameShared;
-    default:
-      assert(false);
-  }
-
-  return kAuditNameUnknown;
-}
-
-std::string_view LogRecordFormatterJson::shutdown_reason_to_string(
-    mysql_event_tracking_shutdown_reason_t reason) const noexcept {
-  switch (reason) {
-    case EVENT_TRACKING_SHUTDOWN_REASON_SHUTDOWN:
-      return kAuditNameShutdownReasonShutdown;
-    case EVENT_TRACKING_SHUTDOWN_REASON_ABORT:
-      return kAuditNameShutdownReasonAbort;
     default:
       assert(false);
   }
@@ -501,71 +456,6 @@ AuditRecordString LogRecordFormatterJson::apply(
          << R"(      "name": ")" << make_escaped_string(&audit_record.event->variable_name) << "\",\n"
          << R"(      "value": ")" << make_escaped_string(&audit_record.event->variable_value) << "\",\n"
          << R"(      "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << "\"}"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
-  /* clang-format on */
-
-  SysVars::update_log_bookmark(rec_id, timestamp);
-
-  return result.str();
-}
-
-AuditRecordString LogRecordFormatterJson::apply(
-    const AuditRecordServerStartup &audit_record) const noexcept {
-  std::stringstream result;
-  const auto time_now = std::chrono::system_clock::now();
-  const auto timestamp = make_timestamp(time_now);
-  const auto rec_id = make_record_id();
-
-  /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
-
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "server_startup",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "args": [)"
-         << "\n";
-  for (unsigned int i = 0; i < audit_record.event->argc; ++i) {
-    if (audit_record.event->argv[i] != nullptr) {
-      result << ((i == 0) ? "" : ",\n") << R"(      ")"
-             << make_escaped_string(audit_record.event->argv[i]) << "\"";
-    }
-  }
-
-  result << "\n     ]" << extra_attrs_to_string(audit_record.extended_info)
-         << "\n  }";
-  /* clang-format on */
-
-  SysVars::update_log_bookmark(rec_id, timestamp);
-
-  return result.str();
-}
-
-AuditRecordString LogRecordFormatterJson::apply(
-    const AuditRecordServerShutdown &audit_record) const noexcept {
-  std::stringstream result;
-  const auto time_now = std::chrono::system_clock::now();
-  const auto timestamp = make_timestamp(time_now);
-  const auto rec_id = make_record_id();
-
-  /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
-
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "server_shutdown",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "server_shutdown_data": {)" << "\n"
-         << R"(      "status": )" << audit_record.event->exit_code << ",\n"
-         << R"(      "reason": ")" << shutdown_reason_to_string(audit_record.event->reason) << "\"}"
          << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 

--- a/components/audit_log_filter/log_record_formatter/json.h
+++ b/components/audit_log_filter/log_record_formatter/json.h
@@ -20,8 +20,6 @@
 
 #include "components/audit_log_filter/audit_record.h"
 
-#include <mysql/components/services/defs/event_tracking_lifecycle_defs.h>
-
 #include <string_view>
 
 namespace audit_log_filter::log_record_formatter {
@@ -65,24 +63,6 @@ class LogRecordFormatter<AuditLogFormatType::Json>
    */
   [[nodiscard]] AuditRecordString apply(
       const AuditRecordGlobalVariable &audit_record) const noexcept override;
-
-  /**
-   * @brief Apply formatting to AuditRecordServerStartup audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] AuditRecordString apply(
-      const AuditRecordServerStartup &audit_record) const noexcept override;
-
-  /**
-   * @brief Apply formatting to AuditRecordServerShutdown audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] AuditRecordString apply(
-      const AuditRecordServerShutdown &audit_record) const noexcept override;
 
   /**
    * @brief Apply formatting to AuditRecordCommand audit record.
@@ -265,24 +245,6 @@ class LogRecordFormatter<AuditLogFormatType::Json>
    * @return String representation of audit event subclass name
    */
   [[nodiscard]] std::string_view event_subclass_to_string(
-      const mysql_event_tracking_startup_data *event) const noexcept override;
-
-  /**
-   * @brief Get string representation of audit event subclass name.
-   *
-   * @param event Audit event
-   * @return String representation of audit event subclass name
-   */
-  [[nodiscard]] std::string_view event_subclass_to_string(
-      const mysql_event_tracking_shutdown_data *event) const noexcept override;
-
-  /**
-   * @brief Get string representation of audit event subclass name.
-   *
-   * @param event Audit event
-   * @return String representation of audit event subclass name
-   */
-  [[nodiscard]] std::string_view event_subclass_to_string(
       const mysql_event_tracking_stored_program_data *event)
       const noexcept override;
 
@@ -321,15 +283,6 @@ class LogRecordFormatter<AuditLogFormatType::Json>
    */
   [[nodiscard]] std::string_view connection_type_name_to_string(
       int connection_type) const noexcept override;
-
-  /**
-   * @brief Get string representation of shutdown reason.
-   *
-   * @param reason Shutdown reason
-   * @return String representation of shutdown reason
-   */
-  [[nodiscard]] std::string_view shutdown_reason_to_string(
-      mysql_event_tracking_shutdown_reason_t reason) const noexcept override;
 
   /**
    * @brief Get escape rules.

--- a/components/audit_log_filter/log_record_formatter/new.cc
+++ b/components/audit_log_filter/log_record_formatter/new.cc
@@ -134,53 +134,6 @@ AuditRecordString LogRecordFormatterNew::apply(
 }
 
 AuditRecordString LogRecordFormatterNew::apply(
-    const AuditRecordServerStartup &audit_record) const noexcept {
-  std::stringstream result;
-  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
-  std::stringstream startup_options;
-
-  for (unsigned int i = 0; i < audit_record.event->argc; ++i) {
-    if (audit_record.event->argv[i] != nullptr) {
-      startup_options << audit_record.event->argv[i] << " ";
-    }
-  }
-
-  std::string startup_options_str = startup_options.str();
-  startup_options_str.pop_back();
-
-  /* clang-format off */
-  result << "  <AUDIT_RECORD>\n"
-         << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
-         << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
-         << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
-         << "    <STARTUP_OPTIONS>" << make_escaped_string(startup_options_str) << "</STARTUP_OPTIONS>\n"
-         << "  </AUDIT_RECORD>\n";
-  /* clang-format on */
-
-  return result.str();
-}
-
-AuditRecordString LogRecordFormatterNew::apply(
-    const AuditRecordServerShutdown &audit_record) const noexcept {
-  std::stringstream result;
-  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
-
-  /* clang-format off */
-  result << "  <AUDIT_RECORD>\n"
-         << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
-         << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
-         << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
-         << "    <STATUS>" << audit_record.event->exit_code << "</STATUS>\n"
-         << "    <SHUTDOWN_REASON>" << shutdown_reason_to_string(audit_record.event->reason) << "</SHUTDOWN_REASON>\n"
-         << "  </AUDIT_RECORD>\n";
-  /* clang-format on */
-
-  return result.str();
-}
-
-AuditRecordString LogRecordFormatterNew::apply(
     const AuditRecordCommand &audit_record) const noexcept {
   std::stringstream result;
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();

--- a/components/audit_log_filter/log_record_formatter/new.h
+++ b/components/audit_log_filter/log_record_formatter/new.h
@@ -61,24 +61,6 @@ class LogRecordFormatter<AuditLogFormatType::New>
       const AuditRecordGlobalVariable &audit_record) const noexcept override;
 
   /**
-   * @brief Apply formatting to AuditRecordServerStartup audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] AuditRecordString apply(
-      const AuditRecordServerStartup &audit_record) const noexcept override;
-
-  /**
-   * @brief Apply formatting to AuditRecordServerShutdown audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] AuditRecordString apply(
-      const AuditRecordServerShutdown &audit_record) const noexcept override;
-
-  /**
    * @brief Apply formatting to AuditRecordCommand audit record.
    *
    * @param [in] audit_record Audit record

--- a/components/audit_log_filter/log_record_formatter/old.cc
+++ b/components/audit_log_filter/log_record_formatter/old.cc
@@ -125,51 +125,6 @@ AuditRecordString LogRecordFormatterOld::apply(
 }
 
 AuditRecordString LogRecordFormatterOld::apply(
-    const AuditRecordServerStartup &audit_record) const noexcept {
-  std::stringstream result;
-  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
-  std::stringstream startup_options;
-
-  for (unsigned int i = 0; i < audit_record.event->argc; ++i) {
-    if (audit_record.event->argv[i] != nullptr) {
-      startup_options << audit_record.event->argv[i] << " ";
-    }
-  }
-
-  std::string startup_options_str = startup_options.str();
-  startup_options_str.pop_back();
-
-  /* clang-format off */
-  result << "  <AUDIT_RECORD\n"
-         << "    NAME=\"" << event_subclass_to_string(audit_record.event) << "\"\n"
-         << "    RECORD_ID=\"" << make_record_id(tp) << "\"\n"
-         << "    TIMESTAMP=\"" << make_timestamp(tp) << "\"\n"
-         << "    COMMAND_CLASS=\"" << event_class_to_string(audit_record.event_class) << "\"\n"
-         << "    STARTUP_OPTIONS=\"" << make_escaped_string(startup_options_str) << "\"/>\n";
-  /* clang-format on */
-
-  return result.str();
-}
-
-AuditRecordString LogRecordFormatterOld::apply(
-    const AuditRecordServerShutdown &audit_record) const noexcept {
-  std::stringstream result;
-  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
-
-  /* clang-format off */
-  result << "  <AUDIT_RECORD\n"
-         << "    NAME=\"" << event_subclass_to_string(audit_record.event) << "\"\n"
-         << "    RECORD_ID=\"" << make_record_id(tp) << "\"\n"
-         << "    TIMESTAMP=\"" << make_timestamp(tp) << "\"\n"
-         << "    COMMAND_CLASS=\"" << event_class_to_string(audit_record.event_class) << "\"\n"
-         << "    STATUS=\"" << audit_record.event->exit_code << "\"\n"
-         << "    SHUTDOWN_REASON=\"" << shutdown_reason_to_string(audit_record.event->reason) << "\"/>\n";
-  /* clang-format on */
-
-  return result.str();
-}
-
-AuditRecordString LogRecordFormatterOld::apply(
     const AuditRecordCommand &audit_record) const noexcept {
   std::stringstream result;
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();

--- a/components/audit_log_filter/log_record_formatter/old.h
+++ b/components/audit_log_filter/log_record_formatter/old.h
@@ -61,24 +61,6 @@ class LogRecordFormatter<AuditLogFormatType::Old>
       const AuditRecordGlobalVariable &audit_record) const noexcept override;
 
   /**
-   * @brief Apply formatting to AuditRecordServerStartup audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] AuditRecordString apply(
-      const AuditRecordServerStartup &audit_record) const noexcept override;
-
-  /**
-   * @brief Apply formatting to AuditRecordServerShutdown audit record.
-   *
-   * @param [in] audit_record Audit record
-   * @return String representing formatted audit record
-   */
-  [[nodiscard]] AuditRecordString apply(
-      const AuditRecordServerShutdown &audit_record) const noexcept override;
-
-  /**
    * @brief Apply formatting to AuditRecordCommand audit record.
    *
    * @param [in] audit_record Audit record

--- a/components/audit_log_filter/log_writer/file_writer_buffering.cc
+++ b/components/audit_log_filter/log_writer/file_writer_buffering.cc
@@ -112,7 +112,8 @@ void FileWriterBuffering::shutdown() noexcept {
 
 void FileWriterBuffering::pause() noexcept {
   mysql_mutex_lock(&m_mutex);
-  while (m_state == FileBufferState::INCOMPLETE) {
+  while (m_flush_pos != m_write_pos) {
+    mysql_cond_signal(&m_written_cond);
     mysql_cond_wait(&m_flushed_cond, &m_mutex);
   }
 }

--- a/mysql-test/suite/component_audit_log_filter/r/status_var_buffer_bypassing_writes.result
+++ b/mysql-test/suite/component_audit_log_filter/r/status_var_buffer_bypassing_writes.result
@@ -10,5 +10,6 @@ Audit_log_filter_direct_writes	0
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_direct_writes';
 Variable_name	Value
 Audit_log_filter_direct_writes	2
+File format Ok
 #
 # Cleanup

--- a/mysql-test/suite/component_audit_log_filter/t/generate_audit_events.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/generate_audit_events.inc
@@ -54,7 +54,6 @@ connection default;
 DROP USER user1;
 --source include/wait_until_count_sessions.inc
 
-# AuditRecordServerShutdown
 #--source include/restart_mysqld.inc
 
 --enable_query_log

--- a/mysql-test/suite/component_audit_log_filter/t/status_var_buffer_bypassing_writes.test
+++ b/mysql-test/suite/component_audit_log_filter/t/status_var_buffer_bypassing_writes.test
@@ -15,6 +15,12 @@ SELECT "4IHYyOZMEAUJcURiOO9nLoceKvbRi3HSZZObmonjTjv4IHYyOZMEAUJcURiOO9nLoceKvbRi
 
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_direct_writes';
 
+--let $audit_filter_log_check_one = `SELECT audit_log_rotate()`
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let $audit_filter_log_format = xml
+--source validate_logs_format.inc
+
 --echo #
 --echo # Cleanup
 --source ../inc/audit_comp_uninstall.inc


### PR DESCRIPTION
### 1. Ignore audit lifecycle startup and shutdown events

The audit log filter already treats `server_startup` and `server_shutdown` as
unsupported filter-definition classes, so keeping dedicated runtime record and
formatter support for those lifecycle callbacks only preserved dead code and
inconsistent behavior. Ignore those lifecycle events when they are received and
keep the filter pipeline focused on supported audit records.

Behavior:
- return early for lifecycle startup and shutdown notifications in
  `AuditLogFilter::notify_event()`
- make `get_audit_record()` return `std::nullopt` for ignored lifecycle event
  classes while preserving internal audit start and stop events
- update the callers that materialize audit records so they handle optional
  results safely

Cleanup:
- remove startup and shutdown record structs, field extraction, and formatter
  overloads from the old, new, and JSON output paths
- drop the lifecycle-specific formatter helpers and string mappings that were
  only used by the removed record types
- update docs and test comments so they describe these lifecycle events as
  unsupported or ignored instead of emitted audit records

### 2. Drain async buffer before direct writes in audit log

When an audit record exceeds the async write buffer size, pause() must
flush all pending buffered data before allowing the oversized record to
bypass the buffer. Previously pause() only waited for an in-progress
wraparound flush to finish but did not drain queued data, so earlier
writes (e.g. the XML header) could end up in the file after the direct
write.

Extend the regression test to rotate the log and validate XML format.