### PR TITLE
PS-10853 [8.4]: Harden noexcept functions against throwing std::filesystem APIs

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -639,10 +639,12 @@ void AuditLogFilter::on_audit_log_rotate_requested(
 void AuditLogFilter::on_encryption_password_prune_requested() noexcept {
   if (m_is_active && SysVars::get_password_history_keep_days() > 0 &&
       audit_keyring::check_keyring_initialized()) {
-    audit_keyring::prune_encryption_options(
-        SysVars::get_password_history_keep_days(),
-        log_writer::FileHandle::get_log_names_list(SysVars::get_file_dir(),
-                                                   SysVars::get_file_name()));
+    std::vector<std::string> log_names;
+    if (log_writer::FileHandle::get_log_names_list(
+            SysVars::get_file_dir(), SysVars::get_file_name(), log_names)) {
+      audit_keyring::prune_encryption_options(
+          SysVars::get_password_history_keep_days(), log_names);
+    }
   }
 }
 

--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -15,6 +15,7 @@
 
 #include "components/audit_log_filter/audit_log_reader.h"
 
+#include "components/audit_log_filter/audit_error_log.h"
 #include "components/audit_log_filter/audit_keyring.h"
 #include "components/audit_log_filter/audit_psi_info.h"
 
@@ -70,8 +71,6 @@ bool AuditLogReader::init() noexcept {
     return true;
   }
 
-  m_reload_requested = false;
-
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
       "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
@@ -96,18 +95,38 @@ bool AuditLogReader::init() noexcept {
   }
 
   std::vector<std::string> all_files;
-  std::vector<std::string> new_files;
-  std::vector<std::string> removed_files;
+  bool have_complete_file_snapshot = true;
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator{SysVars::get_file_dir()}) {
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator{SysVars::get_file_dir(), ec};
+
+  if (ec) {
+    return false;
+  }
+
+  const auto end = std::filesystem::directory_iterator{};
+
+  while (it != end) {
+    const auto &entry = *it;
     auto log_name = entry.path().filename().string();
 
-    if (entry.is_regular_file() &&
+    std::error_code entry_ec;
+    if (entry.is_regular_file(entry_ec) && !entry_ec &&
         log_name.find(log_base_file_name) != std::string::npos) {
       all_files.push_back(std::move(log_name));
+    } else if (entry_ec) {
+      have_complete_file_snapshot = false;
+    }
+
+    it.increment(ec);
+    if (ec) {
+      have_complete_file_snapshot = false;
+      break;
     }
   }
+
+  std::vector<std::string> new_files;
+  std::vector<std::string> removed_files;
 
   std::copy_if(std::cbegin(all_files), std::cend(all_files),
                std::back_inserter(new_files), [this](const auto &name) {
@@ -118,16 +137,19 @@ bool AuditLogReader::init() noexcept {
                                      });
                });
 
-  std::for_each(std::cbegin(m_timestamp_to_file_map),
-                std::cend(m_timestamp_to_file_map),
-                [&all_files, &removed_files](const auto &pair) {
-                  if (!std::any_of(std::cbegin(all_files), std::cend(all_files),
-                                   [&pair](const auto &name) {
-                                     return name == pair.second->name;
-                                   })) {
-                    removed_files.push_back(pair.second->name);
-                  }
-                });
+  if (have_complete_file_snapshot) {
+    std::for_each(
+        std::cbegin(m_timestamp_to_file_map),
+        std::cend(m_timestamp_to_file_map),
+        [&all_files, &removed_files](const auto &pair) {
+          if (!std::any_of(std::cbegin(all_files), std::cend(all_files),
+                           [&pair](const auto &name) {
+                             return name == pair.second->name;
+                           })) {
+            removed_files.push_back(pair.second->name);
+          }
+        });
+  }
 
   for (const auto &log_name : new_files) {
     bool is_current_log =
@@ -182,8 +204,18 @@ bool AuditLogReader::init() noexcept {
     file_info->first_timestamp =
         first_event->GetObject()["timestamp"].GetString();
 
-    m_timestamp_to_file_map.emplace(LogFileTimestamp(log_name),
-                                    std::move(file_info));
+    try {
+      auto ts = LogFileTimestamp(log_name);
+      m_timestamp_to_file_map.emplace(std::move(ts), std::move(file_info));
+    } catch (const std::exception &e) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Skipping audit log file with unparseable name '%s': %s",
+                      log_name.c_str(), e.what());
+    } catch (...) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Skipping audit log file with unparseable name '%s'",
+                      log_name.c_str());
+    }
   }
 
   for (const auto &log_name : removed_files) {
@@ -197,6 +229,7 @@ bool AuditLogReader::init() noexcept {
     }
   }
 
+  m_reload_requested = false;
   return true;
 }
 

--- a/components/audit_log_filter/log_file_timestamp.cc
+++ b/components/audit_log_filter/log_file_timestamp.cc
@@ -27,27 +27,39 @@ LogFileTimestamp::LogFileTimestamp(const std::filesystem::path &path) {
   //    with rotation or encryption key timestamp.
   static const std::regex pattern(
       R"(^.*?\.(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(-(\d+))?(\.enc)?.*)");
-
-  auto filename = path.filename().string();
+  std::string filename;
   std::smatch match;
-  if (!std::regex_match(filename, match, pattern) || match[9].length() != 0) {
-    // If we weren't able to find any timestamp, or we were able to find
-    // only timestamp of an encryption key, we create empty (non-rotated)
-    // timestamp.
+
+  try {
+    filename = path.filename().string();
+    if (!std::regex_match(filename, match, pattern)) return;
+  } catch (...) {
     return;
   }
 
-  std::tm tm = {};
-  tm.tm_year = std::stoi(match[1]) - 1900;
-  tm.tm_mon = std::stoi(match[2]) - 1;
-  tm.tm_mday = std::stoi(match[3]);
-  tm.tm_hour = std::stoi(match[4]);
-  tm.tm_min = std::stoi(match[5]);
-  tm.tm_sec = std::stoi(match[6]);
-  tm.tm_isdst = -1;
+  if (match[9].length() != 0) {
+    // Only an encryption key timestamp, not a rotation timestamp.
+    return;
+  }
 
-  timestamp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-  seq = match[8].length() != 0 ? std::stoul(match[8]) : 0;
+  // Regex matched, so the file IS rotated.  If value conversion fails
+  // below, use epoch as a sentinel so is_rotated() still returns true.
+  try {
+    std::tm tm = {};
+    tm.tm_year = std::stoi(match[1]) - 1900;
+    tm.tm_mon = std::stoi(match[2]) - 1;
+    tm.tm_mday = std::stoi(match[3]);
+    tm.tm_hour = std::stoi(match[4]);
+    tm.tm_min = std::stoi(match[5]);
+    tm.tm_sec = std::stoi(match[6]);
+    tm.tm_isdst = -1;
+
+    timestamp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+    seq = match[8].length() != 0 ? std::stoul(match[8]) : 0;
+  } catch (...) {
+    timestamp = std::chrono::system_clock::time_point{};
+    seq = 0;
+  }
 }
 
 bool operator<(const LogFileTimestamp &lhs,

--- a/components/audit_log_filter/log_file_timestamp.h
+++ b/components/audit_log_filter/log_file_timestamp.h
@@ -32,6 +32,7 @@ namespace audit_log_filter {
  * - rotated files with timestamp collisions (seq != 0)
  */
 struct LogFileTimestamp {
+  LogFileTimestamp() = default;
   LogFileTimestamp(const std::filesystem::path &path);
 
   friend bool operator<(const LogFileTimestamp &lhs,

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -145,11 +145,26 @@ bool LogWriterFile::do_open_file() noexcept {
     file_path += suffix.str();
   }
 
-  bool is_new_file = !std::filesystem::exists(file_path);
+  std::error_code ec;
+  const bool file_exists = std::filesystem::exists(file_path, ec);
+  if (ec) {
+    const auto file_path_str = file_path.string();
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to inspect audit filter log path '%s': %s",
+                    file_path_str.c_str(), ec.message().c_str());
+    return false;
+  }
+  bool is_new_file = !file_exists;
 
   if (!is_new_file) {
-    FileHandle::remove_file_footer(file_path,
-                                   get_formatter()->get_file_footer());
+    if (!FileHandle::remove_file_footer(file_path,
+                                        get_formatter()->get_file_footer())) {
+      const auto file_path_str = file_path.string();
+      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to prepare audit filter log '%s' for appending",
+                      file_path_str.c_str());
+      return false;
+    }
   }
 
   if (!m_file_handle.open_file(file_path)) {

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -175,8 +175,11 @@ bool LogWriterFile::do_open_file() noexcept {
     return false;
   }
 
-  SysVars::set_total_log_size(FileHandle::get_total_log_size(
-      SysVars::get_file_dir(), SysVars::get_file_name()));
+  uint64_t total_size = 0;
+  if (FileHandle::get_total_log_size(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), total_size)) {
+    SysVars::set_total_log_size(total_size);
+  }
   SysVars::set_current_log_size(get_log_size());
 
   init_formatter();
@@ -275,8 +278,11 @@ void LogWriterFile::prune() noexcept {
   const auto prune_seconds = SysVars::get_log_prune_seconds();
 
   if (log_max_size > 0) {
-    auto log_file_list = FileHandle::get_prune_files(SysVars::get_file_dir(),
-                                                     SysVars::get_file_name());
+    PruneFilesList log_file_list;
+    if (!FileHandle::get_prune_files(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), log_file_list)) {
+      return;
+    }
 
     ulonglong current_logs_size = std::accumulate(
         log_file_list.begin(), log_file_list.end(), ulonglong{0},
@@ -306,8 +312,11 @@ void LogWriterFile::prune() noexcept {
       file_queue.pop();
     }
   } else if (prune_seconds > 0) {
-    auto log_file_list = FileHandle::get_prune_files(SysVars::get_file_dir(),
-                                                     SysVars::get_file_name());
+    PruneFilesList log_file_list;
+    if (!FileHandle::get_prune_files(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), log_file_list)) {
+      return;
+    }
 
     for (const auto &entry : log_file_list) {
       if (entry.age > std::chrono::seconds(prune_seconds)) {
@@ -316,8 +325,11 @@ void LogWriterFile::prune() noexcept {
     }
   }
 
-  SysVars::set_total_log_size(FileHandle::get_total_log_size(
-      SysVars::get_file_dir(), SysVars::get_file_name()));
+  uint64_t total_size = 0;
+  if (FileHandle::get_total_log_size(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), total_size)) {
+    SysVars::set_total_log_size(total_size);
+  }
 }
 
 }  // namespace audit_log_filter::log_writer

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -118,9 +118,10 @@ std::filesystem::path FileHandle::get_not_rotated_file_path(
     LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
                     "Failed to list audit log directory '%s': %s",
                     working_dir_name.c_str(), ec.message().c_str());
+    return {};
   }
 
-  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+  while (it != std::filesystem::directory_iterator{}) {
     const auto &entry = *it;
     std::error_code entry_ec;
     if (entry.is_regular_file(entry_ec) && !entry_ec &&
@@ -129,20 +130,30 @@ std::filesystem::path FileHandle::get_not_rotated_file_path(
         !FileName::from_path(entry.path().filename()).is_rotated()) {
       return entry.path();
     }
+
+    it.increment(ec);
+    if (ec) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to iterate audit log directory '%s': %s",
+                      working_dir_name.c_str(), ec.message().c_str());
+      return {};
+    }
   }
 
   return {};
 }
 
-uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
-                                        const std::string &file_name) noexcept {
+bool FileHandle::get_total_log_size(const std::string &working_dir_name,
+                                    const std::string &file_name,
+                                    uint64_t &total_size) noexcept {
+  total_size = 0;
   auto base_name = std::filesystem::path{file_name}.filename();
   while (base_name.has_extension()) {
     base_name.replace_extension();
   }
 
   if (base_name.empty()) {
-    return 0;
+    return true;
   }
 
   uint64_t size = 0;
@@ -153,9 +164,10 @@ uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
     LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
                     "Failed to list audit log directory '%s': %s",
                     working_dir_name.c_str(), ec.message().c_str());
+    return false;
   }
 
-  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+  while (it != std::filesystem::directory_iterator{}) {
     const auto &entry = *it;
     auto entry_file_name = entry.path().filename();
 
@@ -171,9 +183,18 @@ uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
         size += fsize;
       }
     }
+
+    it.increment(ec);
+    if (ec) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to iterate audit log directory '%s': %s",
+                      working_dir_name.c_str(), ec.message().c_str());
+      return false;
+    }
   }
 
-  return size;
+  total_size = size;
+  return true;
 }
 
 bool FileHandle::remove_file(const std::filesystem::path &path) noexcept {
@@ -306,15 +327,15 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
   }
 }
 
-PruneFilesList FileHandle::get_prune_files(
-    const std::string &working_dir_name,
-    const std::string &file_name) noexcept {
-  PruneFilesList prune_files;
+bool FileHandle::get_prune_files(const std::string &working_dir_name,
+                                 const std::string &file_name,
+                                 PruneFilesList &prune_files) noexcept {
+  prune_files.clear();
 
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
 
   if (base_file_name.empty()) {
-    return prune_files;
+    return true;
   }
 
   auto time_now = std::chrono::system_clock::now();
@@ -333,9 +354,10 @@ PruneFilesList FileHandle::get_prune_files(
     LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
                     "Failed to list audit log directory '%s': %s",
                     working_dir_name.c_str(), ec.message().c_str());
+    return false;
   }
 
-  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+  while (it != std::filesystem::directory_iterator{}) {
     const auto &entry = *it;
     std::error_code entry_ec;
     if (entry.is_regular_file(entry_ec) && !entry_ec &&
@@ -351,21 +373,29 @@ PruneFilesList FileHandle::get_prune_files(
         }
       }
     }
+
+    it.increment(ec);
+    if (ec) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to iterate audit log directory '%s': %s",
+                      working_dir_name.c_str(), ec.message().c_str());
+      return false;
+    }
   }
 
-  return prune_files;
+  return true;
 }
 
-std::vector<std::string> FileHandle::get_log_names_list(
-    const std::string &working_dir_name,
-    const std::string &file_name) noexcept {
-  std::vector<std::string> list;
+bool FileHandle::get_log_names_list(
+    const std::string &working_dir_name, const std::string &file_name,
+    std::vector<std::string> &log_names) noexcept {
+  log_names.clear();
 
   auto base_file_name =
       std::filesystem::path{file_name}.replace_extension().string();
 
   if (base_file_name.empty()) {
-    return list;
+    return true;
   }
 
   std::error_code ec;
@@ -375,20 +405,29 @@ std::vector<std::string> FileHandle::get_log_names_list(
     LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
                     "Failed to list audit log directory '%s': %s",
                     working_dir_name.c_str(), ec.message().c_str());
+    return false;
   }
 
-  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+  while (it != std::filesystem::directory_iterator{}) {
     const auto &entry = *it;
     const auto name = entry.path().filename().string();
 
     std::error_code entry_ec;
     if (entry.is_regular_file(entry_ec) && !entry_ec &&
         name.find(base_file_name) != std::string::npos) {
-      list.push_back(name);
+      log_names.push_back(name);
+    }
+
+    it.increment(ec);
+    if (ec) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to iterate audit log directory '%s': %s",
+                      working_dir_name.c_str(), ec.message().c_str());
+      return false;
     }
   }
 
-  return list;
+  return true;
 }
 
 }  // namespace audit_log_filter::log_writer

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -14,6 +14,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
 #include "components/audit_log_filter/log_writer/file_handle.h"
+#include "components/audit_log_filter/audit_error_log.h"
 #include "components/audit_log_filter/audit_psi_info.h"
 #include "components/audit_log_filter/log_writer/file_name.h"
 #include "components/audit_log_filter/sys_vars.h"
@@ -86,11 +87,9 @@ void FileHandle::write_file(const char *record, const size_t size) noexcept {
 
 uint64_t FileHandle::get_file_size() const noexcept {
   assert(m_file.is_open());
-  try {
-    return std::filesystem::file_size(m_path);
-  } catch (const std::filesystem::filesystem_error &) {
-    return 0;
-  }
+  std::error_code ec;
+  auto size = std::filesystem::file_size(m_path, ec);
+  return ec ? 0 : size;
 }
 
 std::filesystem::path FileHandle::get_file_path() const noexcept {
@@ -108,9 +107,23 @@ std::filesystem::path FileHandle::get_not_rotated_file_path(
     const std::string &file_name) noexcept {
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator(working_dir_name)) {
-    if (entry.is_regular_file() &&
+  if (base_file_name.empty()) {
+    return {};
+  }
+
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator(working_dir_name, ec);
+
+  if (ec) {
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit log directory '%s': %s",
+                    working_dir_name.c_str(), ec.message().c_str());
+  }
+
+  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto &entry = *it;
+    std::error_code entry_ec;
+    if (entry.is_regular_file(entry_ec) && !entry_ec &&
         entry.path().filename().string().find(base_file_name) !=
             std::string::npos &&
         !FileName::from_path(entry.path().filename()).is_rotated()) {
@@ -128,18 +141,35 @@ uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
     base_name.replace_extension();
   }
 
-  uint64_t size = 0;
+  if (base_name.empty()) {
+    return 0;
+  }
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator(working_dir_name)) {
+  uint64_t size = 0;
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator(working_dir_name, ec);
+
+  if (ec) {
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit log directory '%s': %s",
+                    working_dir_name.c_str(), ec.message().c_str());
+  }
+
+  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto &entry = *it;
     auto entry_file_name = entry.path().filename();
 
     while (entry_file_name.has_extension()) {
       entry_file_name.replace_extension();
     }
 
-    if (entry.is_regular_file() && entry_file_name == base_name) {
-      size += entry.file_size();
+    std::error_code entry_ec;
+    if (entry.is_regular_file(entry_ec) && !entry_ec &&
+        entry_file_name == base_name) {
+      auto fsize = entry.file_size(entry_ec);
+      if (!entry_ec) {
+        size += fsize;
+      }
     }
   }
 
@@ -151,7 +181,7 @@ bool FileHandle::remove_file(const std::filesystem::path &path) noexcept {
   return std::filesystem::remove(path, ec);
 }
 
-void FileHandle::remove_file_footer(
+bool FileHandle::remove_file_footer(
     const std::filesystem::path &file_path,
     const std::string &expected_footer) noexcept {
   assert(expected_footer.length() > 0);
@@ -160,14 +190,14 @@ void FileHandle::remove_file_footer(
   file.open(file_path, std::ios::in);
 
   if (!file.is_open()) {
-    return;
+    return false;
   }
 
   file.seekg(-expected_footer.length(), std::ios_base::end);
 
   if (file.fail()) {
     file.close();
-    return;
+    return true;
   }
 
   std::string file_footer;
@@ -175,7 +205,7 @@ void FileHandle::remove_file_footer(
 
   if (file.fail()) {
     file.close();
-    return;
+    return true;
   }
 
   file.close();
@@ -184,17 +214,35 @@ void FileHandle::remove_file_footer(
     file_footer.push_back('\n');
   }
 
-  if (expected_footer == file_footer) {
-    std::filesystem::resize_file(
-        file_path,
-        std::filesystem::file_size(file_path) - expected_footer.size());
+  if (expected_footer != file_footer) {
+    return true;
   }
+
+  std::error_code ec;
+  auto current_size = std::filesystem::file_size(file_path, ec);
+  if (!ec && current_size >= expected_footer.size()) {
+    std::filesystem::resize_file(file_path,
+                                 current_size - expected_footer.size(), ec);
+  }
+  if (ec) {
+    const auto path_str = file_path.string();
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to remove footer from audit log '%s': %s",
+                    path_str.c_str(), ec.message().c_str());
+    return false;
+  }
+
+  return true;
 }
 
 void FileHandle::rotate(const std::filesystem::path &current_file_path,
                         FileRotationResult *result) noexcept {
-  if (!std::filesystem::exists(current_file_path)) {
-    result->error_code = 0;
+  std::error_code ec;
+  if (!std::filesystem::exists(current_file_path, ec)) {
+    result->error_code = ec.value();
+    if (ec) {
+      result->status_string = ec.message();
+    }
     return;
   }
 
@@ -219,7 +267,6 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
     extensions_str = filename_str.substr(first_ext_pos);
   }
 
-  std::error_code ec;
   std::filesystem::path new_file_path;
   std::string new_file_name_str;
   std::size_t seq = 0;
@@ -242,6 +289,12 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
     new_file_path.replace_filename(new_file_name_str);
   } while (std::filesystem::exists(new_file_path, ec));
 
+  if (ec) {
+    result->error_code = ec.value();
+    result->status_string = ec.message();
+    return;
+  }
+
   std::filesystem::rename(current_file_path, new_file_path, ec);
 
   result->error_code = ec.value();
@@ -257,7 +310,13 @@ PruneFilesList FileHandle::get_prune_files(
     const std::string &working_dir_name,
     const std::string &file_name) noexcept {
   PruneFilesList prune_files;
+
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
+
+  if (base_file_name.empty()) {
+    return prune_files;
+  }
+
   auto time_now = std::chrono::system_clock::now();
 
   DBUG_EXECUTE_IF("audit_log_filter_debug_timestamp", {
@@ -267,16 +326,29 @@ PruneFilesList FileHandle::get_prune_files(
     time_now = SysVars::get_debug_time_point_for_rotation();
   });
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator{working_dir_name}) {
-    if (entry.is_regular_file() && entry.path().filename().string().find(
-                                       base_file_name) != std::string::npos) {
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator{working_dir_name, ec};
+
+  if (ec) {
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit log directory '%s': %s",
+                    working_dir_name.c_str(), ec.message().c_str());
+  }
+
+  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto &entry = *it;
+    std::error_code entry_ec;
+    if (entry.is_regular_file(entry_ec) && !entry_ec &&
+        entry.path().filename().string().find(base_file_name) !=
+            std::string::npos) {
       auto parsed_file_name = FileName::from_path(entry.path().filename());
 
       if (parsed_file_name.is_rotated()) {
         auto timestamp = parsed_file_name.get_rotation_time().timestamp.value();
-        prune_files.push_back(
-            {entry.path(), entry.file_size(), time_now - timestamp});
+        auto fsize = entry.file_size(entry_ec);
+        if (!entry_ec) {
+          prune_files.push_back({entry.path(), fsize, time_now - timestamp});
+        }
       }
     }
   }
@@ -288,14 +360,29 @@ std::vector<std::string> FileHandle::get_log_names_list(
     const std::string &working_dir_name,
     const std::string &file_name) noexcept {
   std::vector<std::string> list;
+
   auto base_file_name =
       std::filesystem::path{file_name}.replace_extension().string();
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator{working_dir_name}) {
+  if (base_file_name.empty()) {
+    return list;
+  }
+
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator{working_dir_name, ec};
+
+  if (ec) {
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit log directory '%s': %s",
+                    working_dir_name.c_str(), ec.message().c_str());
+  }
+
+  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto &entry = *it;
     const auto name = entry.path().filename().string();
 
-    if (entry.is_regular_file() &&
+    std::error_code entry_ec;
+    if (entry.is_regular_file(entry_ec) && !entry_ec &&
         name.find(base_file_name) != std::string::npos) {
       list.push_back(name);
     }

--- a/components/audit_log_filter/log_writer/file_handle.h
+++ b/components/audit_log_filter/log_writer/file_handle.h
@@ -106,9 +106,11 @@ class FileHandle {
    *
    * @param file_path File path
    * @param expected_footer Expected log footer
+   * @return true if footer was removed or was not present, false on I/O error
    */
-  static void remove_file_footer(const std::filesystem::path &file_path,
-                                 const std::string &expected_footer) noexcept;
+  [[nodiscard]] static bool remove_file_footer(
+      const std::filesystem::path &file_path,
+      const std::string &expected_footer) noexcept;
 
   /**
    * @brief Rotate file.

--- a/components/audit_log_filter/log_writer/file_handle.h
+++ b/components/audit_log_filter/log_writer/file_handle.h
@@ -95,11 +95,12 @@ class FileHandle {
    *
    * @param working_dir_name Working directory name
    * @param file_name Log file name
-   * @return Total logs size in bytes
+   * @param[out] total_size Total logs size in bytes
+   * @return true on success, false on directory iteration error
    */
-  [[nodiscard]] static uint64_t get_total_log_size(
-      const std::string &working_dir_name,
-      const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_total_log_size(
+      const std::string &working_dir_name, const std::string &file_name,
+      uint64_t &total_size) noexcept;
 
   /**
    * @brief Remove log footer from the end of a file.
@@ -126,10 +127,12 @@ class FileHandle {
    *
    * @param working_dir_name Working directory name
    * @param file_name File name
-   * @return List of rotated log files
+   * @param[out] prune_files List of rotated log files
+   * @return true on success, false on directory iteration error
    */
-  static PruneFilesList get_prune_files(const std::string &working_dir_name,
-                                        const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_prune_files(
+      const std::string &working_dir_name, const std::string &file_name,
+      PruneFilesList &prune_files) noexcept;
 
   /**
    * @brief Remove a file.
@@ -155,11 +158,12 @@ class FileHandle {
    *
    * @param working_dir_name Working directory name
    * @param file_name Base file name
-   * @return List of audit log file names
+   * @param[out] log_names List of audit log file names
+   * @return true on success, false on directory iteration error
    */
-  static std::vector<std::string> get_log_names_list(
-      const std::string &working_dir_name,
-      const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_log_names_list(
+      const std::string &working_dir_name, const std::string &file_name,
+      std::vector<std::string> &log_names) noexcept;
 
  private:
   std::fstream m_file;

--- a/components/audit_log_filter/log_writer/file_name.cc
+++ b/components/audit_log_filter/log_writer/file_name.cc
@@ -22,7 +22,6 @@ namespace audit_log_filter::log_writer {
 FileName FileName::from_path(std::filesystem::path filename) noexcept {
   bool is_compressed{false};
   bool is_encrypted{false};
-
   std::string key_id_str;
 
   if (filename.has_extension() && filename.extension().compare(".enc") == 0) {

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -823,8 +823,9 @@ bool SysVars::validate() noexcept {
 
   // Check if log file directory points to a valid file system directory or if
   // it is left at the default setting (empty).
+  std::error_code ec;
   if (!SysVars::get_file_dir().empty() &&
-      !std::filesystem::is_directory(SysVars::get_file_dir())) {
+      !std::filesystem::is_directory(SysVars::get_file_dir(), ec)) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY,
                     SysVars::get_file_dir().c_str());
     return false;


### PR DESCRIPTION
### 1. Harden noexcept functions against throwing std::filesystem APIs

Multiple noexcept functions in the audit_log_filter component call
std::filesystem APIs that may throw std::filesystem::filesystem_error,
which would result in std::terminate. This patch replaces all such call
sites with their std::error_code overloads and adds try/catch guards
where ec overloads are not available:

- directory_iterator is constructed with the ec overload so an
  unopenable directory produces an end-iterator instead of throwing.
- Iteration uses directory_iterator::increment(ec) instead of
  operator++ to avoid the only remaining throwing path.
- Per-entry operations (directory_entry::is_regular_file,
  directory_entry::file_size) use their ec overloads so a single bad
  entry is skipped without aborting the entire loop.
- Standalone filesystem calls (exists, is_directory, file_size,
  resize_file) are switched to their std::error_code overloads.
- Directory scanning functions add an early return when the base file
  name is empty, avoiding a needless directory walk.
- Warning-level messages are logged when directory construction or
  per-entry filesystem operations fail.

file_handle.cc:
  - get_file_size: replace try/catch with file_size(path, ec) overload
  - get_not_rotated_file_path: ec overloads for directory_iterator,
    increment, is_regular_file; early return on empty base name
  - get_total_log_size: ec overloads for directory_iterator, increment,
    is_regular_file, file_size; early return on empty base name
  - remove_file_footer: change return type from void to [[nodiscard]]
    bool (false on I/O error, true otherwise); replace throwing
    file_size and resize_file with ec overloads
  - rotate: ec overload for exists at entry and in the do-while loop;
    propagate filesystem errors through the FileRotationResult output
    parameter
  - get_prune_files: ec overloads for directory_iterator, increment,
    is_regular_file, file_size; early return on empty base name
  - get_log_names_list: ec overloads for directory_iterator, increment,
    is_regular_file; early return on empty base name

file.cc:
  - do_open_file: ec overload for exists; check remove_file_footer
    return value and abort open on failure

log_file_timestamp.cc:
  - constructor: wrap std::regex_match in try/catch so a malformed
    filename does not throw; wrap std::stoi/std::stoul value
    conversions in a separate try/catch, using epoch as a sentinel
    so is_rotated() still returns true for matched-but-unparseable
    timestamps

log_file_timestamp.h:
  - add default constructor so callers can construct a safe default
    in catch blocks

audit_log_reader.cc:
  - init: ec overloads for directory_iterator, increment,
    is_regular_file in the file-listing loop; track
    have_complete_file_snapshot flag so an incomplete directory scan
    skips the removed-files detection (avoids deleting valid entries
    from the timestamp map); try/catch around LogFileTimestamp
    construction to skip individual files with unparseable names;
    move m_reload_requested = false to the end so it is only cleared
    on successful completion

sys_vars.cc:
  - validate: ec overload for is_directory

### 2. Return errors for incomplete directory scan in audit log filter

get_log_names_list(), get_prune_files(), and get_total_log_size() silently
returned partial results when directory iteration hit an error, because the
for-loop called it.increment(ec) in the loop header without checking ec
afterwards. Callers treated these incomplete results as authoritative, which
could lead to incorrect pruning decisions or stale total-size reporting.

Changes in FileHandle (file_handle.h / file_handle.cc):

- Change return types of get_total_log_size(), get_prune_files(), and
  get_log_names_list() from returning their result directly to returning
  bool (true on success), with the result passed via an output reference
  parameter instead.

- Add [[nodiscard]] to all three functions so callers cannot silently
  ignore the success/failure indication.

- Replace for-loops with while-loops that call it.increment(ec) at the
  end of the loop body, checking ec after each increment and returning
  false with a warning log on failure.

- Return early (with failure) when the initial directory_iterator
  construction fails, instead of falling through into the loop. Apply
  the same fix to get_not_rotated_file_path().

Changes in callers (audit_log_filter.cc, file.cc):

- on_encryption_password_prune_requested(): only call
  prune_encryption_options() when get_log_names_list() succeeds.

- do_open_file(): only call set_total_log_size() when
  get_total_log_size() succeeds.

- prune(): early-return from both the max-size and prune-seconds
  branches when get_prune_files() fails; only update total log size
  when get_total_log_size() succeeds
  