### PR TITLE
PS-10083-[8.4] Add more statistics for threadpool

### DIFF
--- a/mysql-test/suite/percona/r/threadpool_stats.result
+++ b/mysql-test/suite/percona/r/threadpool_stats.result
@@ -1,0 +1,52 @@
+#
+# Test Threadpool statistics display, no attempt to create a high load
+#
+DROP TABLE IF EXISTS t1;
+# Create test table and data
+CREATE TABLE t1 (id INT PRIMARY KEY, val CHAR(10)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1,'a'), (2,'b'), (3,'c'), (4,'d'), (5,'e');
+# Show initial threadpool status
+SHOW STATUS LIKE 'Threadpool_%';
+Variable_name	Value
+Threadpool_average_hp_queue_wait_us	<value>
+Threadpool_average_queue_wait_us	<value>
+Threadpool_idle_threads	<value>
+Threadpool_requests_starved_in_queue	<value>
+Threadpool_requests_waiting_in_hp_queue	<value>
+Threadpool_requests_waiting_in_queue	<value>
+Threadpool_threads	<value>
+include/assert.inc [Threadpool_threads should be greater than 0 initially.]
+# Establish connections
+# Connection 1: Start transaction and lock a row
+BEGIN;
+SELECT * FROM t1 WHERE id=1 FOR UPDATE;
+id	val
+1	a
+# Connection 2: Attempt to update locked row (will block)
+UPDATE t1 SET val='Con2' WHERE id=1;
+# Connection 3: Attempt to update locked row (will block)
+UPDATE t1 SET val='Con3' WHERE id=1;
+# Connection 4: Sleep (occupy thread if pool is small)
+SELECT SLEEP(2);
+# Wait a moment for threads to be busy/queued
+# Show threadpool status during activity
+SHOW STATUS LIKE 'Threadpool_%';
+Variable_name	Value
+Threadpool_average_hp_queue_wait_us	<value>
+Threadpool_average_queue_wait_us	<value>
+Threadpool_idle_threads	<value>
+Threadpool_requests_starved_in_queue	<value>
+Threadpool_requests_waiting_in_hp_queue	<value>
+Threadpool_requests_waiting_in_queue	<value>
+Threadpool_threads	<value>
+include/assert.inc [Threadpool_threads should be greater than 0 during activity.]
+# Unblock connections
+COMMIT;
+# Connection 1 committed
+# Connection 2 reaped
+# Connection 3 reaped
+SLEEP(2)
+0
+# Connection 4 reaped
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/percona/t/threadpool_stats-master.opt
+++ b/mysql-test/suite/percona/t/threadpool_stats-master.opt
@@ -1,0 +1,3 @@
+--thread-handling=pool-of-threads
+--thread-pool-size=4
+

--- a/mysql-test/suite/percona/t/threadpool_stats.test
+++ b/mysql-test/suite/percona/t/threadpool_stats.test
@@ -1,0 +1,88 @@
+--source include/have_pool_of_threads.inc
+--source include/count_sessions.inc
+
+--echo #
+--echo # Test Threadpool statistics display, no attempt to create a high load
+--echo #
+
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+--echo # Create test table and data
+CREATE TABLE t1 (id INT PRIMARY KEY, val CHAR(10)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1,'a'), (2,'b'), (3,'c'), (4,'d'), (5,'e');
+
+--echo # Show initial threadpool status
+--replace_column 2 <value>
+SHOW STATUS LIKE 'Threadpool_%';
+
+--let $assert_text= Threadpool_threads should be greater than 0 initially.
+--let $assert_cond= "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME=\"Threadpool_threads\"]" > 0
+--source include/assert.inc
+
+--echo # Establish connections
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+connect (con3,localhost,root,,);
+connect (con4,localhost,root,,);
+connect (con5,localhost,root,,);
+
+connection con1;
+--echo # Connection 1: Start transaction and lock a row
+BEGIN;
+SELECT * FROM t1 WHERE id=1 FOR UPDATE;
+
+connection con2;
+--echo # Connection 2: Attempt to update locked row (will block)
+--send UPDATE t1 SET val='Con2' WHERE id=1
+
+connection con3;
+--echo # Connection 3: Attempt to update locked row (will block)
+--send UPDATE t1 SET val='Con3' WHERE id=1
+
+connection con4;
+--echo # Connection 4: Sleep (occupy thread if pool is small)
+--send SELECT SLEEP(2)
+
+connection default;
+--echo # Wait a moment for threads to be busy/queued
+let $wait_condition= SELECT COUNT(*) >= 2 FROM information_schema.processlist WHERE INFO LIKE 'UPDATE t1%';
+--source include/wait_condition.inc
+
+--echo # Show threadpool status during activity
+--replace_column 2 <value>
+SHOW STATUS LIKE 'Threadpool_%';
+
+--let $assert_text= Threadpool_threads should be greater than 0 during activity.
+--let $assert_cond= "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME=\"Threadpool_threads\"]" > 0
+--source include/assert.inc
+
+--echo # Unblock connections
+connection con1;
+COMMIT;
+--echo # Connection 1 committed
+
+connection con2;
+--reap
+--echo # Connection 2 reaped
+
+connection con3;
+--reap
+--echo # Connection 3 reaped
+
+connection con4;
+--reap
+--echo # Connection 4 reaped
+
+connection default;
+--echo # Cleanup
+disconnect con1;
+disconnect con2;
+disconnect con3;
+disconnect con4;
+disconnect con5;
+
+DROP TABLE t1;
+--source include/wait_until_count_sessions.inc
+

--- a/sql-common/live_stats.h
+++ b/sql-common/live_stats.h
@@ -1,0 +1,105 @@
+/* Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef LIVE_STATS_H_INCLUDED
+#define LIVE_STATS_H_INCLUDED
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+/**
+Utility class which allows to gather basic statistics such as min, max, mean and
+variance for a population in incremental fashion (using Welford's online
+algorithm).
+*/
+
+class LiveStats {
+ public:
+  struct Stats {
+    int64_t count = 0;
+    double min = 0.0;
+    double max = 0.0;
+    double average = 0.0;
+    double deviation = 0.0;
+  };
+
+ private:
+  int64_t count = 0;
+  double c_min = 0.0, c_max = 0.0, m1 = 0.0, m2 = 0.0;
+
+ public:
+  LiveStats() = default;
+  LiveStats(const LiveStats &) = delete;
+  LiveStats(LiveStats &&) = delete;
+  LiveStats &operator=(const LiveStats &) = delete;
+  LiveStats &operator=(LiveStats &&) = delete;
+  ~LiveStats() = default;
+
+  void addValue(double x) {
+    count++;
+    if (count == 1) {
+      c_min = c_max = m1 = x;
+      m2 = 0.0;
+    } else {
+      c_min = std::min(c_min, x);
+      c_max = std::max(c_max, x);
+      double delta = x - m1;
+      m1 += delta / count;
+      m2 += delta * (x - m1);
+    }
+  }
+
+  void reset() {
+    count = 0;
+    c_min = c_max = m1 = m2 = 0.0;
+  }
+
+  Stats getStats() const {
+    return {.count = count,
+            .min = c_min,
+            .max = c_max,
+            .average = m1,
+            .deviation = (count > 1) ? std::sqrt(m2 / count) : 0.0};
+  }
+
+  /**
+   * Merge statistics collected by another LiveStats instance into this one.
+   * Uses the parallel Welford algorithm to combine counts, min/max,
+   * mean and M2 (sum of squared deviations) exactly.
+   */
+  void join(const LiveStats &other) {
+    if (other.count == 0) return;
+    if (count == 0) {
+      count = other.count;
+      c_min = other.c_min;
+      c_max = other.c_max;
+      m1 = other.m1;
+      m2 = other.m2;
+      return;
+    }
+    int64_t combined = count + other.count;
+    double delta = other.m1 - m1;
+    m2 = m2 + other.m2 +
+         (delta * delta * static_cast<double>(count) *
+          static_cast<double>(other.count) / static_cast<double>(combined));
+    m1 = (m1 * count + other.m1 * other.count) / static_cast<double>(combined);
+    c_min = std::min(c_min, other.c_min);
+    c_max = std::max(c_max, other.c_max);
+    count = combined;
+  }
+};
+
+#endif  // LIVE_STATS_H_INCLUDED

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -11762,9 +11762,58 @@ static int show_threadpool_idle_threads(THD *thd [[maybe_unused]],
                                         SHOW_VAR *var, char *buff) {
   var->type = SHOW_INT;
   var->value = buff;
-  *(int *)buff = tp_get_idle_thread_count();
+  *(uint32_t *)buff = tp_get_idle_thread_count();
   return 0;
 }
+
+static int show_threadpool_requests_waiting_in_queue(THD *thd [[maybe_unused]],
+                                                     SHOW_VAR *var,
+                                                     char *buff) {
+  var->type = SHOW_INT;
+  var->value = buff;
+  *(uint32_t *)buff = tp_get_requests_waiting_in_queue_count();
+  return 0;
+}
+
+static int show_threadpool_requests_waiting_in_hp_queue(THD *thd
+                                                        [[maybe_unused]],
+                                                        SHOW_VAR *var,
+                                                        char *buff) {
+  var->type = SHOW_INT;
+  var->value = buff;
+  *(uint32_t *)buff = tp_get_requests_waiting_in_hp_queue_count();
+  return 0;
+}
+
+static int show_threadpool_requests_starved_in_queue(THD *thd [[maybe_unused]],
+                                                     SHOW_VAR *var,
+                                                     char *buff) {
+  var->type = SHOW_INT;
+  var->value = buff;
+  *(uint32_t *)buff = tp_get_threadpool_requests_starved_in_queue();
+  return 0;
+}
+
+static int show_threadpool_average_queue_wait_us(THD *thd [[maybe_unused]],
+                                                 SHOW_VAR *var, char *buff) {
+  var->type = SHOW_CHAR;
+  var->value = buff;
+  auto stat = tp_get_average_queue_wait_stats();
+  sprintf(buff, "avg: %.3f, min: %.3f, max: %.3f, dev: %.3f, cnt: %ld",
+          stat.average, stat.min, stat.max, stat.deviation, stat.count);
+  return 0;
+}
+
+static int show_threadpool_average_hp_queue_wait_us(THD *thd [[maybe_unused]],
+                                                    SHOW_VAR *var, char *buff) {
+  var->type = SHOW_CHAR;
+  var->value = buff;
+  auto stat = tp_get_average_hp_queue_wait_stats();
+  sprintf(buff, "avg: %.3f, min: %.3f, max: %.3f, dev: %.3f, cnt: %ld",
+          stat.average, stat.min, stat.max, stat.deviation, stat.count);
+  return 0;
+}
+
 #endif
 
 static int show_replica_open_temp_tables(THD *, SHOW_VAR *var, char *buf) {
@@ -12264,8 +12313,23 @@ SHOW_VAR status_vars[] = {
     {"Tc_log_page_waits", (char *)&tc_log_page_waits, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
 #ifdef HAVE_POOL_OF_THREADS
+    {"Threadpool_average_hp_queue_wait_us",
+     (char *)&show_threadpool_average_hp_queue_wait_us, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Threadpool_average_queue_wait_us",
+     (char *)&show_threadpool_average_queue_wait_us, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
     {"Threadpool_idle_threads", (char *)&show_threadpool_idle_threads,
      SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Threadpool_requests_starved_in_queue",
+     (char *)&show_threadpool_requests_starved_in_queue, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Threadpool_requests_waiting_in_hp_queue",
+     (char *)&show_threadpool_requests_waiting_in_hp_queue, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Threadpool_requests_waiting_in_queue",
+     (char *)&show_threadpool_requests_waiting_in_queue, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
     {"Threadpool_threads", (char *)&tp_stats.num_worker_threads, SHOW_INT,
      SHOW_SCOPE_GLOBAL},
 #endif

--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -17,8 +17,8 @@
 #define THREADPOOL_INCLUDED
 
 #include <atomic>
-
 #include "conn_handler/connection_handler_manager.h"
+#include "sql-common/live_stats.h"
 
 struct SHOW_VAR;
 
@@ -63,6 +63,15 @@ extern THD_event_functions tp_event_functions;
 
 /* Used in SHOW for threadpool_idle_thread_count */
 extern int tp_get_idle_thread_count() noexcept;
+/* Count of requests waiting in normal priority queues */
+extern int tp_get_requests_waiting_in_queue_count() noexcept;
+/* Count of requests waiting in high priority queues */
+extern int tp_get_requests_waiting_in_hp_queue_count() noexcept;
+/* Count of requests starved in a queue */
+extern int tp_get_threadpool_requests_starved_in_queue() noexcept;
+/* Aggregated queue wait stats across all thread groups */
+extern LiveStats::Stats tp_get_average_queue_wait_stats() noexcept;
+extern LiveStats::Stats tp_get_average_hp_queue_wait_stats() noexcept;
 
 /*
   Threadpool statistics

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -15,6 +15,7 @@
    USA */
 
 #include <atomic>
+#include <cstdint>
 
 #include <time.h>
 #include "my_sys.h"
@@ -118,18 +119,21 @@ struct connection_t {
   bool bound_to_poll_descriptor;
   bool waiting;
   uint tickets;
+  ulonglong queue_enter_time;
 };
 
 typedef I_P_List<connection_t,
                  I_P_List_adapter<connection_t, &connection_t::next_in_queue,
                                   &connection_t::prev_in_queue>,
-                 I_P_List_null_counter, I_P_List_fast_push_back<connection_t>>
+                 I_P_List_counter, I_P_List_fast_push_back<connection_t>>
     connection_queue_t;
 
 struct alignas(128) thread_group_t {
   mysql_mutex_t mutex;
   connection_queue_t queue;
   connection_queue_t high_prio_queue;
+  LiveStats queue_wait_stats;
+  LiveStats hp_queue_wait_stats;
   worker_list_t waiting_threads;
   worker_thread_t *listener;
   pthread_attr_t *pthread_attr;
@@ -145,7 +149,7 @@ struct alignas(128) thread_group_t {
   int shutdown_pipe[2];
   bool shutdown;
   bool stalled;
-  char padding[328];
+  char padding[248];
 };
 
 static_assert(sizeof(thread_group_t) == 512,
@@ -405,6 +409,20 @@ inline bool connection_is_high_prio(const connection_t &c) noexcept {
            c.thd->mdl_context.has_locks(MDL_key::LOCKING_SERVICE)));
 }
 
+inline void mark_queue_enter(connection_t *c) noexcept {
+  c->queue_enter_time = my_microsecond_getsystime();
+}
+
+inline void record_queue_wait(LiveStats &stats, connection_t *c) noexcept {
+  if (!c->queue_enter_time) return;
+
+  const ulonglong now = my_microsecond_getsystime();
+  const ulonglong wait_us =
+      (now >= c->queue_enter_time) ? (now - c->queue_enter_time) : 0;
+  c->queue_enter_time = 0;
+  stats.addValue(static_cast<double>(wait_us));
+}
+
 }  // namespace
 
 /* Dequeue element from a workqueue */
@@ -416,6 +434,7 @@ static connection_t *queue_get(thread_group_t *thread_group) noexcept {
 
   if ((c = thread_group->high_prio_queue.front())) {
     thread_group->high_prio_queue.remove(c);
+    record_queue_wait(thread_group->hp_queue_wait_stats, c);
   }
   /*
     Don't pick events from the low priority queue if there are too many
@@ -424,6 +443,7 @@ static connection_t *queue_get(thread_group_t *thread_group) noexcept {
   else if (!too_many_busy_threads(*thread_group) &&
            (c = thread_group->queue.front())) {
     thread_group->queue.remove(c);
+    record_queue_wait(thread_group->queue_wait_stats, c);
   }
   DBUG_RETURN(c);
 }
@@ -713,6 +733,7 @@ static connection_t *listener(thread_group_t *thread_group) {
     */
     for (int i = (listener_picks_event) ? 1 : 0; i < cnt; i++) {
       connection_t *c = (connection_t *)native_event_get_userdata(&ev[i]);
+      mark_queue_enter(c);
       if (connection_is_high_prio(*c)) {
         c->tickets--;
         thread_group->high_prio_queue.push_back(c);
@@ -725,6 +746,13 @@ static connection_t *listener(thread_group_t *thread_group) {
     if (listener_picks_event) {
       /* Handle the first event. */
       retval = (connection_t *)native_event_get_userdata(&ev[0]);
+      // record 0 wait time to the corresponding stats because we handled event
+      // here
+      if (connection_is_high_prio(*retval)) {
+        thread_group->hp_queue_wait_stats.addValue(0.0);
+      } else {
+        thread_group->queue_wait_stats.addValue(0.0);
+      }
       mysql_mutex_unlock(&thread_group->mutex);
       break;
     }
@@ -994,6 +1022,7 @@ static void queue_put(thread_group_t *thread_group, connection_t *connection) {
 
   mysql_mutex_lock(&thread_group->mutex);
   connection->tickets = connection->thd->variables.threadpool_high_prio_tickets;
+  mark_queue_enter(connection);
   // put new admin connection into high prio queue instead of normal
   // to be able to login when threadpool is exhausted
   if (connection->thd->is_admin_connection()) {
@@ -1071,7 +1100,6 @@ static connection_t *get_event(worker_thread_t *current_thread,
       if (io_poll_wait(thread_group->pollfd, &nev, 1, 0) == 1) {
         thread_group->io_event_count++;
         connection = (connection_t *)native_event_get_userdata(&nev);
-
         /*
           Since we are going to perform an out-of-order event processing for the
           connection, first check whether it is eligible for high priority
@@ -1089,11 +1117,18 @@ static connection_t *get_event(worker_thread_t *current_thread,
 
           connection->tickets =
               connection->thd->variables.threadpool_high_prio_tickets;
+          mark_queue_enter(connection);
           thread_group->queue.push_back(connection);
           connection = nullptr;
         }
 
         if (connection) {
+          /* Add 0-wait to statistics */
+          if (connection_is_high_prio(*connection)) {
+            thread_group->hp_queue_wait_stats.addValue(0.0);
+          } else {
+            thread_group->queue_wait_stats.addValue(0.0);
+          }
           thread_group->queue_event_count++;
           break;
         }
@@ -1196,6 +1231,7 @@ static connection_t *alloc_connection(THD *thd) noexcept {
     connection->bound_to_poll_descriptor = false;
     connection->abs_wait_timeout = ULLONG_MAX;
     connection->tickets = 0;
+    connection->queue_enter_time = 0;
   }
   DBUG_RETURN(connection);
 }
@@ -1565,6 +1601,93 @@ int tp_get_idle_thread_count() noexcept {
     sum += (all_groups[i].thread_count - all_groups[i].active_thread_count);
   }
   return sum;
+}
+
+/* Count requests waiting in all normal queues */
+int tp_get_requests_waiting_in_queue_count() noexcept {
+  int count = 0;
+
+  /* Iterate through all thread groups */
+  for (uint i = 0; i < group_count; i++) {
+    thread_group_t *group = &all_groups[i];
+
+    mysql_mutex_lock(&group->mutex);
+
+    /* Count elements in low priority queue */
+    count += group->queue.elements();
+
+    mysql_mutex_unlock(&group->mutex);
+  }
+
+  return count;
+}
+
+/* Count requests waiting in all high priority queues */
+int tp_get_requests_waiting_in_hp_queue_count() noexcept {
+  int count = 0;
+
+  /* Iterate through all thread groups */
+  for (uint i = 0; i < group_count; i++) {
+    thread_group_t *group = &all_groups[i];
+
+    mysql_mutex_lock(&group->mutex);
+
+    /* Count elements in high priority queue */
+    count += group->high_prio_queue.elements();
+
+    mysql_mutex_unlock(&group->mutex);
+  }
+
+  return count;
+}
+
+/* Count requests starved in queue */
+int tp_get_threadpool_requests_starved_in_queue() noexcept {
+  int count = 0;
+
+  /*
+    Soft saturation model: if low-priority queue cannot be drained due to
+    too_many_busy_threads(), treat those queued requests as not-entered-yet.
+  */
+  for (uint i = 0; i < group_count; i++) {
+    thread_group_t *group = &all_groups[i];
+
+    mysql_mutex_lock(&group->mutex);
+
+    if (too_many_busy_threads(*group)) {
+      count += group->queue.elements();
+    }
+
+    mysql_mutex_unlock(&group->mutex);
+  }
+
+  return count;
+}
+
+LiveStats::Stats tp_get_average_queue_wait_stats() noexcept {
+  LiveStats combined_stats;
+
+  for (uint i = 0; i < group_count; i++) {
+    thread_group_t *group = &all_groups[i];
+    mysql_mutex_lock(&group->mutex);
+    combined_stats.join(group->queue_wait_stats);
+    mysql_mutex_unlock(&group->mutex);
+  }
+
+  return combined_stats.getStats();
+}
+
+LiveStats::Stats tp_get_average_hp_queue_wait_stats() noexcept {
+  LiveStats combined_stats;
+
+  for (uint i = 0; i < group_count; i++) {
+    thread_group_t *group = &all_groups[i];
+    mysql_mutex_lock(&group->mutex);
+    combined_stats.join(group->hp_queue_wait_stats);
+    mysql_mutex_unlock(&group->mutex);
+  }
+
+  return combined_stats.getStats();
 }
 
 /* Report threadpool problems */

--- a/sql/threadpool_win.cc
+++ b/sql/threadpool_win.cc
@@ -676,3 +676,7 @@ void tp_wait_end(THD *thd) { /* Do we need to do anything ? */
  thus function always returns 0.
 */
 int tp_get_idle_thread_count() noexcept { return 0; }
+
+LiveStats::Stats tp_get_average_queue_wait_stats() noexcept { return {}; }
+
+LiveStats::Stats tp_get_average_hp_queue_wait_stats() noexcept { return {}; }


### PR DESCRIPTION
Add more statistics for threadpool: average queue wait time, requests waiting in queues, requests not entered queue

https://perconadev.atlassian.net/browse/PS-10083

Added highly optimized class for live statistic calculation in multi-threaded environment.

Added new status varables:

```
mysql> show status like "Thread%";
+-----------------------------------------+----------------------------------------------------------------+
| Variable_name                           | Value                                                          |
+-----------------------------------------+----------------------------------------------------------------+
| Threadpool_average_hp_queue_wait_us     | avg: 0.000, min: 0.000, max: 0.000, dev: 0.000, cnt: 0         |
| Threadpool_average_queue_wait_us        | avg: 590.000, min: 470.000, max: 736.000, dev: 110.266, cnt: 5 |
| Threadpool_idle_threads                 | 9                                                              |
| Threadpool_requests_not_entered_queue   | 0                                                              |
| Threadpool_requests_waiting_in_hp_queue | 0                                                              |
| Threadpool_requests_waiting_in_queue    | 0                                                              |
| Threadpool_threads                      | 10                                                             |
| Threads_cached                          | 0                                                              |
| Threads_connected                       | 1                                                              |
| Threads_created                         | 10                                                             |
| Threads_running                         | 2                                                              |
+-----------------------------------------+----------------------------------------------------------------+
```