### PR TITLE
PS-10853 [9.x]: Harden noexcept functions against throwing std::filesystem APIs

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -51,6 +51,7 @@
 
 #include <scope_guard.h>
 #include <array>
+#include <exception>
 #include <memory>
 #include <variant>
 
@@ -75,7 +76,7 @@ SERVICE_TYPE(log_builtins_string) *log_bs = nullptr;
 namespace audit_log_filter {
 namespace {
 
-AuditLogFilter *audit_log_filter = nullptr;
+std::unique_ptr<AuditLogFilter> audit_log_filter;
 
 class EventsConsumer {
  public:
@@ -178,7 +179,7 @@ void deinit_abort_exempt_privilege() {
 }  // namespace
 
 AuditLogFilter *get_audit_log_filter_instance() noexcept {
-  return audit_log_filter;
+  return audit_log_filter.get();
 }
 
 /*
@@ -268,7 +269,7 @@ static std::array udfs_list{
  * @return Initialization status, 0 in case of success or non zero
  *         code otherwise
  */
-mysql_service_status_t audit_log_filter_init() {
+mysql_service_status_t audit_log_filter_init() try {
   auto *all_mem_info = get_all_memory_info();
   mysql_memory_register(AUDIT_LOG_FILTER_PSI_CATEGORY, all_mem_info,
                         sizeof(*all_mem_info) / sizeof(PSI_memory_info));
@@ -357,26 +358,34 @@ mysql_service_status_t audit_log_filter_init() {
 
   log_reader->reset();
 
-  audit_log_filter =
-      new AuditLogFilter(std::move(audit_rule_registry), std::move(audit_udf),
-                         std::move(log_writer), std::move(log_reader));
+  auto local_audit_log_filter = std::make_unique<AuditLogFilter>(
+      std::move(audit_rule_registry), std::move(audit_udf),
+      std::move(log_writer), std::move(log_reader));
 
-  if (audit_log_filter == nullptr || !audit_log_filter->init()) {
+  if (!local_audit_log_filter->init()) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_INIT_FAILURE);
     return 1;
   }
 
-  // In case of successful initialization,
-  // prevent comp_registry_srv from being released by the comp_scope_guard.
-  comp_registry_srv = nullptr;
-
   if (SysVars::get_log_disabled()) {
     LogComponentErr(WARNING_LEVEL, ER_AUDIT_INIT_DISABLED_WARN);
   } else {
-    audit_log_filter->send_audit_start_event();
+    local_audit_log_filter->send_audit_start_event();
   }
 
+  // Disarm the scope guard only after all potentially-throwing operations
+  // succeeded, so that SysVars cleanup still runs on exception.
+  comp_registry_srv = nullptr;
+  audit_log_filter = std::move(local_audit_log_filter);
   return 0;
+} catch (const std::exception &e) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Exception in audit_log_filter_init: %s", e.what());
+  return 1;
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Unknown exception in audit_log_filter_init");
+  return 1;
 }
 
 /**
@@ -386,7 +395,7 @@ mysql_service_status_t audit_log_filter_init() {
  * @return Plugin deinit status, 0 in case of success or non zero
  *         code otherwise
  */
-mysql_service_status_t audit_log_filter_deinit() {
+mysql_service_status_t audit_log_filter_deinit() try {
   if (audit_log_filter == nullptr) {
     return 0;
   }
@@ -401,10 +410,17 @@ mysql_service_status_t audit_log_filter_deinit() {
   SysVars::deinit();
   SysVars::release_comp_registry_srv();
 
-  delete audit_log_filter;
-  audit_log_filter = nullptr;
+  audit_log_filter.reset();
 
   return 0;
+} catch (const std::exception &e) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Exception in audit_log_filter_deinit: %s", e.what());
+  return 1;
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Unknown exception in audit_log_filter_deinit");
+  return 1;
 }
 
 AuditLogFilter::AuditLogFilter(
@@ -462,7 +478,7 @@ void AuditLogFilter::deinit() noexcept {
 }
 
 int AuditLogFilter::notify_event(audit_event_class_t event_class,
-                                 const void *event_data) {
+                                 const void *event_data) try {
   if (SysVars::get_log_disabled() || !m_is_active) {
     return 0;
   }
@@ -556,13 +572,26 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
     get_connection_attrs(thd, record);
   }
 
-  m_log_writer->write(record);
+  try {
+    m_log_writer->write(record);
+  } catch (...) {
+    SysVars::inc_events_lost();
+    throw;
+  }
   SysVars::inc_events_written();
 
   return 0;
+} catch (const std::exception &e) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Caught exception in notify_event: %s", e.what());
+  return 0;
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Caught unknown exception in notify_event");
+  return 0;
 }
 
-void AuditLogFilter::send_audit_start_event() noexcept {
+void AuditLogFilter::send_audit_start_event() noexcept try {
   auto event = internal_event_tracking_audit_data{
       INTERNAL_EVENT_TRACKING_AUDIT_AUDIT, static_cast<uint32>(::server_id), 0};
 
@@ -605,9 +634,12 @@ void AuditLogFilter::send_audit_start_event() noexcept {
   }
 
   m_log_writer->write(*audit_record);
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Caught exception in send_audit_start_event");
 }
 
-void AuditLogFilter::send_audit_stop_event() noexcept {
+void AuditLogFilter::send_audit_stop_event() noexcept try {
   auto event =
       internal_event_tracking_audit_data{INTERNAL_EVENT_TRACKING_AUDIT_NOAUDIT,
                                          static_cast<uint32>(::server_id), 0};
@@ -625,9 +657,12 @@ void AuditLogFilter::send_audit_stop_event() noexcept {
   }
 
   m_log_writer->write(*audit_record);
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Caught exception in send_audit_stop_event");
 }
 
-bool AuditLogFilter::on_audit_rule_flush_requested() noexcept {
+bool AuditLogFilter::on_audit_rule_flush_requested() noexcept try {
   if (!m_is_active) {
     return false;
   }
@@ -638,6 +673,10 @@ bool AuditLogFilter::on_audit_rule_flush_requested() noexcept {
                   { m_log_writer->rotate(nullptr); });
 
   return is_flushed;
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Caught exception in on_audit_rule_flush_requested");
+  return false;
 }
 
 void AuditLogFilter::on_audit_log_prune_requested() noexcept {
@@ -654,7 +693,7 @@ void AuditLogFilter::on_audit_log_rotate_requested(
   }
 }
 
-void AuditLogFilter::on_encryption_password_prune_requested() noexcept {
+void AuditLogFilter::on_encryption_password_prune_requested() noexcept try {
   if (m_is_active && SysVars::get_password_history_keep_days() > 0 &&
       audit_keyring::check_keyring_initialized()) {
     std::vector<std::string> log_names;
@@ -664,6 +703,9 @@ void AuditLogFilter::on_encryption_password_prune_requested() noexcept {
           SysVars::get_password_history_keep_days(), log_names);
     }
   }
+} catch (...) {
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Caught exception in on_encryption_password_prune_requested");
 }
 
 void AuditLogFilter::on_audit_log_rotated() noexcept {
@@ -709,7 +751,7 @@ void AuditLogFilter::get_connection_attrs(MYSQL_THD thd,
 
 bool AuditLogFilter::get_connection_user(Security_context_handle &ctx,
                                          std::string &user_name,
-                                         std::string &user_host) noexcept {
+                                         std::string &user_host) noexcept try {
   MYSQL_LEX_CSTRING user{"", 0};
   MYSQL_LEX_CSTRING host{"", 0};
 
@@ -737,6 +779,8 @@ bool AuditLogFilter::get_connection_user(Security_context_handle &ctx,
   }
 
   return true;
+} catch (...) {
+  return false;
 }
 
 bool AuditLogFilter::check_abort_exempt_privilege(
@@ -762,7 +806,8 @@ bool AuditLogFilter::get_security_context(
 
 bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
                                                  const std::string &name,
-                                                 std::string &value) noexcept {
+                                                 std::string &value) noexcept
+    try {
   MYSQL_LEX_CSTRING val{"", 0};
   // calls mysql_security_context_imp::get
   if (m_security_context_opts_srv->get(ctx, name.c_str(), &val) != 0) {
@@ -778,6 +823,8 @@ bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
   }
 
   return true;
+} catch (...) {
+  return false;
 }
 
 std::string AuditLogFilter::get_sql_text(MYSQL_THD thd) {

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -657,10 +657,12 @@ void AuditLogFilter::on_audit_log_rotate_requested(
 void AuditLogFilter::on_encryption_password_prune_requested() noexcept {
   if (m_is_active && SysVars::get_password_history_keep_days() > 0 &&
       audit_keyring::check_keyring_initialized()) {
-    audit_keyring::prune_encryption_options(
-        SysVars::get_password_history_keep_days(),
-        log_writer::FileHandle::get_log_names_list(SysVars::get_file_dir(),
-                                                   SysVars::get_file_name()));
+    std::vector<std::string> log_names;
+    if (log_writer::FileHandle::get_log_names_list(
+            SysVars::get_file_dir(), SysVars::get_file_name(), log_names)) {
+      audit_keyring::prune_encryption_options(
+          SysVars::get_password_history_keep_days(), log_names);
+    }
   }
 }
 

--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -15,6 +15,7 @@
 
 #include "components/audit_log_filter/audit_log_reader.h"
 
+#include "components/audit_log_filter/audit_error_log.h"
 #include "components/audit_log_filter/audit_keyring.h"
 #include "components/audit_log_filter/audit_psi_info.h"
 
@@ -70,8 +71,6 @@ bool AuditLogReader::init() noexcept {
     return true;
   }
 
-  m_reload_requested = false;
-
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
       "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
@@ -96,18 +95,34 @@ bool AuditLogReader::init() noexcept {
   }
 
   std::vector<std::string> all_files;
-  std::vector<std::string> new_files;
-  std::vector<std::string> removed_files;
+  bool have_complete_file_snapshot = true;
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator{SysVars::get_file_dir()}) {
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator{SysVars::get_file_dir(), ec};
+
+  if (ec) {
+    return false;
+  }
+
+  for (; it != std::filesystem::directory_iterator{}; it.increment(ec)) {
+    const auto &entry = *it;
     auto log_name = entry.path().filename().string();
 
-    if (entry.is_regular_file() &&
+    std::error_code entry_ec;
+    if (entry.is_regular_file(entry_ec) && !entry_ec &&
         log_name.find(log_base_file_name) != std::string::npos) {
       all_files.push_back(std::move(log_name));
+    } else if (entry_ec) {
+      have_complete_file_snapshot = false;
     }
   }
+
+  if (ec) {
+    have_complete_file_snapshot = false;
+  }
+
+  std::vector<std::string> new_files;
+  std::vector<std::string> removed_files;
 
   std::copy_if(std::cbegin(all_files), std::cend(all_files),
                std::back_inserter(new_files), [this](const auto &name) {
@@ -118,16 +133,19 @@ bool AuditLogReader::init() noexcept {
                                      });
                });
 
-  std::for_each(std::cbegin(m_timestamp_to_file_map),
-                std::cend(m_timestamp_to_file_map),
-                [&all_files, &removed_files](const auto &pair) {
-                  if (!std::any_of(std::cbegin(all_files), std::cend(all_files),
-                                   [&pair](const auto &name) {
-                                     return name == pair.second->name;
-                                   })) {
-                    removed_files.push_back(pair.second->name);
-                  }
-                });
+  if (have_complete_file_snapshot) {
+    std::for_each(
+        std::cbegin(m_timestamp_to_file_map),
+        std::cend(m_timestamp_to_file_map),
+        [&all_files, &removed_files](const auto &pair) {
+          if (!std::any_of(std::cbegin(all_files), std::cend(all_files),
+                           [&pair](const auto &name) {
+                             return name == pair.second->name;
+                           })) {
+            removed_files.push_back(pair.second->name);
+          }
+        });
+  }
 
   for (const auto &log_name : new_files) {
     bool is_current_log =
@@ -182,8 +200,18 @@ bool AuditLogReader::init() noexcept {
     file_info->first_timestamp =
         first_event->GetObject()["timestamp"].GetString();
 
-    m_timestamp_to_file_map.emplace(LogFileTimestamp(log_name),
-                                    std::move(file_info));
+    try {
+      auto ts = LogFileTimestamp(log_name);
+      m_timestamp_to_file_map.emplace(std::move(ts), std::move(file_info));
+    } catch (const std::exception &e) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Skipping audit log file with unparseable name '%s': %s",
+                      log_name.c_str(), e.what());
+    } catch (...) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Skipping audit log file with unparseable name '%s'",
+                      log_name.c_str());
+    }
   }
 
   for (const auto &log_name : removed_files) {
@@ -197,6 +225,11 @@ bool AuditLogReader::init() noexcept {
     }
   }
 
+  if (!have_complete_file_snapshot) {
+    return false;
+  }
+
+  m_reload_requested = false;
   return true;
 }
 

--- a/components/audit_log_filter/log_file_timestamp.cc
+++ b/components/audit_log_filter/log_file_timestamp.cc
@@ -27,13 +27,18 @@ LogFileTimestamp::LogFileTimestamp(const std::filesystem::path &path) {
   //    with rotation or encryption key timestamp.
   static const std::regex pattern(
       R"(^.*?\.(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(-(\d+))?(\.enc)?.*)");
-
-  auto filename = path.filename().string();
+  std::string filename;
   std::smatch match;
-  if (!std::regex_match(filename, match, pattern) || match[9].length() != 0) {
-    // If we weren't able to find any timestamp, or we were able to find
-    // only timestamp of an encryption key, we create empty (non-rotated)
-    // timestamp.
+
+  try {
+    filename = path.filename().string();
+    if (!std::regex_match(filename, match, pattern)) return;
+  } catch (...) {
+    return;
+  }
+
+  if (match[9].length() != 0) {
+    // Only an encryption key timestamp, not a rotation timestamp.
     return;
   }
 

--- a/components/audit_log_filter/log_file_timestamp.h
+++ b/components/audit_log_filter/log_file_timestamp.h
@@ -32,6 +32,7 @@ namespace audit_log_filter {
  * - rotated files with timestamp collisions (seq != 0)
  */
 struct LogFileTimestamp {
+  LogFileTimestamp() = default;
   LogFileTimestamp(const std::filesystem::path &path);
 
   friend bool operator<(const LogFileTimestamp &lhs,

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -90,8 +90,15 @@ LogWriter<AuditLogHandlerType::File>::LogWriter(
 LogWriter<AuditLogHandlerType::File>::~LogWriter() {
   do_close_file();
 
-  const auto current_log_path = FileHandle::get_not_rotated_file_path(
-      SysVars::get_file_dir(), SysVars::get_file_name());
+  std::filesystem::path current_log_path;
+  if (!FileHandle::get_not_rotated_file_path(SysVars::get_file_dir(),
+                                             SysVars::get_file_name(),
+                                             current_log_path)) {
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit filter log directory '%s'",
+                    SysVars::get_file_dir().c_str());
+    return;
+  }
   auto rotation_result = std::make_unique<log_writer::FileRotationResult>();
   FileHandle::rotate(current_log_path, rotation_result.get());
 
@@ -111,8 +118,15 @@ bool LogWriterFile::init() noexcept {
 bool LogWriterFile::open() noexcept {
   assert(m_file_writer != nullptr);
 
-  const auto current_log_path = FileHandle::get_not_rotated_file_path(
-      SysVars::get_file_dir(), SysVars::get_file_name());
+  std::filesystem::path current_log_path;
+  if (!FileHandle::get_not_rotated_file_path(SysVars::get_file_dir(),
+                                             SysVars::get_file_name(),
+                                             current_log_path)) {
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit filter log directory '%s'",
+                    SysVars::get_file_dir().c_str());
+    return false;
+  }
   auto rotation_result = std::make_unique<log_writer::FileRotationResult>();
   FileHandle::rotate(current_log_path, rotation_result.get());
 
@@ -176,8 +190,11 @@ bool LogWriterFile::do_open_file() noexcept {
     return false;
   }
 
-  SysVars::set_total_log_size(FileHandle::get_total_log_size(
-      SysVars::get_file_dir(), SysVars::get_file_name()));
+  uint64_t total_size = 0;
+  if (FileHandle::get_total_log_size(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), total_size)) {
+    SysVars::set_total_log_size(total_size);
+  }
   SysVars::set_current_log_size(get_log_size());
 
   init_formatter();
@@ -276,8 +293,11 @@ void LogWriterFile::prune() noexcept {
   const auto prune_seconds = SysVars::get_log_prune_seconds();
 
   if (log_max_size > 0) {
-    auto log_file_list = FileHandle::get_prune_files(SysVars::get_file_dir(),
-                                                     SysVars::get_file_name());
+    PruneFilesList log_file_list;
+    if (!FileHandle::get_prune_files(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), log_file_list)) {
+      return;
+    }
 
     ulonglong current_logs_size = std::accumulate(
         log_file_list.begin(), log_file_list.end(), ulonglong{0},
@@ -307,8 +327,11 @@ void LogWriterFile::prune() noexcept {
       file_queue.pop();
     }
   } else if (prune_seconds > 0) {
-    auto log_file_list = FileHandle::get_prune_files(SysVars::get_file_dir(),
-                                                     SysVars::get_file_name());
+    PruneFilesList log_file_list;
+    if (!FileHandle::get_prune_files(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), log_file_list)) {
+      return;
+    }
 
     for (const auto &entry : log_file_list) {
       if (entry.age > std::chrono::seconds(prune_seconds)) {
@@ -317,8 +340,11 @@ void LogWriterFile::prune() noexcept {
     }
   }
 
-  SysVars::set_total_log_size(FileHandle::get_total_log_size(
-      SysVars::get_file_dir(), SysVars::get_file_name()));
+  uint64_t total_size = 0;
+  if (FileHandle::get_total_log_size(SysVars::get_file_dir(),
+                                     SysVars::get_file_name(), total_size)) {
+    SysVars::set_total_log_size(total_size);
+  }
 }
 
 }  // namespace audit_log_filter::log_writer

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -146,11 +146,26 @@ bool LogWriterFile::do_open_file() noexcept {
     file_path += suffix.str();
   }
 
-  bool is_new_file = !std::filesystem::exists(file_path);
+  std::error_code ec;
+  const bool file_exists = std::filesystem::exists(file_path, ec);
+  if (ec) {
+    const auto file_path_str = file_path.string();
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to inspect audit filter log path '%s': %s",
+                    file_path_str.c_str(), ec.message().c_str());
+    return false;
+  }
+  bool is_new_file = !file_exists;
 
   if (!is_new_file) {
-    FileHandle::remove_file_footer(file_path,
-                                   get_formatter()->get_file_footer());
+    if (!FileHandle::remove_file_footer(file_path,
+                                        get_formatter()->get_file_footer())) {
+      const auto file_path_str = file_path.string();
+      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to prepare audit filter log '%s' for appending",
+                      file_path_str.c_str());
+      return false;
+    }
   }
 
   if (!m_file_handle.open_file(file_path)) {

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -37,19 +37,19 @@ bool is_regular_file(const std::filesystem::directory_entry &entry) noexcept {
 }
 
 bool get_entry_file_size(const std::filesystem::directory_entry &entry,
-                         uintmax_t *size) noexcept {
+                         uintmax_t &size) noexcept {
   std::error_code ec;
-  *size = entry.file_size(ec);
+  size = entry.file_size(ec);
   if (ec) {
-    *size = 0;
+    size = 0;
     return false;
   }
   return true;
 }
 
 template <typename Callback>
-void for_each_directory_entry(const std::string &working_dir_name,
-                              Callback callback) noexcept {
+bool for_each_directory_entry(const std::string &working_dir_name,
+                              const Callback &callback) noexcept {
   std::error_code ec;
   auto it = std::filesystem::directory_iterator(working_dir_name, ec);
   const auto end = std::filesystem::directory_iterator{};
@@ -58,13 +58,24 @@ void for_each_directory_entry(const std::string &working_dir_name,
     LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
                     "Failed to list audit log directory '%s': %s",
                     working_dir_name.c_str(), ec.message().c_str());
+    return false;
   }
 
-  for (; !ec && it != end; it.increment(ec)) {
+  while (it != end) {
     if (!callback(*it)) {
-      break;
+      return true;
+    }
+
+    it.increment(ec);
+    if (ec) {
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to iterate audit log directory '%s': %s",
+                      working_dir_name.c_str(), ec.message().c_str());
+      return false;
     }
   }
+
+  return true;
 }
 }
 
@@ -139,59 +150,75 @@ void FileHandle::flush() noexcept {
   m_file.flush();
 }
 
-std::filesystem::path FileHandle::get_not_rotated_file_path(
-    const std::string &working_dir_name,
-    const std::string &file_name) noexcept {
+bool FileHandle::get_not_rotated_file_path(
+    const std::string &working_dir_name, const std::string &file_name,
+    std::filesystem::path &file_path) noexcept {
+  file_path.clear();
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
 
   if (base_file_name.empty()) {
-    return {};
+    return true;
   }
 
-  std::filesystem::path result;
-  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
-    if (is_regular_file(entry) &&
-        entry.path().filename().string().find(base_file_name) !=
-            std::string::npos &&
-        !FileName::from_path(entry.path().filename()).is_rotated()) {
-      result = entry.path();
-      return false;
-    }
-    return true;
-  });
+  if (!for_each_directory_entry(working_dir_name, [&](const auto &entry) {
+        if (!is_regular_file(entry)) {
+          return true;
+        }
 
-  return result;
+        if (entry.path().filename().string().find(base_file_name) ==
+            std::string::npos) {
+          return true;
+        }
+
+        const auto parsed_file_name =
+            FileName::from_path(entry.path().filename());
+        if (parsed_file_name.get_base_name() == base_file_name &&
+            !parsed_file_name.is_rotated()) {
+          file_path = entry.path();
+          return false;
+        }
+        return true;
+      })) {
+    return false;
+  }
+
+  return true;
 }
 
-uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
-                                        const std::string &file_name) noexcept {
+bool FileHandle::get_total_log_size(const std::string &working_dir_name,
+                                    const std::string &file_name,
+                                    uint64_t &total_size) noexcept {
+  total_size = 0;
   auto base_name = std::filesystem::path{file_name}.filename();
   while (base_name.has_extension()) {
     base_name.replace_extension();
   }
 
   if (base_name.empty()) {
-    return 0;
+    return true;
   }
 
   uint64_t size = 0;
-  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
-    auto entry_file_name = entry.path().filename();
+  if (!for_each_directory_entry(working_dir_name, [&](const auto &entry) {
+        auto entry_file_name = entry.path().filename();
 
-    while (entry_file_name.has_extension()) {
-      entry_file_name.replace_extension();
-    }
+        while (entry_file_name.has_extension()) {
+          entry_file_name.replace_extension();
+        }
 
-    if (is_regular_file(entry) && entry_file_name == base_name) {
-      uintmax_t fsize = 0;
-      if (get_entry_file_size(entry, &fsize)) {
-        size += fsize;
-      }
-    }
-    return true;
-  });
+        if (is_regular_file(entry) && entry_file_name == base_name) {
+          uintmax_t fsize = 0;
+          if (get_entry_file_size(entry, fsize)) {
+            size += fsize;
+          }
+        }
+        return true;
+      })) {
+    return false;
+  }
 
-  return size;
+  total_size = size;
+  return true;
 }
 
 bool FileHandle::remove_file(const std::filesystem::path &path) noexcept {
@@ -324,15 +351,15 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
   }
 }
 
-PruneFilesList FileHandle::get_prune_files(
-    const std::string &working_dir_name,
-    const std::string &file_name) noexcept {
-  PruneFilesList prune_files;
+bool FileHandle::get_prune_files(const std::string &working_dir_name,
+                                 const std::string &file_name,
+                                 PruneFilesList &prune_files) noexcept {
+  prune_files.clear();
 
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
 
   if (base_file_name.empty()) {
-    return prune_files;
+    return true;
   }
 
   auto time_now = std::chrono::system_clock::now();
@@ -344,49 +371,55 @@ PruneFilesList FileHandle::get_prune_files(
     time_now = SysVars::get_debug_time_point_for_rotation();
   });
 
-  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
-    if (is_regular_file(entry) &&
-        entry.path().filename().string().find(base_file_name) !=
-            std::string::npos) {
-      auto parsed_file_name = FileName::from_path(entry.path().filename());
+  if (!for_each_directory_entry(working_dir_name, [&](const auto &entry) {
+        if (is_regular_file(entry) &&
+            entry.path().filename().string().find(base_file_name) !=
+                std::string::npos) {
+          auto parsed_file_name = FileName::from_path(entry.path().filename());
 
-      if (parsed_file_name.is_rotated()) {
-        auto timestamp = parsed_file_name.get_rotation_time().timestamp.value();
-        uintmax_t fsize = 0;
-        if (get_entry_file_size(entry, &fsize)) {
-          prune_files.push_back({entry.path(), fsize, time_now - timestamp});
+          if (parsed_file_name.is_rotated()) {
+            auto timestamp =
+                parsed_file_name.get_rotation_time().timestamp.value();
+            uintmax_t fsize = 0;
+            if (get_entry_file_size(entry, fsize)) {
+              prune_files.push_back(
+                  {entry.path(), fsize, time_now - timestamp});
+            }
+          }
         }
-      }
-    }
-    return true;
-  });
+        return true;
+      })) {
+    return false;
+  }
 
-  return prune_files;
+  return true;
 }
 
-std::vector<std::string> FileHandle::get_log_names_list(
-    const std::string &working_dir_name,
-    const std::string &file_name) noexcept {
-  std::vector<std::string> list;
+bool FileHandle::get_log_names_list(
+    const std::string &working_dir_name, const std::string &file_name,
+    std::vector<std::string> &log_names) noexcept {
+  log_names.clear();
 
   auto base_file_name =
       std::filesystem::path{file_name}.replace_extension().string();
 
   if (base_file_name.empty()) {
-    return list;
+    return true;
   }
 
-  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
-    const auto name = entry.path().filename().string();
+  if (!for_each_directory_entry(working_dir_name, [&](const auto &entry) {
+        const auto name = entry.path().filename().string();
 
-    if (is_regular_file(entry) &&
-        name.find(base_file_name) != std::string::npos) {
-      list.push_back(name);
-    }
-    return true;
-  });
+        if (is_regular_file(entry) &&
+            name.find(base_file_name) != std::string::npos) {
+          log_names.push_back(name);
+        }
+        return true;
+      })) {
+    return false;
+  }
 
-  return list;
+  return true;
 }
 
 }  // namespace audit_log_filter::log_writer

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -15,6 +15,7 @@
 
 #define ALLOW_COMPONENT_INCLUDE // for plugin.h
 #include "components/audit_log_filter/log_writer/file_handle.h"
+#include "components/audit_log_filter/audit_error_log.h"
 #include "components/audit_log_filter/audit_psi_info.h"
 #include "components/audit_log_filter/log_writer/file_name.h"
 #include "components/audit_log_filter/sys_vars.h"
@@ -29,6 +30,42 @@
 
 namespace {
 const std::string kRotationTimeFormat{"%Y%m%dT%H%M%S"};
+
+bool is_regular_file(const std::filesystem::directory_entry &entry) noexcept {
+  std::error_code ec;
+  return entry.is_regular_file(ec) && !ec;
+}
+
+bool get_entry_file_size(const std::filesystem::directory_entry &entry,
+                         uintmax_t *size) noexcept {
+  std::error_code ec;
+  *size = entry.file_size(ec);
+  if (ec) {
+    *size = 0;
+    return false;
+  }
+  return true;
+}
+
+template <typename Callback>
+void for_each_directory_entry(const std::string &working_dir_name,
+                              Callback callback) noexcept {
+  std::error_code ec;
+  auto it = std::filesystem::directory_iterator(working_dir_name, ec);
+  const auto end = std::filesystem::directory_iterator{};
+
+  if (ec) {
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to list audit log directory '%s': %s",
+                    working_dir_name.c_str(), ec.message().c_str());
+  }
+
+  for (; !ec && it != end; it.increment(ec)) {
+    if (!callback(*it)) {
+      break;
+    }
+  }
+}
 }
 
 #if defined(HAVE_PSI_INTERFACE)
@@ -87,11 +124,9 @@ void FileHandle::write_file(const char *record, const size_t size) noexcept {
 
 uint64_t FileHandle::get_file_size() const noexcept {
   assert(m_file.is_open());
-  try {
-    return std::filesystem::file_size(m_path);
-  } catch (const std::filesystem::filesystem_error &) {
-    return 0;
-  }
+  std::error_code ec;
+  auto size = std::filesystem::file_size(m_path, ec);
+  return ec ? 0 : size;
 }
 
 std::filesystem::path FileHandle::get_file_path() const noexcept {
@@ -109,17 +144,23 @@ std::filesystem::path FileHandle::get_not_rotated_file_path(
     const std::string &file_name) noexcept {
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator(working_dir_name)) {
-    if (entry.is_regular_file() &&
+  if (base_file_name.empty()) {
+    return {};
+  }
+
+  std::filesystem::path result;
+  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
+    if (is_regular_file(entry) &&
         entry.path().filename().string().find(base_file_name) !=
             std::string::npos &&
         !FileName::from_path(entry.path().filename()).is_rotated()) {
-      return entry.path();
+      result = entry.path();
+      return false;
     }
-  }
+    return true;
+  });
 
-  return {};
+  return result;
 }
 
 uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
@@ -129,20 +170,26 @@ uint64_t FileHandle::get_total_log_size(const std::string &working_dir_name,
     base_name.replace_extension();
   }
 
-  uint64_t size = 0;
+  if (base_name.empty()) {
+    return 0;
+  }
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator(working_dir_name)) {
+  uint64_t size = 0;
+  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
     auto entry_file_name = entry.path().filename();
 
     while (entry_file_name.has_extension()) {
       entry_file_name.replace_extension();
     }
 
-    if (entry.is_regular_file() && entry_file_name == base_name) {
-      size += entry.file_size();
+    if (is_regular_file(entry) && entry_file_name == base_name) {
+      uintmax_t fsize = 0;
+      if (get_entry_file_size(entry, &fsize)) {
+        size += fsize;
+      }
     }
-  }
+    return true;
+  });
 
   return size;
 }
@@ -152,7 +199,7 @@ bool FileHandle::remove_file(const std::filesystem::path &path) noexcept {
   return std::filesystem::remove(path, ec);
 }
 
-void FileHandle::remove_file_footer(
+bool FileHandle::remove_file_footer(
     const std::filesystem::path &file_path,
     const std::string &expected_footer) noexcept {
   assert(expected_footer.length() > 0);
@@ -161,14 +208,14 @@ void FileHandle::remove_file_footer(
   file.open(file_path, std::ios::in);
 
   if (!file.is_open()) {
-    return;
+    return false;
   }
 
   file.seekg(-expected_footer.length(), std::ios_base::end);
 
   if (file.fail()) {
     file.close();
-    return;
+    return true;
   }
 
   std::string file_footer;
@@ -176,7 +223,7 @@ void FileHandle::remove_file_footer(
 
   if (file.fail()) {
     file.close();
-    return;
+    return true;
   }
 
   file.close();
@@ -185,17 +232,35 @@ void FileHandle::remove_file_footer(
     file_footer.push_back('\n');
   }
 
-  if (expected_footer == file_footer) {
-    std::filesystem::resize_file(
-        file_path,
-        std::filesystem::file_size(file_path) - expected_footer.size());
+  if (expected_footer != file_footer) {
+    return true;
   }
+
+  std::error_code ec;
+  auto current_size = std::filesystem::file_size(file_path, ec);
+  if (!ec && current_size >= expected_footer.size()) {
+    std::filesystem::resize_file(file_path,
+                                 current_size - expected_footer.size(), ec);
+  }
+  if (ec) {
+    const auto path_str = file_path.string();
+    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to remove footer from audit log '%s': %s",
+                    path_str.c_str(), ec.message().c_str());
+    return false;
+  }
+
+  return true;
 }
 
 void FileHandle::rotate(const std::filesystem::path &current_file_path,
                         FileRotationResult *result) noexcept {
-  if (!std::filesystem::exists(current_file_path)) {
-    result->error_code = 0;
+  std::error_code ec;
+  if (!std::filesystem::exists(current_file_path, ec)) {
+    result->error_code = ec.value();
+    if (ec) {
+      result->status_string = ec.message();
+    }
     return;
   }
 
@@ -220,7 +285,6 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
     extensions_str = filename_str.substr(first_ext_pos);
   }
 
-  std::error_code ec;
   std::filesystem::path new_file_path;
   std::string new_file_name_str;
   std::size_t seq = 0;
@@ -243,6 +307,12 @@ void FileHandle::rotate(const std::filesystem::path &current_file_path,
     new_file_path.replace_filename(new_file_name_str);
   } while (std::filesystem::exists(new_file_path, ec));
 
+  if (ec) {
+    result->error_code = ec.value();
+    result->status_string = ec.message();
+    return;
+  }
+
   std::filesystem::rename(current_file_path, new_file_path, ec);
 
   result->error_code = ec.value();
@@ -258,7 +328,13 @@ PruneFilesList FileHandle::get_prune_files(
     const std::string &working_dir_name,
     const std::string &file_name) noexcept {
   PruneFilesList prune_files;
+
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
+
+  if (base_file_name.empty()) {
+    return prune_files;
+  }
+
   auto time_now = std::chrono::system_clock::now();
 
   DBUG_EXECUTE_IF("audit_log_filter_debug_timestamp", {
@@ -268,19 +344,22 @@ PruneFilesList FileHandle::get_prune_files(
     time_now = SysVars::get_debug_time_point_for_rotation();
   });
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator{working_dir_name}) {
-    if (entry.is_regular_file() && entry.path().filename().string().find(
-                                       base_file_name) != std::string::npos) {
+  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
+    if (is_regular_file(entry) &&
+        entry.path().filename().string().find(base_file_name) !=
+            std::string::npos) {
       auto parsed_file_name = FileName::from_path(entry.path().filename());
 
       if (parsed_file_name.is_rotated()) {
         auto timestamp = parsed_file_name.get_rotation_time().timestamp.value();
-        prune_files.push_back(
-            {entry.path(), entry.file_size(), time_now - timestamp});
+        uintmax_t fsize = 0;
+        if (get_entry_file_size(entry, &fsize)) {
+          prune_files.push_back({entry.path(), fsize, time_now - timestamp});
+        }
       }
     }
-  }
+    return true;
+  });
 
   return prune_files;
 }
@@ -289,18 +368,23 @@ std::vector<std::string> FileHandle::get_log_names_list(
     const std::string &working_dir_name,
     const std::string &file_name) noexcept {
   std::vector<std::string> list;
+
   auto base_file_name =
       std::filesystem::path{file_name}.replace_extension().string();
 
-  for (const auto &entry :
-       std::filesystem::directory_iterator{working_dir_name}) {
+  if (base_file_name.empty()) {
+    return list;
+  }
+
+  for_each_directory_entry(working_dir_name, [&](const auto &entry) {
     const auto name = entry.path().filename().string();
 
-    if (entry.is_regular_file() &&
+    if (is_regular_file(entry) &&
         name.find(base_file_name) != std::string::npos) {
       list.push_back(name);
     }
-  }
+    return true;
+  });
 
   return list;
 }

--- a/components/audit_log_filter/log_writer/file_handle.h
+++ b/components/audit_log_filter/log_writer/file_handle.h
@@ -106,9 +106,11 @@ class FileHandle {
    *
    * @param file_path File path
    * @param expected_footer Expected log footer
+   * @return true if footer was removed or was not present, false on I/O error
    */
-  static void remove_file_footer(const std::filesystem::path &file_path,
-                                 const std::string &expected_footer) noexcept;
+  [[nodiscard]] static bool remove_file_footer(
+      const std::filesystem::path &file_path,
+      const std::string &expected_footer) noexcept;
 
   /**
    * @brief Rotate file.

--- a/components/audit_log_filter/log_writer/file_handle.h
+++ b/components/audit_log_filter/log_writer/file_handle.h
@@ -95,11 +95,12 @@ class FileHandle {
    *
    * @param working_dir_name Working directory name
    * @param file_name Log file name
-   * @return Total logs size in bytes
+   * @param[out] total_size Total logs size in bytes
+   * @return true on success, false on directory iteration error
    */
-  [[nodiscard]] static uint64_t get_total_log_size(
-      const std::string &working_dir_name,
-      const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_total_log_size(
+      const std::string &working_dir_name, const std::string &file_name,
+      uint64_t &total_size) noexcept;
 
   /**
    * @brief Remove log footer from the end of a file.
@@ -126,10 +127,12 @@ class FileHandle {
    *
    * @param working_dir_name Working directory name
    * @param file_name File name
-   * @return List of rotated log files
+   * @param[out] prune_files List of rotated log files
+   * @return true on success, false on directory iteration error
    */
-  static PruneFilesList get_prune_files(const std::string &working_dir_name,
-                                        const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_prune_files(
+      const std::string &working_dir_name, const std::string &file_name,
+      PruneFilesList &prune_files) noexcept;
 
   /**
    * @brief Remove a file.
@@ -144,22 +147,24 @@ class FileHandle {
    *
    * @param working_dir_name Working directory name
    * @param file_name Log file name
-   * @return Path to not rotated log file
+   * @param[out] file_path Path to not rotated log file, empty if none exists
+   * @return true on success, false on directory iteration error
    */
-  static std::filesystem::path get_not_rotated_file_path(
-      const std::string &working_dir_name,
-      const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_not_rotated_file_path(
+      const std::string &working_dir_name, const std::string &file_name,
+      std::filesystem::path &file_path) noexcept;
 
   /**
    * @brief Get list of currently existent audit log file names.
    *
    * @param working_dir_name Working directory name
    * @param file_name Base file name
-   * @return List of audit log file names
+   * @param[out] log_names List of audit log file names
+   * @return true on success, false on directory iteration error
    */
-  static std::vector<std::string> get_log_names_list(
-      const std::string &working_dir_name,
-      const std::string &file_name) noexcept;
+  [[nodiscard]] static bool get_log_names_list(
+      const std::string &working_dir_name, const std::string &file_name,
+      std::vector<std::string> &log_names) noexcept;
 
  private:
   std::fstream m_file;

--- a/components/audit_log_filter/log_writer/file_name.cc
+++ b/components/audit_log_filter/log_writer/file_name.cc
@@ -22,7 +22,6 @@ namespace audit_log_filter::log_writer {
 FileName FileName::from_path(std::filesystem::path filename) noexcept {
   bool is_compressed{false};
   bool is_encrypted{false};
-
   std::string key_id_str;
 
   if (filename.has_extension() && filename.extension().compare(".enc") == 0) {
@@ -37,7 +36,11 @@ FileName FileName::from_path(std::filesystem::path filename) noexcept {
     filename.replace_extension();
   }
 
-  auto timestamp = LogFileTimestamp(filename);
+  LogFileTimestamp timestamp;
+  try {
+    timestamp = LogFileTimestamp(filename);
+  } catch (...) {
+  }
 
   while (filename.has_extension()) {
     filename.replace_extension();

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -824,8 +824,9 @@ bool SysVars::validate() noexcept {
 
   // Check if log file directory points to a valid file system directory or if
   // it is left at the default setting (empty).
+  std::error_code ec;
   if (!SysVars::get_file_dir().empty() &&
-      !std::filesystem::is_directory(SysVars::get_file_dir())) {
+      !std::filesystem::is_directory(SysVars::get_file_dir(), ec)) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_SYS_VAR_INVALID_FILE_DIRECTORY,
                     SysVars::get_file_dir().c_str());
     return false;


### PR DESCRIPTION
### 1. Harden noexcept functions against throwing std::filesystem APIs

Multiple noexcept functions in the audit_log_filter component call
std::filesystem APIs that may throw std::filesystem::filesystem_error,
which would result in std::terminate. This patch replaces all such call
sites with their std::error_code overloads and adds try/catch guards
where ec overloads are not available.

- Introduce a for_each_directory_entry() helper template that constructs
  directory_iterator with the ec overload and advances with
  increment(ec), replacing all raw range-based for loops over
  directory_iterator. Add is_regular_file() and get_entry_file_size()
  helper functions that wrap directory_entry methods with ec overloads so
  individual bad entries are skipped instead of aborting the entire loop.

- Switch standalone filesystem calls (exists, is_directory, file_size,
  resize_file) to their std::error_code overloads.

- Change remove_file_footer() from void to [[nodiscard]] bool so
  callers can detect and handle truncation failures. Abort file open if
  footer removal fails.

- Wrap LogFileTimestamp construction in try/catch guards since
  std::regex_match and std::stoi/std::stoul can throw. Add a default
  constructor as a safe fallback value. Wrap FileName::from_path()'s
  LogFileTimestamp construction in try/catch as well.

- In the audit log reader, use ec overloads for directory iteration and
  track a have_complete_file_snapshot flag so that an incomplete
  directory scan skips the removed-files detection rather than
  incorrectly deleting valid entries from the timestamp map. Defer
  clearing m_reload_requested until init() fully succeeds. Wrap
  LogFileTimestamp construction in try/catch to skip individual files
  with unparseable names.

- Add early returns when the base file name is empty to avoid needless
  directory walks.

- Log warning-level messages on directory construction, per-entry, and
  standalone filesystem operation failures.
  
### 2. Return errors for incomplete directory scan in audit log filter

The directory-scanning functions get_log_names_list(),
get_prune_files(), get_total_log_size(), and
get_not_rotated_file_path() returned their results directly, making it
impossible for callers to distinguish an empty result from a failed
scan. The for_each_directory_entry() helper was void-returning, so
iteration errors were logged but silently swallowed.

- Change for_each_directory_entry() from void to bool, returning false
  on directory-open or mid-iteration errors. Replace the combined
  for-loop condition with a while-loop that checks the error code after
  each increment() call, and add a dedicated warning message for
  mid-iteration failures.

- Change the return type of get_total_log_size(), get_prune_files(),
  get_log_names_list(), and get_not_rotated_file_path() from returning
  results directly to returning [[nodiscard]] bool (true on success),
  with results passed via output reference parameters.

- Update all callers to check the return value: skip
  prune_encryption_options() when get_log_names_list() fails, abort
  file open and log rotation when get_not_rotated_file_path() fails,
  early-return from prune when get_prune_files() fails, and only
  update total log size when get_total_log_size() succeeds.

- Tighten get_not_rotated_file_path() to use exact base-name
  comparison (via FileName::get_base_name()) instead of substring
  matching, preventing false positives from files whose names contain
  the base name as a substring.

### 3. Guard audit log filter entry points against exceptions

- Wrap audit_log_filter_init(), audit_log_filter_deinit(), and
notify_event() in function-try-blocks as defense-in-depth so that if
any future code re-introduces a throwing call, the server won't crash.

- Use a local std::unique_ptr in audit_log_filter_init() and move it to
the global only after all potentially-throwing operations succeed, so
exception cleanup is automatic via RAII. Replace the raw global
AuditLogFilter* with std::unique_ptr. Disarm the comp_registry_srv
scope guard only after the move.

- Track lost events: a nested try/catch around m_log_writer->write()
increments the events_lost counter and re-throws to the outer handler.

- Add noexcept try/catch guards to send_audit_start_event,
send_audit_stop_event, on_audit_rule_flush_requested,
on_encryption_password_prune_requested, get_connection_user, and
get_security_context_option.
