### PR TITLE
PS-10351 [9.x]: Introduce `audit_log_filter.event_mode` variable (`REDUCED/FULL`)

### DIFF
--- a/components/audit_log_filter/audit_keyring.cc
+++ b/components/audit_log_filter/audit_keyring.cc
@@ -190,8 +190,8 @@ bool get_keyring_options(const std::string &options_id,
   });
 
   if (reader_object == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "No data found for key '%s'", options_id.c_str());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_KEYRING_KEY_NOT_FOUND,
+                    options_id.c_str());
     return false;
   }
 
@@ -452,8 +452,7 @@ void prune_encryption_options(
     }
 
     if (writer_srv->remove(el.data_id.c_str(), kAuthId)) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to remove options with ID: %s",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_KEYRING_OPTIONS_REMOVE_FAILURE,
                       el.data_id.c_str());
     }
   }

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -522,6 +522,37 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
 
   SysVars::set_session_filter_id(thd, filter_rule->get_filter_id());
 
+  if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced) {
+    switch (event_class) {
+      case audit_event_class_t::AUDIT_GLOBAL_VARIABLE_CLASS:
+      case audit_event_class_t::AUDIT_COMMAND_CLASS:
+      case audit_event_class_t::AUDIT_QUERY_CLASS:
+      case audit_event_class_t::AUDIT_STORED_PROGRAM_CLASS:
+      case audit_event_class_t::AUDIT_AUTHENTICATION_CLASS:
+      case audit_event_class_t::AUDIT_PARSE_CLASS:
+        return 0;
+      case audit_event_class_t::AUDIT_GENERAL_CLASS: {
+        auto sc =
+            static_cast<const mysql_event_tracking_general_data *>(event_data)
+                ->event_subclass;
+        if (sc == EVENT_TRACKING_GENERAL_LOG ||
+            sc == EVENT_TRACKING_GENERAL_ERROR ||
+            sc == EVENT_TRACKING_GENERAL_RESULT)
+          return 0;
+        break;
+      }
+      case audit_event_class_t::AUDIT_CONNECTION_CLASS: {
+        auto sc = static_cast<const mysql_event_tracking_connection_data *>(
+                      event_data)
+                      ->event_subclass;
+        if (sc == EVENT_TRACKING_CONNECTION_PRE_AUTHENTICATE) return 0;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
   // Get actual event info based on event class
   auto audit_record = get_audit_record(event_class, event_data);
   if (!audit_record.has_value()) {

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -688,12 +688,13 @@ void AuditLogFilter::send_audit_stop_event() noexcept try {
                   "Caught exception in send_audit_stop_event");
 }
 
-bool AuditLogFilter::on_audit_rule_flush_requested() noexcept try {
+bool AuditLogFilter::on_audit_rule_flush_requested(
+    std::string &error_message) noexcept try {
   if (!m_is_active) {
     return false;
   }
 
-  const bool is_flushed = m_audit_rules_registry->load();
+  const bool is_flushed = m_audit_rules_registry->load(error_message);
 
   DBUG_EXECUTE_IF("audit_log_filter_rotate_after_audit_rules_flush",
                   { m_log_writer->rotate(nullptr); });
@@ -703,6 +704,12 @@ bool AuditLogFilter::on_audit_rule_flush_requested() noexcept try {
   LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
                   "Caught exception in on_audit_rule_flush_requested");
   return false;
+}
+
+void AuditLogFilter::invalidate_audit_rules() noexcept {
+  if (m_is_active) {
+    m_audit_rules_registry->invalidate();
+  }
 }
 
 void AuditLogFilter::on_audit_log_prune_requested() noexcept {

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -379,8 +379,7 @@ mysql_service_status_t audit_log_filter_init() try {
   audit_log_filter = std::move(local_audit_log_filter);
   return 0;
 } catch (const std::exception &e) {
-  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                  "Exception in audit_log_filter_init: %s", e.what());
+  LogComponentErr(ERROR_LEVEL, ER_AUDIT_INIT_EXCEPTION, e.what());
   return 1;
 } catch (...) {
   LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -414,8 +413,7 @@ mysql_service_status_t audit_log_filter_deinit() try {
 
   return 0;
 } catch (const std::exception &e) {
-  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                  "Exception in audit_log_filter_deinit: %s", e.what());
+  LogComponentErr(ERROR_LEVEL, ER_AUDIT_DEINIT_EXCEPTION, e.what());
   return 1;
 } catch (...) {
   LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -517,8 +515,8 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   auto filter_rule = m_audit_rules_registry->get_rule(rule_name);
 
   if (filter_rule == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to find '%s' filtering rule", rule_name.c_str());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_FILTER_RULE_NOT_FOUND,
+                    rule_name.c_str());
     return 0;
   }
 
@@ -532,8 +530,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   auto &record = *audit_record;
 
   if (std::holds_alternative<AuditRecordUnknown>(record)) {
-    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Unsupported audit event class with ID %i received",
+    LogComponentErr(WARNING_LEVEL, ER_AUDIT_UNSUPPORTED_EVENT_CLASS,
                     event_class);
     return 0;
   }
@@ -562,8 +559,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
           return rec.event_class_name;
         },
         record);
-    LogComponentErr(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Blocked audit event '%s' with class %i", ev_name.data(),
+    LogComponentErr(INFORMATION_LEVEL, ER_AUDIT_BLOCKED_EVENT, ev_name.data(),
                     event_class);
     return 1;
   }
@@ -582,8 +578,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
 
   return 0;
 } catch (const std::exception &e) {
-  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                  "Caught exception in notify_event: %s", e.what());
+  LogComponentErr(ERROR_LEVEL, ER_AUDIT_NOTIFY_EVENT_EXCEPTION, e.what());
   return 0;
 } catch (...) {
   LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -811,8 +806,8 @@ bool AuditLogFilter::get_security_context_option(Security_context_handle &ctx,
   MYSQL_LEX_CSTRING val{"", 0};
   // calls mysql_security_context_imp::get
   if (m_security_context_opts_srv->get(ctx, name.c_str(), &val) != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Can not get %s from security context", name.c_str());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_SECURITY_CONTEXT_FIELD_FAILURE,
+                    name.c_str());
     return false;
   }
 

--- a/components/audit_log_filter/audit_log_filter.h
+++ b/components/audit_log_filter/audit_log_filter.h
@@ -98,9 +98,19 @@ class AuditLogFilter {
   /**
    * @brief Handle filters flush request.
    *
+   * @param error_message Out-parameter for a human-readable error
    * @return true in case filters reloaded successfully, false otherwise
    */
-  bool on_audit_rule_flush_requested() noexcept;
+  bool on_audit_rule_flush_requested(std::string &error_message) noexcept;
+
+  /**
+   * @brief Mark the rule registry for lazy reload on the next audit event.
+   *
+   * Unlike on_audit_rule_flush_requested(), this does not open tables and
+   * is safe to call from contexts that hold LOCK_plugin (e.g. sysvar update
+   * callbacks).
+   */
+  void invalidate_audit_rules() noexcept;
 
   /**
    * @brief Handle log files pruning request.

--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -204,12 +204,11 @@ bool AuditLogReader::init() noexcept {
       auto ts = LogFileTimestamp(log_name);
       m_timestamp_to_file_map.emplace(std::move(ts), std::move(file_info));
     } catch (const std::exception &e) {
-      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Skipping audit log file with unparseable name '%s': %s",
+      LogComponentErr(WARNING_LEVEL, ER_AUDIT_LOG_FILE_NAME_PARSE_FAILURE,
                       log_name.c_str(), e.what());
     } catch (...) {
-      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Skipping audit log file with unparseable name '%s'",
+      LogComponentErr(WARNING_LEVEL,
+                      ER_AUDIT_LOG_FILE_NAME_UNKNOWN_PARSE_FAILURE,
                       log_name.c_str());
     }
   }

--- a/components/audit_log_filter/audit_record.cc
+++ b/components/audit_log_filter/audit_record.cc
@@ -670,6 +670,48 @@ AuditRecordFieldsList get_audit_record_fields(const AuditRecordUnknown &record
   return {};
 }
 
+bool is_event_class_allowed_in_reduced_mode(std::string_view class_name) {
+  static constexpr std::array<std::string_view, 4> allowed_classes{{
+      kClassNameGeneral,
+      kClassNameConnection,
+      kClassNameTableAccess,
+      kClassNameMessage,
+  }};
+  return contains_string_view(class_name, allowed_classes);
+}
+
+bool is_event_subclass_allowed_in_reduced_mode(std::string_view class_name,
+                                               std::string_view subclass_name) {
+  if (class_name == kClassNameGeneral) {
+    return subclass_name == kSubclassNameGeneralStatus;
+  }
+  if (class_name == kClassNameConnection) {
+    static constexpr std::array<std::string_view, 3> allowed{{
+        kSubclassNameConnect,
+        kSubclassNameDisconnect,
+        kSubclassNameChangeUser,
+    }};
+    return contains_string_view(subclass_name, allowed);
+  }
+  if (class_name == kClassNameTableAccess) {
+    static constexpr std::array<std::string_view, 4> allowed{{
+        kSubclassNameRead,
+        kSubclassNameInsert,
+        kSubclassNameUpdate,
+        kSubclassNameDelete,
+    }};
+    return contains_string_view(subclass_name, allowed);
+  }
+  if (class_name == kClassNameMessage) {
+    static constexpr std::array<std::string_view, 2> allowed{{
+        kSubclassNameMessageInternal,
+        kSubclassNameUser,
+    }};
+    return contains_string_view(subclass_name, allowed);
+  }
+  return false;
+}
+
 bool is_valid_event_class_name(std::string_view class_name) {
   // Filter definitions intentionally accept only the supported subset of
   // class names. That excludes authorization, internal audit lifecycle,

--- a/components/audit_log_filter/audit_record.h
+++ b/components/audit_log_filter/audit_record.h
@@ -310,6 +310,26 @@ bool field_value_matches(const AuditRecordFieldValue &value,
                          const std::string &expected);
 
 /**
+ * @brief Check if an event class has at least one subclass allowed in
+ *        REDUCED event mode.
+ *
+ * @param class_name Event class name to validate (e.g. "connection")
+ * @return true if the class has any allowed subclass in REDUCED mode,
+ *         false otherwise
+ */
+bool is_event_class_allowed_in_reduced_mode(std::string_view class_name);
+
+/**
+ * @brief Check if a specific event subclass is allowed in REDUCED event mode.
+ *
+ * @param class_name Event class name (e.g. "connection")
+ * @param subclass_name Event subclass name (e.g. "connect")
+ * @return true if the event is allowed in REDUCED mode, false otherwise
+ */
+bool is_event_subclass_allowed_in_reduced_mode(std::string_view class_name,
+                                               std::string_view subclass_name);
+
+/**
  * @brief Check if an event class name is supported by filter definitions.
  *
  * @param class_name Event class name to validate (e.g. "connection")

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -15,6 +15,7 @@
 
 #include "components/audit_log_filter/audit_rule_parser.h"
 #include "components/audit_log_filter/audit_error_log.h"
+#include "components/audit_log_filter/sys_vars.h"
 
 #include "components/audit_log_filter/event_field_action/block.h"
 #include "components/audit_log_filter/event_field_action/log.h"
@@ -267,6 +268,14 @@ bool AuditRuleParser::parse_event_class_obj_json(
       return false;
     }
 
+    if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
+        !is_event_class_allowed_in_reduced_mode(event_class_name)) {
+      audit_rule->set_parse_error(
+          "event class '" + event_class_name +
+          "' is disabled in audit_log_filter.event_mode=REDUCED");
+      return false;
+    }
+
     if (has_print) {
       replace_field =
           parse_action_json(EventActionType::ReplaceField, event_class_json,
@@ -350,6 +359,14 @@ bool AuditRuleParser::parse_event_class_obj_json(
                         event_class_name.c_str());
         audit_rule->set_parse_error("unknown event class name '" +
                                     event_class_name + "'");
+        return false;
+      }
+
+      if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
+          !is_event_class_allowed_in_reduced_mode(event_class_name)) {
+        audit_rule->set_parse_error(
+            "event class '" + event_class_name +
+            "' is disabled in audit_log_filter.event_mode=REDUCED");
         return false;
       }
 
@@ -508,6 +525,14 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
                       class_name.c_str());
       audit_rule->set_parse_error("unknown event subclass name '" + name +
                                   "' for class '" + class_name + "'");
+      return false;
+    }
+
+    if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
+        !is_event_subclass_allowed_in_reduced_mode(class_name, name)) {
+      audit_rule->set_parse_error(
+          "event '" + class_name + "/" + name +
+          "' is disabled in audit_log_filter.event_mode=REDUCED");
       return false;
     }
   }

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -53,16 +53,17 @@ std::string find_unknown_key(const rapidjson::Value &json_obj,
 
 }  // namespace
 
-bool AuditRuleParser::parse(const char *rule_str,
-                            AuditRule *audit_rule) noexcept {
+bool AuditRuleParser::parse(const char *rule_str, AuditRule *audit_rule,
+                            bool skip_disabled_events) noexcept {
   rapidjson::Document json_doc;
   json_doc.Parse(rule_str);
 
-  return parse(json_doc, audit_rule);
+  return parse(json_doc, audit_rule, skip_disabled_events);
 }
 
 bool AuditRuleParser::parse(rapidjson::Document &json_doc,
-                            AuditRule *audit_rule) noexcept {
+                            AuditRule *audit_rule,
+                            bool skip_disabled_events) noexcept {
   // Do basic check of rule structure
   if (json_doc.HasParseError()) {
     audit_rule->set_parse_error("JSON parse error");
@@ -98,7 +99,7 @@ bool AuditRuleParser::parse(rapidjson::Document &json_doc,
     return false;
   }
 
-  if (!parse_event_class_json(json_doc, audit_rule)) {
+  if (!parse_event_class_json(json_doc, audit_rule, skip_disabled_events)) {
     return false;
   }
 
@@ -145,7 +146,8 @@ bool AuditRuleParser::parse_default_log_action_json(
 }
 
 bool AuditRuleParser::parse_event_class_json(
-    const rapidjson::Document &json_doc, AuditRule *audit_rule) noexcept {
+    const rapidjson::Document &json_doc, AuditRule *audit_rule,
+    bool skip_disabled_events) noexcept {
   /*
    * Parsing event class name
    *
@@ -175,7 +177,8 @@ bool AuditRuleParser::parse_event_class_json(
   const auto &ev_class_json = json_doc["filter"]["class"];
 
   if (ev_class_json.IsObject()) {
-    return parse_event_class_obj_json(ev_class_json, audit_rule);
+    return parse_event_class_obj_json(ev_class_json, audit_rule,
+                                      skip_disabled_events);
   } else if (ev_class_json.IsArray()) {
     if (ev_class_json.Empty()) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_EMPTY_ARRAY,
@@ -195,7 +198,7 @@ bool AuditRuleParser::parse_event_class_json(
         return false;
       }
 
-      if (!parse_event_class_obj_json(*it, audit_rule)) {
+      if (!parse_event_class_obj_json(*it, audit_rule, skip_disabled_events)) {
         return false;
       }
     }
@@ -210,7 +213,8 @@ bool AuditRuleParser::parse_event_class_json(
 }
 
 bool AuditRuleParser::parse_event_class_obj_json(
-    const rapidjson::Value &event_class_json, AuditRule *audit_rule) noexcept {
+    const rapidjson::Value &event_class_json, AuditRule *audit_rule,
+    bool skip_disabled_events) noexcept {
   assert(event_class_json.IsObject());
 
   if (!event_class_json.HasMember("name")) {
@@ -270,6 +274,12 @@ bool AuditRuleParser::parse_event_class_obj_json(
 
     if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
         !is_event_class_allowed_in_reduced_mode(event_class_name)) {
+      if (skip_disabled_events) {
+        LogComponentErr(WARNING_LEVEL, ER_AUDIT_PARSE_SKIP_DISABLED_EVENT_CLASS,
+                        event_class_name.c_str(),
+                        audit_rule->get_rule_name().c_str());
+        return true;
+      }
       audit_rule->set_parse_error(
           "event class '" + event_class_name +
           "' is disabled in audit_log_filter.event_mode=REDUCED");
@@ -299,11 +309,11 @@ bool AuditRuleParser::parse_event_class_obj_json(
         return false;
       }
 
-      // There is a subclass specific definition, it will provide actual action
       should_log = false;
 
       if (!parse_event_subclass_json(event_class_name,
-                                     event_class_json["event"], audit_rule)) {
+                                     event_class_json["event"], audit_rule,
+                                     skip_disabled_events)) {
         return false;
       }
     }
@@ -364,6 +374,12 @@ bool AuditRuleParser::parse_event_class_obj_json(
 
       if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
           !is_event_class_allowed_in_reduced_mode(event_class_name)) {
+        if (skip_disabled_events) {
+          LogComponentErr(
+              WARNING_LEVEL, ER_AUDIT_PARSE_SKIP_DISABLED_EVENT_CLASS,
+              event_class_name.c_str(), audit_rule->get_rule_name().c_str());
+          continue;
+        }
         audit_rule->set_parse_error(
             "event class '" + event_class_name +
             "' is disabled in audit_log_filter.event_mode=REDUCED");
@@ -402,7 +418,7 @@ bool AuditRuleParser::parse_event_class_obj_json(
 
 bool AuditRuleParser::parse_event_subclass_json(
     const std::string &class_name, const rapidjson::Value &event_subclass_json,
-    AuditRule *audit_rule) noexcept {
+    AuditRule *audit_rule, bool skip_disabled_events) noexcept {
   /*
    * Parse event subclass, 'event' may be an object or an array of objects
    *
@@ -421,7 +437,7 @@ bool AuditRuleParser::parse_event_subclass_json(
    */
   if (event_subclass_json.IsObject()) {
     if (!parse_event_subclass_obj_json(class_name, event_subclass_json,
-                                       audit_rule)) {
+                                       audit_rule, skip_disabled_events)) {
       return false;
     }
   } else if (event_subclass_json.IsArray()) {
@@ -443,7 +459,8 @@ bool AuditRuleParser::parse_event_subclass_json(
         return false;
       }
 
-      if (!parse_event_subclass_obj_json(class_name, *it, audit_rule)) {
+      if (!parse_event_subclass_obj_json(class_name, *it, audit_rule,
+                                         skip_disabled_events)) {
         return false;
       }
     }
@@ -461,7 +478,7 @@ bool AuditRuleParser::parse_event_subclass_json(
 
 bool AuditRuleParser::parse_event_subclass_obj_json(
     const std::string &class_name, const rapidjson::Value &event_subclass_json,
-    AuditRule *audit_rule) noexcept {
+    AuditRule *audit_rule, bool skip_disabled_events) noexcept {
   assert(event_subclass_json.IsObject());
 
   if (!event_subclass_json.HasMember("name")) {
@@ -518,7 +535,8 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
     return false;
   }
 
-  for (const auto &name : subclass_names) {
+  for (auto it = subclass_names.begin(); it != subclass_names.end();) {
+    const auto &name = *it;
     if (!is_valid_event_subclass_name(class_name, name)) {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_INVALID_EVENT_SUBCLASS_NAME,
                       audit_rule->get_rule_name().c_str(), name.c_str(),
@@ -530,11 +548,21 @@ bool AuditRuleParser::parse_event_subclass_obj_json(
 
     if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
         !is_event_subclass_allowed_in_reduced_mode(class_name, name)) {
+      if (skip_disabled_events) {
+        LogComponentErr(WARNING_LEVEL,
+                        ER_AUDIT_PARSE_SKIP_DISABLED_EVENT_SUBCLASS,
+                        class_name.c_str(), name.c_str(),
+                        audit_rule->get_rule_name().c_str());
+        it = subclass_names.erase(it);
+        continue;
+      }
       audit_rule->set_parse_error(
           "event '" + class_name + "/" + name +
           "' is disabled in audit_log_filter.event_mode=REDUCED");
       return false;
     }
+
+    ++it;
   }
 
   const auto has_log_tag = event_subclass_json.HasMember("log");
@@ -1543,7 +1571,7 @@ std::shared_ptr<AuditRule> AuditRuleParser::make_replacement_rule(
       audit_rule != nullptr ? audit_rule->get_rule_name() : std::string{};
   auto rule = std::make_shared<AuditRule>(rule_name.c_str());
 
-  if (AuditRuleParser::parse(d, rule.get())) {
+  if (AuditRuleParser::parse(d, rule.get(), false)) {
     return rule;
   }
 

--- a/components/audit_log_filter/audit_rule_parser.h
+++ b/components/audit_log_filter/audit_rule_parser.h
@@ -30,10 +30,14 @@ class AuditRuleParser {
    *
    * @param rule_str String representation of audit filtering rule
    * @param audit_rule Audit filtering rule instance to be initialized
+   * @param skip_disabled_events When true, silently skip event
+   *        classes/subclasses disabled by the current event_mode
+   *        instead of treating them as parse errors
    * @return true in case rule is parsed successfully,
    *         false otherwise
    */
-  static bool parse(const char *rule_str, AuditRule *audit_rule) noexcept;
+  static bool parse(const char *rule_str, AuditRule *audit_rule,
+                    bool skip_disabled_events = false) noexcept;
 
  private:
   /**
@@ -41,11 +45,12 @@ class AuditRuleParser {
    *
    * @param json_doc JSON document representation of audit filtering rule
    * @param audit_rule Audit filtering rule instance to be initialized
+   * @param skip_disabled_events When true, silently skip disabled events
    * @return true in case rule is parsed successfully,
    *         false otherwise
    */
-  static bool parse(rapidjson::Document &json_doc,
-                    AuditRule *audit_rule) noexcept;
+  static bool parse(rapidjson::Document &json_doc, AuditRule *audit_rule,
+                    bool skip_disabled_events) noexcept;
 
   /**
    * @brief Determine the default logging action for unmatched audit events.
@@ -67,7 +72,8 @@ class AuditRuleParser {
    *         false otherwise
    */
   static bool parse_event_class_json(const rapidjson::Document &json_doc,
-                                     AuditRule *audit_rule) noexcept;
+                                     AuditRule *audit_rule,
+                                     bool skip_disabled_events) noexcept;
 
   /**
    * @brief Parse one JSON object related to audit event class definition.
@@ -79,7 +85,8 @@ class AuditRuleParser {
    *         false otherwise
    */
   static bool parse_event_class_obj_json(
-      const rapidjson::Value &event_class_json, AuditRule *audit_rule) noexcept;
+      const rapidjson::Value &event_class_json, AuditRule *audit_rule,
+      bool skip_disabled_events) noexcept;
 
   /**
    * @brief Parse audit event subclass related definitions in a filtering rule
@@ -93,8 +100,8 @@ class AuditRuleParser {
    */
   static bool parse_event_subclass_json(
       const std::string &class_name,
-      const rapidjson::Value &event_subclass_json,
-      AuditRule *audit_rule) noexcept;
+      const rapidjson::Value &event_subclass_json, AuditRule *audit_rule,
+      bool skip_disabled_events) noexcept;
 
   /**
    * @brief Parse JSON definition for one event subclass in a filtering rule.
@@ -107,8 +114,8 @@ class AuditRuleParser {
    */
   static bool parse_event_subclass_obj_json(
       const std::string &class_name,
-      const rapidjson::Value &event_subclass_json,
-      AuditRule *audit_rule) noexcept;
+      const rapidjson::Value &event_subclass_json, AuditRule *audit_rule,
+      bool skip_disabled_events) noexcept;
 
   /**
    * @brief Parse definition of a logical condition in audit event filter

--- a/components/audit_log_filter/audit_rule_registry.cc
+++ b/components/audit_log_filter/audit_rule_registry.cc
@@ -44,7 +44,8 @@ bool AuditRuleRegistry::lookup_rule_name(const std::string &user_name,
                                          std::string &rule_name) noexcept {
   if (!m_is_initialised) {
     m_is_initialised = true;
-    if (!load()) {
+    std::string error_msg;
+    if (!load(error_msg)) {
       LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
                       "Failed to load filtering rules");
     }
@@ -67,7 +68,9 @@ bool AuditRuleRegistry::lookup_rule_name(const std::string &user_name,
   return false;
 }
 
-bool AuditRuleRegistry::load() noexcept {
+void AuditRuleRegistry::invalidate() noexcept { m_is_initialised = false; }
+
+bool AuditRuleRegistry::load(std::string &error_message) noexcept {
   audit_table::AuditLogFilter audit_log_filter{
       SysVars::get_config_database_name()};
   audit_table::AuditLogUser audit_log_user{SysVars::get_config_database_name()};
@@ -76,7 +79,7 @@ bool AuditRuleRegistry::load() noexcept {
   auto tmp_rules = audit_table::AuditLogFilter::AuditRulesContainer{};
 
   const bool is_success =
-      (audit_log_filter.load_filters(tmp_rules) ==
+      (audit_log_filter.load_filters(tmp_rules, error_message) ==
        audit_table::TableResult::Ok) &&
       (audit_log_user.load_users(tmp_users) == audit_table::TableResult::Ok);
 

--- a/components/audit_log_filter/audit_rule_registry.h
+++ b/components/audit_log_filter/audit_rule_registry.h
@@ -35,10 +35,11 @@ class AuditRuleRegistry {
   /**
    * @brief Load filtering rules from DB.
    *
+   * @param error_message Out-parameter for a human-readable error
    * @return true in case filtering rules are loaded successfully,
    *         false otherwise
    */
-  bool load() noexcept;
+  bool load(std::string &error_message) noexcept;
 
   /**
    * @brief Get filtering rule by name.
@@ -61,6 +62,15 @@ class AuditRuleRegistry {
   bool lookup_rule_name(const std::string &user_name,
                         const std::string &host_name,
                         std::string &rule_name) noexcept;
+
+  /**
+   * @brief Mark the registry as needing a reload on the next rule lookup.
+   *
+   * Safe to call from any context (lock-free atomic store). The actual
+   * reload happens inside the next lookup_rule_name() call, which runs
+   * in a THD context where table access is permitted.
+   */
+  void invalidate() noexcept;
 
  private:
   std::atomic<bool> m_is_initialised{false};

--- a/components/audit_log_filter/audit_table/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_table/audit_log_filter.cc
@@ -88,8 +88,8 @@ TableResult AuditLogFilter::index_scan_locate_record_by_rule_name(
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyFilterNameName, kKeyFilterNameNameLength,
                       key_filter_name_cols, kKeyFilterNameNumcol, key) != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init index scan of %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_INDEX_SCAN_INIT_FAILURE,
+                    get_table_name());
     return TableResult::Fail;
   }
 
@@ -130,8 +130,8 @@ TableResult AuditLogFilter::get_next_pk_value(TableAccessContext *ta_context,
                       kKeyFilterPrimaryName, kKeyFilterPrimaryNameLength,
                       key_filter_primary_cols, kKeyFilterPrimaryNumcol,
                       &filter_id_key) != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init index scan of %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_INDEX_SCAN_INIT_FAILURE,
+                    get_table_name());
     return TableResult::Fail;
   }
 
@@ -144,8 +144,8 @@ TableResult AuditLogFilter::get_next_pk_value(TableAccessContext *ta_context,
 
     if (integer_srv->get(ta_context->ta_session, ta_context->ta_table,
                          kAuditLogFilterFilterId, &found_filter_id)) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.filter_id", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "filter_id");
       index_scan_end(ta_context, filter_id_key);
       return TableResult::Fail;
     }
@@ -190,8 +190,8 @@ TableResult AuditLogFilter::load_filters(
       "field_any_access_v1", SysVars::get_comp_registry_srv());
 
   if (scan_srv->init(ta_context->ta_session, ta_context->ta_table)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init full scan of %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FULL_SCAN_INIT_FAILURE,
+                    get_table_name());
     return TableResult::Fail;
   }
 
@@ -210,20 +210,20 @@ TableResult AuditLogFilter::load_filters(
 
     if (integer_srv->get(ta_context->ta_session, ta_context->ta_table,
                          kAuditLogFilterFilterId, &filter_id)) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.filter_id", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "filter_id");
       return TableResult::Fail;
     }
     if (varchar_srv->get(ta_context->ta_session, ta_context->ta_table,
                          kAuditLogFilterName, filter_name_value.get())) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.filter", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "filter");
       return TableResult::Fail;
     }
     if (any_srv->get(ta_context->ta_session, ta_context->ta_table,
                      kAuditLogFilterFilter, filter_filter_value.get())) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.filter", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "filter");
       return TableResult::Fail;
     }
 
@@ -240,15 +240,14 @@ TableResult AuditLogFilter::load_filters(
     if (AuditRuleParser::parse(buff_filter_filter_value, rule.get())) {
       container.insert({buff_filter_name_value, std::move(rule)});
     } else {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "audit_log_filter name: %s, filter: %s has wrong format",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FILTER_WRONG_FORMAT,
                       buff_filter_name_value, buff_filter_filter_value);
     }
   }
 
   if (scan_srv->end(ta_context->ta_session, ta_context->ta_table)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to end full scan of %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FULL_SCAN_END_FAILURE,
+                    get_table_name());
     return TableResult::Fail;
   }
 
@@ -332,15 +331,13 @@ TableResult AuditLogFilter::insert_filter(
       table_update_srv->insert(ta_context->ta_session, ta_context->ta_table);
 
   if (rc != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to insert filtering rule '%s', '%s'",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_UDF_SET_FILTER_FAILURE,
                     rule_name.c_str(), rule_definition.c_str());
     return TableResult::Fail;
   }
 
   if (table_access_srv->commit(ta_context->ta_session)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to insert filtering rule '%s', '%s', commit failed",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FILTER_INSERT_COMMIT_FAILURE,
                     rule_name.c_str(), rule_definition.c_str());
     return TableResult::Fail;
   }
@@ -381,16 +378,14 @@ TableResult AuditLogFilter::delete_filter(
                                          ta_context->ta_table);
 
   if (rc != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to delete filter with the name '%s'",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FILTER_DELETE_FAILURE,
                     rule_name.c_str());
     index_scan_end(ta_context.get(), filter_name_key);
     return TableResult::Fail;
   }
 
   if (table_access_srv->commit(ta_context->ta_session)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to delete filter with the name '%s', commit failed",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FILTER_DELETE_COMMIT_FAILURE,
                     rule_name.c_str());
     index_scan_end(ta_context.get(), filter_name_key);
     return TableResult::Fail;

--- a/components/audit_log_filter/audit_table/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_table/audit_log_filter.cc
@@ -161,8 +161,8 @@ TableResult AuditLogFilter::get_next_pk_value(TableAccessContext *ta_context,
   return TableResult::Ok;
 }
 
-TableResult AuditLogFilter::load_filters(
-    AuditRulesContainer &container) noexcept {
+TableResult AuditLogFilter::load_filters(AuditRulesContainer &container,
+                                         std::string &error_message) noexcept {
   container.clear();
 
   DBUG_EXECUTE_IF("audit_log_filter_fail_filters_flush",
@@ -203,6 +203,8 @@ TableResult AuditLogFilter::load_filters(
   HStringContainer filter_name_value{string_srv};
   HStringContainer filter_filter_value{string_srv};
 
+  bool has_parse_error = false;
+
   while (true) {
     if (scan_srv->next(ta_context->ta_session, ta_context->ta_table)) {
       break;
@@ -237,11 +239,16 @@ TableResult AuditLogFilter::load_filters(
     auto rule = std::make_shared<AuditRule>(static_cast<uint64_t>(filter_id),
                                             buff_filter_name_value);
 
-    if (AuditRuleParser::parse(buff_filter_filter_value, rule.get())) {
+    if (AuditRuleParser::parse(buff_filter_filter_value, rule.get(),
+                               /*skip_disabled_events=*/true)) {
       container.insert({buff_filter_name_value, std::move(rule)});
     } else {
       LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FILTER_WRONG_FORMAT,
                       buff_filter_name_value, buff_filter_filter_value);
+      error_message = std::string("Filter '") + buff_filter_name_value +
+                      "' has wrong format, consider using "
+                      "audit_log_filter.event_mode=FULL";
+      has_parse_error = true;
     }
   }
 
@@ -251,7 +258,7 @@ TableResult AuditLogFilter::load_filters(
     return TableResult::Fail;
   }
 
-  return TableResult::Ok;
+  return has_parse_error ? TableResult::Fail : TableResult::Ok;
 }
 
 TableResult AuditLogFilter::check_name_exists(

--- a/components/audit_log_filter/audit_table/audit_log_filter.h
+++ b/components/audit_log_filter/audit_table/audit_log_filter.h
@@ -35,9 +35,11 @@ class AuditLogFilter : public AuditTableBase {
    * @brief Load filtering rules list.
    *
    * @param container Container to store filtering rules list into
+   * @param error_message Out-parameter for a human-readable error
    * @return Table access result, @ref TableResult
    */
-  TableResult load_filters(AuditRulesContainer &container) noexcept;
+  TableResult load_filters(AuditRulesContainer &container,
+                           std::string &error_message) noexcept;
 
   /**
    * @brief Check if filtering rule with provided name exists.

--- a/components/audit_log_filter/audit_table/audit_log_user.cc
+++ b/components/audit_log_filter/audit_table/audit_log_user.cc
@@ -98,8 +98,7 @@ TableResult AuditLogUser::index_scan_locate_record_by_rule_name(
                         kKeyFilterNameLegacyName,
                         kKeyFilterNameLegacyNameLength, key_filter_name_cols,
                         kKeyFilterNameNumcol, key)) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to init index access of %s table",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_INDEX_ACCESS_INIT_FAILURE,
                       get_table_name());
       return TableResult::Fail;
     }
@@ -136,8 +135,7 @@ TableResult AuditLogUser::index_scan_locate_record_by_user_name_host(
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyPrimaryName, kKeyPrimaryLength, key_primary_cols,
                       kKeyPrimaryNumcol, key)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init index access of %s table",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_INDEX_ACCESS_INIT_FAILURE,
                     get_table_name());
     return TableResult::Fail;
   }
@@ -196,8 +194,8 @@ TableResult AuditLogUser::load_users(AuditUsersContainer &container) noexcept {
       "table_access_scan_v1", SysVars::get_comp_registry_srv());
 
   if (scan_srv->init(ta_context->ta_session, ta_context->ta_table)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init full scan of %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FULL_SCAN_INIT_FAILURE,
+                    get_table_name());
     return TableResult::Fail;
   }
 
@@ -217,21 +215,21 @@ TableResult AuditLogUser::load_users(AuditUsersContainer &container) noexcept {
 
     if (varchar_srv->get(ta_context->ta_session, ta_context->ta_table,
                          kAuditLogUserUsername, user_name_value.get())) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.username", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "username");
       return TableResult::Fail;
     }
     if (varchar_srv->get(ta_context->ta_session, ta_context->ta_table,
                          kAuditLogUserUserhost, user_host_value.get())) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.userhost", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "userhost");
       return TableResult::Fail;
     }
     if (varchar_srv->get(ta_context->ta_session, ta_context->ta_table,
                          kAuditLogUserFiltername,
                          user_filter_name_value.get())) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to read %s.filtername", get_table_name());
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                      get_table_name(), "filtername");
       return TableResult::Fail;
     }
 
@@ -250,8 +248,8 @@ TableResult AuditLogUser::load_users(AuditUsersContainer &container) noexcept {
   }
 
   if (scan_srv->end(ta_context->ta_session, ta_context->ta_table)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to end full scan of %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_FULL_SCAN_END_FAILURE,
+                    get_table_name());
     return TableResult::Fail;
   }
 
@@ -293,8 +291,7 @@ TableResult AuditLogUser::delete_user_by_filter(
   while (rc == 0) {
     if (table_update_srv->delete_row(ta_context->ta_session,
                                      ta_context->ta_table) != 0) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to delete record for filter '%s'",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_USER_DELETE_FILTER_FAILURE,
                       rule_name.c_str());
       index_scan_end(ta_context.get(), filter_name_key);
       return TableResult::Fail;
@@ -308,8 +305,8 @@ TableResult AuditLogUser::delete_user_by_filter(
   if (table_access_srv->commit(ta_context->ta_session)) {
     index_scan_end(ta_context.get(), filter_name_key);
 
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to delete record for filter '%s', commit failed",
+    LogComponentErr(ERROR_LEVEL,
+                    ER_AUDIT_TABLE_USER_DELETE_FILTER_COMMIT_FAILURE,
                     rule_name.c_str());
     return TableResult::Fail;
   }
@@ -346,8 +343,7 @@ TableResult AuditLogUser::delete_user_by_name_host(
   if (scan_result == TableResult::Found &&
       table_update_srv->delete_row(ta_context->ta_session,
                                    ta_context->ta_table) != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to delete record for user '%s@%s'",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_USER_DELETE_USER_FAILURE,
                     user_name.c_str(), user_host.c_str());
     index_scan_end(ta_context.get(), user_host_key);
     return TableResult::Fail;
@@ -356,8 +352,7 @@ TableResult AuditLogUser::delete_user_by_name_host(
   if (table_access_srv->commit(ta_context->ta_session)) {
     index_scan_end(ta_context.get(), user_host_key);
 
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to delete record for user '%s@%s', commit failed",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_USER_DELETE_USER_COMMIT_FAILURE,
                     user_name.c_str(), user_host.c_str());
     return TableResult::Fail;
   }
@@ -418,8 +413,7 @@ TableResult AuditLogUser::set_update_filter(
   if (rc != 0) {
     index_scan_end(ta_context.get(), user_host_key);
 
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to assign '%s' filtering rule for user '%s@%s'",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_USER_ASSIGN_FILTER_FAILURE,
                     filter_name.c_str(), user_name.c_str(), user_host.c_str());
     return TableResult::Fail;
   }
@@ -427,10 +421,9 @@ TableResult AuditLogUser::set_update_filter(
   if (table_access_srv->commit(ta_context->ta_session)) {
     index_scan_end(ta_context.get(), user_host_key);
 
-    LogComponentErr(
-        ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-        "Failed to assign '%s' filtering rule for user '%s@%s', commit failed",
-        filter_name.c_str(), user_name.c_str(), user_host.c_str());
+    LogComponentErr(ERROR_LEVEL,
+                    ER_AUDIT_TABLE_USER_ASSIGN_FILTER_COMMIT_FAILURE,
+                    filter_name.c_str(), user_name.c_str(), user_host.c_str());
     return TableResult::Fail;
   }
 

--- a/components/audit_log_filter/audit_table/base.cc
+++ b/components/audit_log_filter/audit_table/base.cc
@@ -81,16 +81,15 @@ std::unique_ptr<TableAccessContext> AuditTableBase::open_table() noexcept {
       table_access_srv->get(ta_context->ta_session, ta_context->table_ticket);
 
   if (ta_context->ta_table == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to get an opened %s table", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_OPEN_FAILURE, get_table_name());
     return nullptr;
   }
 
   if (table_access_srv->check(ta_context->ta_session, ta_context->ta_table,
                               get_table_field_def(),
                               get_table_field_count()) != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to check %s table fields", get_table_name());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_CHECK_FIELDS_FAILURE,
+                    get_table_name());
     return nullptr;
   }
 

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -207,8 +207,7 @@ bool AuditUdf::init(UdfFuncInfo *begin, UdfFuncInfo *end) {
                 ? reinterpret_cast<Udf_func_any>(it->udf_str_func)
                 : reinterpret_cast<Udf_func_any>(it->udf_int_func),
             it->init_func, it->deinit_func) == 1) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to register %s UDF", it->udf_name);
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_UDF_REGISTER_FAILURE, it->udf_name);
       return false;
     }
 

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -459,7 +459,8 @@ char *AuditUdf::audit_log_filter_remove_filter_udf(
     return result;
   }
 
-  get_audit_log_filter_instance()->on_audit_rule_flush_requested();
+  std::string error_msg;
+  get_audit_log_filter_instance()->on_audit_rule_flush_requested(error_msg);
 
   std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   *length = std::strlen(result);
@@ -586,7 +587,8 @@ char *AuditUdf::audit_log_filter_set_user_udf(AuditUdf *udf [[maybe_unused]],
     return result;
   }
 
-  get_audit_log_filter_instance()->on_audit_rule_flush_requested();
+  std::string error_msg;
+  get_audit_log_filter_instance()->on_audit_rule_flush_requested(error_msg);
 
   std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   *length = std::strlen(result);
@@ -672,7 +674,8 @@ char *AuditUdf::audit_log_filter_remove_user_udf(
     return result;
   }
 
-  get_audit_log_filter_instance()->on_audit_rule_flush_requested();
+  std::string error_msg;
+  get_audit_log_filter_instance()->on_audit_rule_flush_requested(error_msg);
 
   std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   *length = std::strlen(result);
@@ -720,8 +723,12 @@ char *AuditUdf::audit_log_filter_flush_udf(AuditUdf *udf [[maybe_unused]],
                                            char *result, unsigned long *length,
                                            unsigned char *is_null,
                                            unsigned char *error) noexcept {
-  if (get_audit_log_filter_instance()->on_audit_rule_flush_requested()) {
+  std::string flush_error;
+  if (get_audit_log_filter_instance()->on_audit_rule_flush_requested(
+          flush_error)) {
     std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
+  } else if (!flush_error.empty()) {
+    std::snprintf(result, MYSQL_ERRMSG_SIZE, "ERROR: %s", flush_error.c_str());
   } else {
     std::snprintf(result, MYSQL_ERRMSG_SIZE,
                   "ERROR: Could not reinitialize audit log filters");

--- a/components/audit_log_filter/filter_definition_fields.md
+++ b/components/audit_log_filter/filter_definition_fields.md
@@ -12,6 +12,18 @@ filter-definition validation through `audit_log_filter_set_filter()`.
 - Some numeric-looking fields are currently validated as `string` because they
   are not explicitly typed in `get_event_field_value_type()`.
 - Filter-definition validation only accepts the class names documented below.
+- When `audit_log_filter.event_mode=REDUCED` (the default), only the following
+  events are tracked and accepted by filter-definition validation:
+  - `general`: `status`
+  - `connection`: `connect`, `disconnect`, `change_user`
+  - `table_access`: `read`, `insert`, `update`, `delete`
+  - `message`: `internal`, `user`
+
+  Class names that have no allowed events in REDUCED mode (`global_variable`,
+  `command`, `query`, `stored_program`, `authentication`, `parse`) are rejected
+  entirely. Subclass names that are not in the list above (e.g. `general/log`,
+  `connection/pre_authenticate`) are also rejected during filter validation.
+  At runtime, events not in the REDUCED set are silently skipped.
 - Lifecycle-related records with class names `audit`, `server_startup`, and
   `server_shutdown` are not valid filter-definition targets. Startup and
   shutdown lifecycle events are ignored by the audit log filter if they are
@@ -23,6 +35,7 @@ filter-definition validation through `audit_log_filter_set_filter()`.
 ## `general`
 
 Supported events: `log`, `error`, `result`, `status`
+REDUCED mode: only `status`
 
 | Field Name | Field Type | Description |
 | --- | --- | --- |
@@ -47,6 +60,7 @@ Supported events: `log`, `error`, `result`, `status`
 ## `connection`
 
 Supported events: `connect`, `disconnect`, `change_user`, `pre_authenticate`
+REDUCED mode: `connect`, `disconnect`, `change_user`
 
 | Field Name | Field Type | Description |
 | --- | --- | --- |
@@ -77,6 +91,7 @@ Supported events: `connect`, `disconnect`, `change_user`, `pre_authenticate`
 ## `table_access`
 
 Supported events: `read`, `insert`, `update`, `delete`
+REDUCED mode: all events
 
 | Field Name | Field Type | Description |
 | --- | --- | --- |
@@ -89,7 +104,7 @@ Supported events: `read`, `insert`, `update`, `delete`
 | `table_name.str` | string | Table name associated with event. |
 | `table_name.length` | unsigned integer | Table name length. |
 
-## `global_variable`
+## `global_variable` *(FULL mode only)*
 
 Supported events: `get`, `set`
 
@@ -101,7 +116,7 @@ Supported events: `get`, `set`
 | `variable_value.str` | string | Variable value. |
 | `variable_value.length` | string | Variable value length. |
 
-## `command`
+## `command` *(FULL mode only)*
 
 Supported events: `start`, `end`
 
@@ -112,7 +127,7 @@ Supported events: `start`, `end`
 | `command.str` | string | Command text. |
 | `command.length` | string | Command text length. |
 
-## `query`
+## `query` *(FULL mode only)*
 
 Supported events: `start`, `nested_start`, `status_end`, `nested_status_end`
 
@@ -125,7 +140,7 @@ Supported events: `start`, `nested_start`, `status_end`, `nested_status_end`
 | `query.length` | string | SQL query text length. |
 | `query_charset` | string | SQL query character set name. |
 
-## `stored_program`
+## `stored_program` *(FULL mode only)*
 
 Supported events: `execute`
 
@@ -137,7 +152,7 @@ Supported events: `execute`
 | `name.str` | string | Stored program name. |
 | `name.length` | string | Stored program name length. |
 
-## `authentication`
+## `authentication` *(FULL mode only)*
 
 Supported events: `flush`, `authid_create`, `credential_change`, `authid_rename`, `authid_drop`
 
@@ -153,6 +168,7 @@ Supported events: `flush`, `authid_create`, `credential_change`, `authid_rename`
 ## `message`
 
 Supported events: `internal`, `user`
+REDUCED mode: all events
 
 | Field Name | Field Type | Description |
 | --- | --- | --- |
@@ -164,7 +180,7 @@ Supported events: `internal`, `user`
 | `message.str` | string | Message text. |
 | `message.length` | string | Message text length. |
 
-## `parse`
+## `parse` *(FULL mode only)*
 
 Supported events: `preparse`, `postparse`
 

--- a/components/audit_log_filter/json_reader/file_reader.cc
+++ b/components/audit_log_filter/json_reader/file_reader.cc
@@ -30,8 +30,7 @@ bool FileReader::open(FileInfo *file_info) noexcept {
   m_fp = fopen(file_info->name.c_str(), "r");
 
   if (m_fp == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to open file for reading: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_FILE_OPEN_READ_FAILURE,
                     file_info->name.c_str());
     return false;
   }
@@ -50,7 +49,7 @@ ReadStatus FileReader::read(unsigned char *out_buffer,
     const auto err = std::ferror(m_fp);
 
     if (err != 0) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, "Failed to read: %s",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_FILE_READ_FAILURE,
                       std::strerror(err));
       return ReadStatus::Error;
     }

--- a/components/audit_log_filter/json_reader/file_reader_decompressing.cc
+++ b/components/audit_log_filter/json_reader/file_reader_decompressing.cc
@@ -55,8 +55,7 @@ bool FileReaderDecompressing::open(FileInfo *file_info) noexcept {
   auto ret = inflateInit2(&m_strm, MAX_WBITS + 16);
 
   if (ret != Z_OK) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init decompressing: %i", ret);
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_DECOMPRESSION_INIT_FAILURE, ret);
     FileReaderDecoratorBase::close();
     return false;
   }

--- a/components/audit_log_filter/json_reader/file_reader_decrypting.cc
+++ b/components/audit_log_filter/json_reader/file_reader_decrypting.cc
@@ -79,8 +79,7 @@ bool FileReaderDecrypting::open(FileInfo *file_info) noexcept {
   const auto *encryption_options = file_info->encryption_options.get();
 
   if (encryption_options == nullptr || !encryption_options->check_valid()) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Invalid options provided for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_INVALID_OPTIONS,
                     file_info->encryption_options_id.c_str());
     return false;
   }
@@ -90,20 +89,19 @@ bool FileReaderDecrypting::open(FileInfo *file_info) noexcept {
   const auto &keyring_salt = encryption_options->get_salt();
 
   if (keyring_password.empty()) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, "Empty password for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_EMPTY_PASSWORD,
                     file_info->encryption_options_id.c_str());
     return false;
   }
 
   if (keyring_iterations < 1) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Bad iterations count for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_BAD_ITERATIONS,
                     file_info->encryption_options_id.c_str());
     return false;
   }
 
   if (keyring_salt.empty()) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, "Empty salt for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_EMPTY_SALT,
                     file_info->encryption_options_id.c_str());
     return false;
   }
@@ -119,8 +117,7 @@ bool FileReaderDecrypting::open(FileInfo *file_info) noexcept {
           keyring_salt.data(), static_cast<int>(keyring_salt.size()),
           static_cast<int>(keyring_iterations), EVP_sha256(), ik_len + iv_len,
           tmp_key_iv)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "PKCS5_PBKDF2_HMAC error: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_PBKDF2_ERROR,
                     ERR_error_string(ERR_peek_error(), nullptr));
     return false;
   }
@@ -136,8 +133,7 @@ bool FileReaderDecrypting::open(FileInfo *file_info) noexcept {
   }
 
   if (EVP_DecryptInit(m_ctx, m_cipher, m_key.get(), m_iv.get()) != 1) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "EVP_CipherInit_ex error: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_CIPHER_INIT_ERROR,
                     ERR_error_string(ERR_peek_error(), nullptr));
     ERR_clear_error();
     EVP_CIPHER_CTX_free(m_ctx);
@@ -197,8 +193,7 @@ ReadStatus FileReaderDecrypting::read(unsigned char *out_buffer,
 
   if (EVP_DecryptUpdate(m_ctx, out_buffer, &decrypted_size, m_in_buff.get(),
                         static_cast<int>(in_buff_data_size)) != 1) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "EVP_DecryptUpdate error: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_DECRYPT_UPDATE_ERROR,
                     ERR_error_string(ERR_peek_error(), nullptr));
     return ReadStatus::Error;
   }
@@ -210,8 +205,7 @@ ReadStatus FileReaderDecrypting::read(unsigned char *out_buffer,
 
     if (EVP_DecryptFinal(m_ctx, out_buffer + decrypted_size, &final_size) !=
         1) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "EVP_DecryptFinal error: %s",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_DECRYPT_FINAL_ERROR,
                       ERR_error_string(ERR_peek_error(), nullptr));
       return ReadStatus::Error;
     }

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -67,8 +67,7 @@ FileWriterPtr get_file_writer(FileHandle &file_handle) {
 
     return writer;
   } catch (std::exception &e) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to create Audit Log Filter file writer (%s)",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_FILE_WRITER_CREATE_FAILURE,
                     e.what());
   } catch (...) {
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -94,8 +93,7 @@ LogWriter<AuditLogHandlerType::File>::~LogWriter() {
   if (!FileHandle::get_not_rotated_file_path(SysVars::get_file_dir(),
                                              SysVars::get_file_name(),
                                              current_log_path)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to list audit filter log directory '%s'",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_DIR_LIST_FAILURE,
                     SysVars::get_file_dir().c_str());
     return;
   }
@@ -103,8 +101,7 @@ LogWriter<AuditLogHandlerType::File>::~LogWriter() {
   FileHandle::rotate(current_log_path, rotation_result.get());
 
   if (rotation_result->error_code != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to rotate audit filter log: %i, %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_ROTATE_INTERNAL_FAILURE,
                     rotation_result->error_code,
                     rotation_result->status_string.c_str());
   }
@@ -122,8 +119,7 @@ bool LogWriterFile::open() noexcept {
   if (!FileHandle::get_not_rotated_file_path(SysVars::get_file_dir(),
                                              SysVars::get_file_name(),
                                              current_log_path)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to list audit filter log directory '%s'",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_DIR_LIST_FAILURE,
                     SysVars::get_file_dir().c_str());
     return false;
   }
@@ -131,8 +127,7 @@ bool LogWriterFile::open() noexcept {
   FileHandle::rotate(current_log_path, rotation_result.get());
 
   if (rotation_result->error_code != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to rotate audit filter log: %i, %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_ROTATE_INTERNAL_FAILURE,
                     rotation_result->error_code,
                     rotation_result->status_string.c_str());
     return false;
@@ -164,8 +159,7 @@ bool LogWriterFile::do_open_file() noexcept {
   const bool file_exists = std::filesystem::exists(file_path, ec);
   if (ec) {
     const auto file_path_str = file_path.string();
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to inspect audit filter log path '%s': %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_FILE_INSPECT_FAILURE,
                     file_path_str.c_str(), ec.message().c_str());
     return false;
   }
@@ -175,8 +169,7 @@ bool LogWriterFile::do_open_file() noexcept {
     if (!FileHandle::remove_file_footer(file_path,
                                         get_formatter()->get_file_footer())) {
       const auto file_path_str = file_path.string();
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to prepare audit filter log '%s' for appending",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_FILE_PREPARE_FAILURE,
                       file_path_str.c_str());
       return false;
     }
@@ -277,8 +270,7 @@ void LogWriterFile::do_rotate(FileRotationResult *result) noexcept {
   FileHandle::rotate(current_log_path, result);
 
   if (result->error_code != 0) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to rotate audit filter log: %i, %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_LOG_ROTATE_INTERNAL_FAILURE,
                     result->error_code, result->status_string.c_str());
   }
 

--- a/components/audit_log_filter/log_writer/file_handle.cc
+++ b/components/audit_log_filter/log_writer/file_handle.cc
@@ -55,8 +55,7 @@ bool for_each_directory_entry(const std::string &working_dir_name,
   const auto end = std::filesystem::directory_iterator{};
 
   if (ec) {
-    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to list audit log directory '%s': %s",
+    LogComponentErr(WARNING_LEVEL, ER_AUDIT_LOG_DIR_LISTING_FAILURE,
                     working_dir_name.c_str(), ec.message().c_str());
     return false;
   }
@@ -68,8 +67,7 @@ bool for_each_directory_entry(const std::string &working_dir_name,
 
     it.increment(ec);
     if (ec) {
-      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to iterate audit log directory '%s': %s",
+      LogComponentErr(WARNING_LEVEL, ER_AUDIT_LOG_DIR_ITERATE_FAILURE,
                       working_dir_name.c_str(), ec.message().c_str());
       return false;
     }
@@ -271,8 +269,7 @@ bool FileHandle::remove_file_footer(
   }
   if (ec) {
     const auto path_str = file_path.string();
-    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to remove footer from audit log '%s': %s",
+    LogComponentErr(WARNING_LEVEL, ER_AUDIT_LOG_FOOTER_REMOVE_FAILURE,
                     path_str.c_str(), ec.message().c_str());
     return false;
   }

--- a/components/audit_log_filter/log_writer/file_writer_compressing.cc
+++ b/components/audit_log_filter/log_writer/file_writer_compressing.cc
@@ -34,8 +34,7 @@ bool FileWriterCompressing::open() noexcept {
                           MAX_WBITS + 16, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
 
   if (ret != Z_OK) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to init compressing: %i", ret);
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_COMPRESSION_INIT_FAILURE, ret);
     return false;
   }
 

--- a/components/audit_log_filter/log_writer/file_writer_encrypting.cc
+++ b/components/audit_log_filter/log_writer/file_writer_encrypting.cc
@@ -68,8 +68,7 @@ bool FileWriterEncrypting::open() noexcept {
   const auto options = audit_keyring::get_encryption_options(keyring_key_id);
 
   if (options == nullptr || !options->check_valid()) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Failed to fetch options for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_OPTIONS_FETCH_FAILURE,
                     keyring_key_id.c_str());
     return false;
   }
@@ -79,19 +78,19 @@ bool FileWriterEncrypting::open() noexcept {
   const auto &keyring_salt = options->get_salt();
 
   if (keyring_password.empty()) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, "Empty password for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_EMPTY_PASSWORD,
                     keyring_key_id.c_str());
     return false;
   }
 
   if (keyring_iterations < 1) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "Bad iterations count for id %s", keyring_key_id.c_str());
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_BAD_ITERATIONS,
+                    keyring_key_id.c_str());
     return false;
   }
 
   if (keyring_salt.empty()) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, "Empty salt for id %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_EMPTY_SALT,
                     keyring_key_id.c_str());
     return false;
   }
@@ -107,8 +106,7 @@ bool FileWriterEncrypting::open() noexcept {
           keyring_salt.data(), static_cast<int>(keyring_salt.size()),
           static_cast<int>(keyring_iterations), EVP_sha256(), ik_len + iv_len,
           tmp_key_iv)) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "PKCS5_PBKDF2_HMAC error: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_PBKDF2_ERROR,
                     ERR_error_string(ERR_peek_error(), nullptr));
     return false;
   }
@@ -125,8 +123,7 @@ bool FileWriterEncrypting::open() noexcept {
 
   if (EVP_CipherInit_ex(m_ctx, m_cipher, nullptr, m_key.get(), m_iv.get(), 1) !=
       1) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "EVP_CipherInit_ex error: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_CIPHER_INIT_ERROR,
                     ERR_error_string(ERR_peek_error(), nullptr));
     ERR_clear_error();
     EVP_CIPHER_CTX_free(m_ctx);
@@ -149,8 +146,7 @@ void FileWriterEncrypting::close() noexcept {
   int out_size = 0;
 
   if (EVP_EncryptFinal_ex(m_ctx, m_out_buff.get(), &out_size) != 1) {
-    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                    "EVP_EncryptFinal error: %s",
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_ENCRYPT_FINAL_ERROR,
                     ERR_error_string(ERR_peek_error(), nullptr));
   }
 
@@ -181,8 +177,7 @@ void FileWriterEncrypting::write(const char *record, size_t size) noexcept {
             m_ctx, m_out_buff.get(), &out_size,
             reinterpret_cast<const unsigned char *>(record + encrypted_size),
             chunk_size) != 1) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "EVP_EncryptUpdate error: %s",
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_ENCRYPTION_ENCRYPT_UPDATE_ERROR,
                       ERR_error_string(ERR_peek_error(), nullptr));
       return;
     }

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -274,6 +274,17 @@ void prune_seconds_update_func(MYSQL_THD, SYS_VAR *, void *val_ptr,
   }
 }
 
+void event_mode_update_func(MYSQL_THD, SYS_VAR *, void *val_ptr,
+                            const void *save) {
+  const auto new_val = *static_cast<const ulong *>(save);
+  const auto old_val = *static_cast<ulong *>(val_ptr);
+  *static_cast<ulong *>(val_ptr) = new_val;
+
+  if (old_val != new_val) {
+    get_audit_log_filter_instance()->invalidate_audit_rules();
+  }
+}
+
 const int audit_log_filter_syslog_facility_codes[] = {
     LOG_USER,     LOG_AUTHPRIV, LOG_CRON,   LOG_DAEMON, LOG_FTP,    LOG_KERN,
     LOG_LPR,      LOG_MAIL,     LOG_NEWS,
@@ -479,7 +490,7 @@ SysVarListType sys_vars = {
     {{"event_mode", PLUGIN_VAR_ENUM | PLUGIN_VAR_RQCMDARG,
       "Event mode controlling which event types are tracked. REDUCED limits "
       "events to a predefined subset, FULL tracks all events.",
-      nullptr, nullptr, static_cast<void *>(&check_event_mode),
+      nullptr, event_mode_update_func, static_cast<void *>(&check_event_mode),
       static_cast<void *>(&log_event_mode_type)},
      false},
     /*

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -205,6 +205,7 @@ std::string default_log_file_name{"audit_filter.log"};
 char *config_database_name;
 std::string default_config_database_name{"mysql"};
 ulong log_handler_type = static_cast<ulong>(AuditLogHandlerType::File);
+ulong log_event_mode_type = static_cast<ulong>(AuditLogEventModeType::Reduced);
 ulong log_format_type = static_cast<ulong>(AuditLogFormatType::New);
 ulong log_strategy_type =
     static_cast<ulong>(AuditLogStrategyType::Asynchronous);
@@ -231,6 +232,12 @@ const char *audit_log_filter_handler_names[] = {"FILE", "SYSLOG", nullptr};
 TYPE_LIB audit_log_filter_handler_typelib = {
     array_elements(audit_log_filter_handler_names) - 1,
     "audit_log_filter_handler_typelib", audit_log_filter_handler_names,
+    nullptr};
+
+const char *audit_log_filter_event_mode_names[] = {"REDUCED", "FULL", nullptr};
+TYPE_LIB audit_log_filter_event_mode_typelib = {
+    array_elements(audit_log_filter_event_mode_names) - 1,
+    "audit_log_filter_event_mode_typelib", audit_log_filter_event_mode_names,
     nullptr};
 
 const char *audit_log_filter_format_names[] = {"NEW", "OLD", "JSON", nullptr};
@@ -394,6 +401,9 @@ using int_arg_check_type = INTEGRAL_CHECK_ARG(int);
 str_arg_check_type check_file{default_log_file_name.data()};
 enum_arg_check_type check_handler{static_cast<ulong>(AuditLogHandlerType::File),
                                   &audit_log_filter_handler_typelib};
+enum_arg_check_type check_event_mode{
+    static_cast<ulong>(AuditLogEventModeType::Reduced),
+    &audit_log_filter_event_mode_typelib};
 enum_arg_check_type check_format{static_cast<ulong>(AuditLogFormatType::New),
                                  &audit_log_filter_format_typelib};
 enum_arg_check_type check_strategy{
@@ -460,6 +470,17 @@ SysVarListType sys_vars = {
       "The audit log handler.", nullptr, nullptr,
       static_cast<void *>(&check_handler),
       static_cast<void *>(&log_handler_type)},
+     false},
+    /*
+     * The audit_log_filter.event_mode variable controls which event types are
+     * tracked. REDUCED mode limits events to a predefined subset, FULL mode
+     * tracks all events. Defaults to REDUCED.
+     */
+    {{"event_mode", PLUGIN_VAR_ENUM | PLUGIN_VAR_RQCMDARG,
+      "Event mode controlling which event types are tracked. REDUCED limits "
+      "events to a predefined subset, FULL tracks all events.",
+      nullptr, nullptr, static_cast<void *>(&check_event_mode),
+      static_cast<void *>(&log_event_mode_type)},
      false},
     /*
      * The audit_log_filter.format variable is used to specify the audit filter
@@ -865,6 +886,10 @@ const char *SysVars::get_config_database_name() noexcept {
 
 AuditLogHandlerType SysVars::get_handler_type() noexcept {
   return static_cast<AuditLogHandlerType>(log_handler_type);
+}
+
+AuditLogEventModeType SysVars::get_event_mode_type() noexcept {
+  return static_cast<AuditLogEventModeType>(log_event_mode_type);
 }
 
 AuditLogFormatType SysVars::get_format_type() noexcept {

--- a/components/audit_log_filter/sys_vars.h
+++ b/components/audit_log_filter/sys_vars.h
@@ -36,6 +36,8 @@ using log_writer::AuditLogEncryptionType;
 using log_writer::AuditLogHandlerType;
 using log_writer::AuditLogStrategyType;
 
+enum class AuditLogEventModeType { Reduced = 0, Full = 1 };
+
 struct LogBookmark {
   uint64_t id;
   std::string timestamp;
@@ -90,6 +92,14 @@ class SysVars {
    *         of AuditLogHandlerType
    */
   [[nodiscard]] static AuditLogHandlerType get_handler_type() noexcept;
+
+  /**
+   * @brief Get audit log filter event mode.
+   *
+   * @return Audit log filter event mode, may be one of possible values
+   *         of AuditLogEventModeType
+   */
+  [[nodiscard]] static AuditLogEventModeType get_event_mode_type() noexcept;
 
   /**
    * @brief Get audit log filter format type.

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_filter_by_class.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_filter_by_class.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 #
 # Create all simple filters
 SELECT audit_log_filter_set_filter('log_general', '{"filter": {"class": {"name": "general"}}}');

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_filter_by_subclass.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_filter_by_subclass.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SET GLOBAL DEBUG='+d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';
 #

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_function_query_digest.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_function_query_digest.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SET GLOBAL DEBUG='+d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';
 #

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_print_query_attrs.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_print_query_attrs.result
@@ -67,7 +67,7 @@ SELECT audit_log_filter_set_filter('query_attrs_access_general', '{
 {
 "name": "general",
 "event": {
-"name": ["log", "error", "result", "status"],
+"name": ["status"],
 "print": {
 "query_attributes": {
 "tag": "query_attributes",

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SET GLOBAL DEBUG='+d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';
 CREATE TABLE t1 (id INT);

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_class.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_validate_class.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 #
 # Broken: empty "class" array
 SELECT audit_log_filter_set_filter('filter_broken_emptyClassArr', '{"filter": { "class": [] } }');

--- a/mysql-test/suite/component_audit_log_filter/r/log_format_xml_escape.result
+++ b/mysql-test/suite/component_audit_log_filter/r/log_format_xml_escape.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SELECT audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query", "event": {"name": "start"}}}}');
 audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query", "event": {"name": "start"}}}}')
 OK

--- a/mysql-test/suite/component_audit_log_filter/r/prepared_statement.result
+++ b/mysql-test/suite/component_audit_log_filter/r/prepared_statement.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SELECT audit_log_filter_set_filter('log_prepared', '{
 "filter": {
 "class": {

--- a/mysql-test/suite/component_audit_log_filter/r/status_var_buffer_bypassing_writes.result
+++ b/mysql-test/suite/component_audit_log_filter/r/status_var_buffer_bypassing_writes.result
@@ -1,3 +1,4 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SELECT audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query"}}}');
 audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query"}}}')
 OK

--- a/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_event_mode.result
+++ b/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_event_mode.result
@@ -1,0 +1,15 @@
+SELECT @@global.audit_log_filter.event_mode;
+@@global.audit_log_filter.event_mode
+REDUCED
+SELECT @@session.audit_log_filter.event_mode;
+ERROR HY000: Variable 'audit_log_filter.event_mode' is a GLOBAL variable
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT @@global.audit_log_filter.event_mode;
+@@global.audit_log_filter.event_mode
+REDUCED
+SET GLOBAL audit_log_filter.event_mode=FULL;
+SELECT @@global.audit_log_filter.event_mode;
+@@global.audit_log_filter.event_mode
+FULL
+SET GLOBAL audit_log_filter.event_mode="INVALID";
+ERROR 42000: Variable 'audit_log_filter.event_mode' can't be set to the value of 'INVALID'

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_validate_output.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_validate_output.result
@@ -2,6 +2,7 @@
 # PS-10347: AuditJsonHandler used by audit_log_read UDF returns malformed JSON
 # https://perconadev.atlassian.net/browse/PS-10347
 #
+SET GLOBAL audit_log_filter.event_mode=FULL;
 CREATE TABLE t1 (c1 INT);
 CREATE USER user1@localhost IDENTIFIED BY 'pass';
 GRANT ALL ON *.* TO user1@localhost;

--- a/mysql-test/suite/component_audit_log_filter/r/validate_event_mode_reduced.result
+++ b/mysql-test/suite/component_audit_log_filter/r/validate_event_mode_reduced.result
@@ -1,0 +1,66 @@
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT @@global.audit_log_filter.event_mode;
+@@global.audit_log_filter.event_mode
+REDUCED
+#
+# Reduced mode rejects disabled event classes during validation
+SELECT audit_log_filter_set_filter('disabled_query', '{"filter":{"class":{"name":"query"}}}');
+audit_log_filter_set_filter('disabled_query', '{"filter":{"class":{"name":"query"}}}')
+ERROR: Incorrect rule definition: event class 'query' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_global_variable', '{"filter":{"class":{"name":"global_variable"}}}');
+audit_log_filter_set_filter('disabled_global_variable', '{"filter":{"class":{"name":"global_variable"}}}')
+ERROR: Incorrect rule definition: event class 'global_variable' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_command', '{"filter":{"class":{"name":"command"}}}');
+audit_log_filter_set_filter('disabled_command', '{"filter":{"class":{"name":"command"}}}')
+ERROR: Incorrect rule definition: event class 'command' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_stored_program', '{"filter":{"class":{"name":"stored_program"}}}');
+audit_log_filter_set_filter('disabled_stored_program', '{"filter":{"class":{"name":"stored_program"}}}')
+ERROR: Incorrect rule definition: event class 'stored_program' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_authentication', '{"filter":{"class":{"name":"authentication"}}}');
+audit_log_filter_set_filter('disabled_authentication', '{"filter":{"class":{"name":"authentication"}}}')
+ERROR: Incorrect rule definition: event class 'authentication' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_parse', '{"filter":{"class":{"name":"parse"}}}');
+audit_log_filter_set_filter('disabled_parse', '{"filter":{"class":{"name":"parse"}}}')
+ERROR: Incorrect rule definition: event class 'parse' is disabled in audit_log_filter.event_mode=REDUCED
+#
+# Reduced mode rejects disabled event subclasses during validation
+SELECT audit_log_filter_set_filter('disabled_general_log', '{"filter":{"class":{"name":"general","event":{"name":"log"}}}}');
+audit_log_filter_set_filter('disabled_general_log', '{"filter":{"class":{"name":"general","event":{"name":"log"}}}}')
+ERROR: Incorrect rule definition: event 'general/log' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_general_error', '{"filter":{"class":{"name":"general","event":{"name":"error"}}}}');
+audit_log_filter_set_filter('disabled_general_error', '{"filter":{"class":{"name":"general","event":{"name":"error"}}}}')
+ERROR: Incorrect rule definition: event 'general/error' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_general_result', '{"filter":{"class":{"name":"general","event":{"name":"result"}}}}');
+audit_log_filter_set_filter('disabled_general_result', '{"filter":{"class":{"name":"general","event":{"name":"result"}}}}')
+ERROR: Incorrect rule definition: event 'general/result' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('disabled_conn_preauth', '{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate"}}}}');
+audit_log_filter_set_filter('disabled_conn_preauth', '{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate"}}}}')
+ERROR: Incorrect rule definition: event 'connection/pre_authenticate' is disabled in audit_log_filter.event_mode=REDUCED
+#
+# Reduced mode rejects mixed valid + invalid class names in arrays
+SELECT audit_log_filter_set_filter('mixed_general_query', '{"filter":{"class":{"name":["general","query"]}}}');
+audit_log_filter_set_filter('mixed_general_query', '{"filter":{"class":{"name":["general","query"]}}}')
+ERROR: Incorrect rule definition: event class 'query' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('mixed_connection_parse', '{"filter":{"class":{"name":["connection","parse"]}}}');
+audit_log_filter_set_filter('mixed_connection_parse', '{"filter":{"class":{"name":["connection","parse"]}}}')
+ERROR: Incorrect rule definition: event class 'parse' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('mixed_table_access_command', '{"filter":{"class":{"name":["table_access","command"]}}}');
+audit_log_filter_set_filter('mixed_table_access_command', '{"filter":{"class":{"name":["table_access","command"]}}}')
+ERROR: Incorrect rule definition: event class 'command' is disabled in audit_log_filter.event_mode=REDUCED
+SELECT audit_log_filter_set_filter('mixed_message_auth', '{"filter":{"class":{"name":["message","authentication"]}}}');
+audit_log_filter_set_filter('mixed_message_auth', '{"filter":{"class":{"name":["message","authentication"]}}}')
+ERROR: Incorrect rule definition: event class 'authentication' is disabled in audit_log_filter.event_mode=REDUCED
+#
+# Reduced mode logs only the reduced event-class subset
+SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}')
+OK
+SELECT audit_log_filter_set_user('%', 'log_all');
+audit_log_filter_set_user('%', 'log_all')
+OK
+SELECT audit_log_filter_flush();
+audit_log_filter_flush()
+OK
+OK
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/validate_event_mode_reduced.result
+++ b/mysql-test/suite/component_audit_log_filter/r/validate_event_mode_reduced.result
@@ -51,6 +51,94 @@ SELECT audit_log_filter_set_filter('mixed_message_auth', '{"filter":{"class":{"n
 audit_log_filter_set_filter('mixed_message_auth', '{"filter":{"class":{"name":["message","authentication"]}}}')
 ERROR: Incorrect rule definition: event class 'authentication' is disabled in audit_log_filter.event_mode=REDUCED
 #
+# Persisted filters keep the enabled subset after reload
+SELECT audit_log_filter_set_filter('mixed_rule', '{"filter":{"class":{"name":["general","query"]}}}');
+audit_log_filter_set_filter('mixed_rule', '{"filter":{"class":{"name":["general","query"]}}}')
+ERROR: Incorrect rule definition: event class 'query' is disabled in audit_log_filter.event_mode=REDUCED
+SET GLOBAL audit_log_filter.event_mode=FULL;
+SELECT audit_log_filter_set_filter('mixed_rule', '{"filter":{"class":{"name":["general","query"]}}}');
+audit_log_filter_set_filter('mixed_rule', '{"filter":{"class":{"name":["general","query"]}}}')
+OK
+SELECT audit_log_filter_set_filter('mixed_subclass_rule', '{"filter":{"class":{"name":"general","event":{"name":["status","log"]}}}}');
+audit_log_filter_set_filter('mixed_subclass_rule', '{"filter":{"class":{"name":"general","event":{"name":["status","log"]}}}}')
+OK
+SELECT audit_log_filter_set_filter('mixed_conn_command_rule', '{"filter":{"class":{"name":["connection","command"]}}}');
+audit_log_filter_set_filter('mixed_conn_command_rule', '{"filter":{"class":{"name":["connection","command"]}}}')
+OK
+SELECT audit_log_filter_set_filter('mixed_ta_sp_rule', '{"filter":{"class":{"name":["table_access","stored_program"]}}}');
+audit_log_filter_set_filter('mixed_ta_sp_rule', '{"filter":{"class":{"name":["table_access","stored_program"]}}}')
+OK
+SELECT audit_log_filter_set_filter('mixed_conn_subclass_rule', '{"filter":{"class":{"name":"connection","event":{"name":["connect","pre_authenticate"]}}}}');
+audit_log_filter_set_filter('mixed_conn_subclass_rule', '{"filter":{"class":{"name":"connection","event":{"name":["connect","pre_authenticate"]}}}}')
+OK
+SELECT * FROM mysql.audit_log_filter;
+filter_id	name	filter
+1	mixed_rule	{"filter": {"class": {"name": ["general", "query"]}}}
+2	mixed_subclass_rule	{"filter": {"class": {"name": "general", "event": {"name": ["status", "log"]}}}}
+3	mixed_conn_command_rule	{"filter": {"class": {"name": ["connection", "command"]}}}
+4	mixed_ta_sp_rule	{"filter": {"class": {"name": ["table_access", "stored_program"]}}}
+5	mixed_conn_subclass_rule	{"filter": {"class": {"name": "connection", "event": {"name": ["connect", "pre_authenticate"]}}}}
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT audit_log_filter_flush();
+audit_log_filter_flush()
+OK
+SELECT audit_log_filter_set_user('%', 'mixed_rule');
+audit_log_filter_set_user('%', 'mixed_rule')
+OK
+Tag "class": "general" Ok
+SELECT audit_log_filter_set_user('%', 'mixed_subclass_rule');
+audit_log_filter_set_user('%', 'mixed_subclass_rule')
+OK
+Tag "event": "status" Ok
+SELECT audit_log_filter_set_user('%', 'mixed_conn_command_rule');
+audit_log_filter_set_user('%', 'mixed_conn_command_rule')
+OK
+Tag "class": "connection" Ok
+SELECT audit_log_filter_set_user('%', 'mixed_ta_sp_rule');
+audit_log_filter_set_user('%', 'mixed_ta_sp_rule')
+OK
+Tag "class": "table_access" Ok
+SELECT audit_log_filter_set_user('%', 'mixed_conn_subclass_rule');
+audit_log_filter_set_user('%', 'mixed_conn_subclass_rule')
+OK
+Tag "event": "connect" Ok
+SELECT audit_log_filter_remove_filter('mixed_conn_subclass_rule');
+audit_log_filter_remove_filter('mixed_conn_subclass_rule')
+OK
+SELECT audit_log_filter_remove_filter('mixed_ta_sp_rule');
+audit_log_filter_remove_filter('mixed_ta_sp_rule')
+OK
+SELECT audit_log_filter_remove_filter('mixed_conn_command_rule');
+audit_log_filter_remove_filter('mixed_conn_command_rule')
+OK
+SELECT audit_log_filter_remove_filter('mixed_subclass_rule');
+audit_log_filter_remove_filter('mixed_subclass_rule')
+OK
+SELECT audit_log_filter_remove_filter('mixed_rule');
+audit_log_filter_remove_filter('mixed_rule')
+OK
+SELECT * FROM mysql.audit_log_filter;
+filter_id	name	filter
+SELECT audit_log_filter_flush();
+audit_log_filter_flush()
+OK
+#
+# Changing to FULL reloads already-loaded rules without explicit flush
+SET GLOBAL audit_log_filter.event_mode=FULL;
+SELECT audit_log_filter_set_filter('query_only_rule', '{"filter":{"class":{"name":"query"}}}');
+audit_log_filter_set_filter('query_only_rule', '{"filter":{"class":{"name":"query"}}}')
+OK
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT audit_log_filter_set_user('%', 'query_only_rule');
+audit_log_filter_set_user('%', 'query_only_rule')
+OK
+SET GLOBAL audit_log_filter.event_mode=FULL;
+Tag "class": "query" Ok
+SELECT audit_log_filter_remove_filter('query_only_rule');
+audit_log_filter_remove_filter('query_only_rule')
+OK
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+#
 # Reduced mode logs only the reduced event-class subset
 SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
 audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}')

--- a/mysql-test/suite/component_audit_log_filter/r/verify_event_occurrence_full.result
+++ b/mysql-test/suite/component_audit_log_filter/r/verify_event_occurrence_full.result
@@ -1,0 +1,627 @@
+SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}')
+OK
+SELECT audit_log_filter_set_filter('log_pre_auth',
+'{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate","log":true}}}}');
+audit_log_filter_set_filter('log_pre_auth',
+'{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate","log":true}}}}')
+OK
+SELECT audit_log_filter_set_user('%', 'log_pre_auth');
+audit_log_filter_set_user('%', 'log_pre_auth')
+OK
+SELECT audit_log_filter_set_user('audit_user@localhost', 'log_all');
+audit_log_filter_set_user('audit_user@localhost', 'log_all')
+OK
+--- audit/startup ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "audit",
+  "event": "startup",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "root",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "root",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "startup_data": {
+    "args": [
+      "<hidden>"
+    ],
+    "mysql_version": "<hidden>",
+    "os_version": "<hidden>",
+    "server_id": <hidden>
+  }
+}
+
+--- general/log ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "log",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- general/error ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "error",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT * FROM missing_table_for_audit",
+    "status": 1146
+  }
+}
+
+--- general/result ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "result",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- general/status ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "status",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- connection/connect ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "connect",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": "test"
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/disconnect ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "disconnect",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/change_user ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "change_user",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/pre_authenticate ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "pre_authenticate",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  }
+}
+
+--- table_access/read ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "read",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "select",
+    "query": "SELECT * FROM t_events WHERE id = 1",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/insert ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "insert",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "insert",
+    "query": "INSERT INTO t_events VALUES (3, 'three')",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/update ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "update",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "update",
+    "query": "UPDATE t_events SET val = 'THREE' WHERE id = 3",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/delete ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "delete",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "delete",
+    "query": "DELETE FROM t_events WHERE id = 3",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- global_variable/variable_get ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "global_variable",
+  "event": "variable_get",
+  "connection_id": <hidden>,
+  "global_variable_data": {
+    "sql_command": "select",
+    "name": "default_password_lifetime",
+    "value": "100"
+  }
+}
+
+--- global_variable/variable_set ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "global_variable",
+  "event": "variable_set",
+  "connection_id": <hidden>,
+  "global_variable_data": {
+    "sql_command": "set_option",
+    "name": "default_password_lifetime",
+    "value": "101"
+  }
+}
+
+--- command/command_start ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "command",
+  "event": "command_start",
+  "connection_id": <hidden>,
+  "command_data": {
+    "command": "Query",
+    "status": 0,
+    "name": "command_start"
+  }
+}
+
+--- command/command_end ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "command",
+  "event": "command_end",
+  "connection_id": <hidden>,
+  "command_data": {
+    "command": "Query",
+    "status": 0,
+    "name": "command_end"
+  }
+}
+
+--- query/query_start ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_start",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- query/query_nested_start ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_nested_start",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT x",
+    "status": 0
+  }
+}
+
+--- query/query_status_end ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_status_end",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT 1",
+    "status": 0
+  }
+}
+
+--- query/query_nested_status_end ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "query",
+  "event": "query_nested_status_end",
+  "connection_id": <hidden>,
+  "query_data": {
+    "sql_command": "select",
+    "query": "SELECT x",
+    "status": 0
+  }
+}
+
+--- stored_program/execute ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "stored_program",
+  "event": "execute",
+  "connection_id": <hidden>,
+  "stored_program_data": {
+    "db": "test",
+    "name": "p_nested"
+  }
+}
+
+--- authentication/auth_flush ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_flush",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "",
+    "host": ""
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- authentication/auth_authid_create ---
+MISSING: authentication/auth_authid_create
+
+--- authentication/auth_credential_change ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_credential_change",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "auth_evt_user",
+    "host": "localhost"
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- authentication/auth_authid_rename ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_authid_rename",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "auth_evt_user",
+    "host": "localhost"
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- authentication/auth_authid_drop ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "authentication",
+  "event": "auth_authid_drop",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "auth_evt_user2",
+    "host": "localhost"
+  },
+  "authentication_data": {
+    "status": 0
+  }
+}
+
+--- message/internal ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "message",
+  "event": "internal",
+  "connection_id": <hidden>,
+  "message_data": {
+    "component": "test_audit_api_message",
+    "producer": "test_audit_api_message",
+    "message": "test_audit_api_message_internal",
+    "message_attributes": {
+      "my_numeric_key": -9223372036854775808
+    }
+  }
+}
+
+--- message/user ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "message",
+  "event": "user",
+  "connection_id": <hidden>,
+  "message_data": {
+    "component": "test_audit_api_message",
+    "producer": "test_audit_api_message",
+    "message": "test_audit_api_message_user",
+    "message_attributes": {
+      "my_string_key": "my_string_value"
+    }
+  }
+}
+
+--- parse/preparse ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "parse",
+  "event": "preparse",
+  "connection_id": <hidden>,
+  "parse_data": {
+    "query": "CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB, ENCRYPTION = 'N'",
+    "rewritten_query": "CREATE TABLE t_parse_rewrite (id INT) ENGINE = InnoDB ",
+    "flags": 1
+  }
+}
+
+--- parse/postparse ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "parse",
+  "event": "postparse",
+  "connection_id": <hidden>,
+  "parse_data": {
+    "query": "CREATE TABLE t_parse_ps (id INT) ENGINE = InnoDB",
+    "rewritten_query": "",
+    "flags": 2
+  }
+}
+
+--- audit/shutdown ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "audit",
+  "event": "shutdown",
+  "connection_id": <hidden>,
+  "shutdown_data": {
+    "server_id": <hidden>
+  }
+}
+

--- a/mysql-test/suite/component_audit_log_filter/r/verify_event_occurrence_reduced.result
+++ b/mysql-test/suite/component_audit_log_filter/r/verify_event_occurrence_reduced.result
@@ -1,0 +1,363 @@
+SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}')
+OK
+SELECT audit_log_filter_set_user('%', 'log_all');
+audit_log_filter_set_user('%', 'log_all')
+OK
+SELECT audit_log_filter_set_user('audit_user@localhost', 'log_all');
+audit_log_filter_set_user('audit_user@localhost', 'log_all')
+OK
+--- audit/startup ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "audit",
+  "event": "startup",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "root",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "root",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "startup_data": {
+    "args": [
+      "<hidden>"
+    ],
+    "mysql_version": "<hidden>",
+    "os_version": "<hidden>",
+    "server_id": <hidden>
+  }
+}
+
+--- general/log ---
+MISSING: general/log
+
+--- general/error ---
+MISSING: general/error
+
+--- general/result ---
+MISSING: general/result
+
+--- general/status ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "general",
+  "event": "status",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "root",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "root",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "general_data": {
+    "command": "Query",
+    "sql_command": "select",
+    "query": "SELECT audit_log_filter_set_user('%', 'log_all')",
+    "status": 0
+  }
+}
+
+--- connection/connect ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "connect",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": "test"
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/disconnect ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "disconnect",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/change_user ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "connection",
+  "event": "change_user",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "connection_data": {
+    "status": 0,
+    "connection_type": "socket",
+    "db": ""
+  },
+  "connection_attributes": {
+    "_pid": "<hidden>",
+    "_platform": "<hidden>",
+    "_os": "<hidden>",
+    "_client_name": "<hidden>",
+    "_client_version": "<hidden>",
+    "program_name": "<hidden>"
+  }
+}
+
+--- connection/pre_authenticate ---
+MISSING: connection/pre_authenticate
+
+--- table_access/read ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "read",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "select",
+    "query": "SELECT * FROM t_events WHERE id = 1",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/insert ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "insert",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "insert",
+    "query": "INSERT INTO t_events VALUES (3, 'three')",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/update ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "update",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "update",
+    "query": "UPDATE t_events SET val = 'THREE' WHERE id = 3",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- table_access/delete ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "table_access",
+  "event": "delete",
+  "connection_id": <hidden>,
+  "account": {
+    "user": "audit_user",
+    "host": "localhost"
+  },
+  "login": {
+    "user": "audit_user",
+    "os": "",
+    "ip": "",
+    "proxy": ""
+  },
+  "table_access_data": {
+    "sql_command": "delete",
+    "query": "DELETE FROM t_events WHERE id = 3",
+    "db": "test",
+    "table": "t_events"
+  }
+}
+
+--- global_variable/variable_get ---
+MISSING: global_variable/variable_get
+
+--- global_variable/variable_set ---
+MISSING: global_variable/variable_set
+
+--- command/command_start ---
+MISSING: command/command_start
+
+--- command/command_end ---
+MISSING: command/command_end
+
+--- query/query_start ---
+MISSING: query/query_start
+
+--- query/query_nested_start ---
+MISSING: query/query_nested_start
+
+--- query/query_status_end ---
+MISSING: query/query_status_end
+
+--- query/query_nested_status_end ---
+MISSING: query/query_nested_status_end
+
+--- stored_program/execute ---
+MISSING: stored_program/execute
+
+--- authentication/auth_flush ---
+MISSING: authentication/auth_flush
+
+--- authentication/auth_authid_create ---
+MISSING: authentication/auth_authid_create
+
+--- authentication/auth_credential_change ---
+MISSING: authentication/auth_credential_change
+
+--- authentication/auth_authid_rename ---
+MISSING: authentication/auth_authid_rename
+
+--- authentication/auth_authid_drop ---
+MISSING: authentication/auth_authid_drop
+
+--- message/internal ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "message",
+  "event": "internal",
+  "connection_id": <hidden>,
+  "message_data": {
+    "component": "test_audit_api_message",
+    "producer": "test_audit_api_message",
+    "message": "test_audit_api_message_internal",
+    "message_attributes": {
+      "my_numeric_key": -9223372036854775808
+    }
+  }
+}
+
+--- message/user ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "message",
+  "event": "user",
+  "connection_id": <hidden>,
+  "message_data": {
+    "component": "test_audit_api_message",
+    "producer": "test_audit_api_message",
+    "message": "test_audit_api_message_user",
+    "message_attributes": {
+      "my_string_key": "my_string_value"
+    }
+  }
+}
+
+--- parse/preparse ---
+MISSING: parse/preparse
+
+--- parse/postparse ---
+MISSING: parse/postparse
+
+--- audit/shutdown ---
+{
+  "timestamp": "<hidden>",
+  "id": <hidden>,
+  "class": "audit",
+  "event": "shutdown",
+  "connection_id": <hidden>,
+  "shutdown_data": {
+    "server_id": <hidden>
+  }
+}
+

--- a/mysql-test/suite/component_audit_log_filter/r/writer_buffer_size_overflow.result
+++ b/mysql-test/suite/component_audit_log_filter/r/writer_buffer_size_overflow.result
@@ -1,10 +1,11 @@
+SET GLOBAL audit_log_filter.event_mode=FULL;
 SELECT audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query"}}}');
 audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query"}}}')
 OK
 SELECT audit_log_filter_set_user('%', 'log_query');
 audit_log_filter_set_user('%', 'log_query')
 OK
-# restart: --audit_log_filter.buffer_size=4096
+# restart: --audit_log_filter.buffer_size=4096 --audit_log_filter.event_mode=FULL
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_events_lost';
 Variable_name	Value
 Audit_log_filter_events_lost	0
@@ -17,7 +18,7 @@ Audit_log_filter_events_lost	0
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_event_max_drop_size';
 Variable_name	Value
 Audit_log_filter_event_max_drop_size	0
-# restart: --audit_log_filter.buffer_size=4096 --audit_log_filter.strategy=PERFORMANCE
+# restart: --audit_log_filter.buffer_size=4096 --audit_log_filter.strategy=PERFORMANCE --audit_log_filter.event_mode=FULL
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_events_lost';
 Variable_name	Value
 Audit_log_filter_events_lost	0

--- a/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_event_classes_subclasses_json-master.opt
@@ -1,3 +1,0 @@
---loose-audit_log_filter.file=audit_event_classes_subclasses_json.log
---loose-audit_log_filter.format=JSON
-$DDL_REWRITER_OPT

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_class.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_class.test
@@ -2,6 +2,7 @@
 --source include/have_debug.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_subclass.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_subclass.test
@@ -2,6 +2,7 @@
 --source include/have_debug.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_function_query_digest.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_function_query_digest.test
@@ -2,6 +2,7 @@
 --source include/have_debug.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_print_query_attrs.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_print_query_attrs.test
@@ -73,7 +73,7 @@ let $filter = {
       {
         "name": "general",
         "event": {
-          "name": ["log", "error", "result", "status"],
+          "name": ["status"],
           "print": {
             "query_attributes": {
               "tag": "query_attributes",

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
@@ -2,6 +2,7 @@
 --source include/have_debug.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_class.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_validate_class.test
@@ -1,6 +1,7 @@
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --disable_query_log
 call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");

--- a/mysql-test/suite/component_audit_log_filter/t/log_format_xml_escape.test
+++ b/mysql-test/suite/component_audit_log_filter/t/log_format_xml_escape.test
@@ -1,6 +1,7 @@
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --let $MYSQLD_DATADIR = `SELECT @@global.datadir`
 --let $MYSQL_TMP_DIR = `select @@tmpdir`

--- a/mysql-test/suite/component_audit_log_filter/t/prepared_statement.test
+++ b/mysql-test/suite/component_audit_log_filter/t/prepared_statement.test
@@ -4,6 +4,7 @@
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 let $filter = {
   "filter": {

--- a/mysql-test/suite/component_audit_log_filter/t/status_var_buffer_bypassing_writes.test
+++ b/mysql-test/suite/component_audit_log_filter/t/status_var_buffer_bypassing_writes.test
@@ -1,6 +1,7 @@
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 SELECT audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "query"}}}');
 SELECT audit_log_filter_set_user('%', 'log_query');

--- a/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_event_mode.test
+++ b/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_event_mode.test
@@ -1,0 +1,18 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+SELECT @@global.audit_log_filter.event_mode;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.audit_log_filter.event_mode;
+
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT @@global.audit_log_filter.event_mode;
+SET GLOBAL audit_log_filter.event_mode=FULL;
+SELECT @@global.audit_log_filter.event_mode;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_filter.event_mode="INVALID";
+
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
@@ -6,6 +6,7 @@
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 

--- a/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced-master.opt
@@ -1,0 +1,2 @@
+--loose-audit_log_filter.file=validate_event_mode_reduced.log
+--loose-audit_log_filter.format=JSON

--- a/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
+++ b/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
@@ -5,10 +5,18 @@
 --disable_query_log
 call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
 call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+call mtr.add_suppression("Component audit_log_filter reported: 'Skipping disabled event .*' in filter");
 --enable_query_log
 
 SET GLOBAL audit_log_filter.event_mode=REDUCED;
 SELECT @@global.audit_log_filter.event_mode;
+
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--let audit_filter_log_path = $audit_filter_log_path
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let audit_filter_log_name = $audit_filter_log_name
+--let $audit_filter_log_format = json
+--let audit_filter_log_format = $audit_filter_log_format
 
 --echo #
 --echo # Reduced mode rejects disabled event classes during validation
@@ -34,18 +42,71 @@ SELECT audit_log_filter_set_filter('mixed_table_access_command', '{"filter":{"cl
 SELECT audit_log_filter_set_filter('mixed_message_auth', '{"filter":{"class":{"name":["message","authentication"]}}}');
 
 --echo #
+--echo # Persisted filters keep the enabled subset after reload
+SELECT audit_log_filter_set_filter('mixed_rule', '{"filter":{"class":{"name":["general","query"]}}}');
+SET GLOBAL audit_log_filter.event_mode=FULL;
+SELECT audit_log_filter_set_filter('mixed_rule', '{"filter":{"class":{"name":["general","query"]}}}');
+SELECT audit_log_filter_set_filter('mixed_subclass_rule', '{"filter":{"class":{"name":"general","event":{"name":["status","log"]}}}}');
+SELECT audit_log_filter_set_filter('mixed_conn_command_rule', '{"filter":{"class":{"name":["connection","command"]}}}');
+SELECT audit_log_filter_set_filter('mixed_ta_sp_rule', '{"filter":{"class":{"name":["table_access","stored_program"]}}}');
+SELECT audit_log_filter_set_filter('mixed_conn_subclass_rule', '{"filter":{"class":{"name":"connection","event":{"name":["connect","pre_authenticate"]}}}}');
+SELECT * FROM mysql.audit_log_filter;
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT audit_log_filter_flush();
+SELECT audit_log_filter_set_user('%', 'mixed_rule');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag="class": "general"
+--source check_all_events_with_tag.inc
+SELECT audit_log_filter_set_user('%', 'mixed_subclass_rule');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag="event": "status"
+--source check_all_events_with_tag.inc
+SELECT audit_log_filter_set_user('%', 'mixed_conn_command_rule');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag="class": "connection"
+--source check_all_events_with_tag.inc
+SELECT audit_log_filter_set_user('%', 'mixed_ta_sp_rule');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag="class": "table_access"
+--source check_all_events_with_tag.inc
+SELECT audit_log_filter_set_user('%', 'mixed_conn_subclass_rule');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag="event": "connect"
+--source check_all_events_with_tag.inc
+SELECT audit_log_filter_remove_filter('mixed_conn_subclass_rule');
+SELECT audit_log_filter_remove_filter('mixed_ta_sp_rule');
+SELECT audit_log_filter_remove_filter('mixed_conn_command_rule');
+SELECT audit_log_filter_remove_filter('mixed_subclass_rule');
+SELECT audit_log_filter_remove_filter('mixed_rule');
+SELECT * FROM mysql.audit_log_filter;
+SELECT audit_log_filter_flush();
+
+--echo #
+--echo # Changing to FULL reloads already-loaded rules without explicit flush
+SET GLOBAL audit_log_filter.event_mode=FULL;
+SELECT audit_log_filter_set_filter('query_only_rule', '{"filter":{"class":{"name":"query"}}}');
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT audit_log_filter_set_user('%', 'query_only_rule');
+SET GLOBAL audit_log_filter.event_mode=FULL;
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag="class": "query"
+--source check_all_events_with_tag.inc
+SELECT audit_log_filter_remove_filter('query_only_rule');
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+
+--echo #
 --echo # Reduced mode logs only the reduced event-class subset
 SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
 SELECT audit_log_filter_set_user('%', 'log_all');
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 SELECT audit_log_filter_flush();
-
-# Export datadir and log file name as environment variables for the perl block
---let $audit_filter_log_path = `SELECT @@global.datadir`
---let audit_filter_log_path = $audit_filter_log_path
---let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
---let audit_filter_log_name = $audit_filter_log_name
 
 perl;
   use strict;

--- a/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
+++ b/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
@@ -1,0 +1,96 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+SET GLOBAL audit_log_filter.event_mode=REDUCED;
+SELECT @@global.audit_log_filter.event_mode;
+
+--echo #
+--echo # Reduced mode rejects disabled event classes during validation
+SELECT audit_log_filter_set_filter('disabled_query', '{"filter":{"class":{"name":"query"}}}');
+SELECT audit_log_filter_set_filter('disabled_global_variable', '{"filter":{"class":{"name":"global_variable"}}}');
+SELECT audit_log_filter_set_filter('disabled_command', '{"filter":{"class":{"name":"command"}}}');
+SELECT audit_log_filter_set_filter('disabled_stored_program', '{"filter":{"class":{"name":"stored_program"}}}');
+SELECT audit_log_filter_set_filter('disabled_authentication', '{"filter":{"class":{"name":"authentication"}}}');
+SELECT audit_log_filter_set_filter('disabled_parse', '{"filter":{"class":{"name":"parse"}}}');
+
+--echo #
+--echo # Reduced mode rejects disabled event subclasses during validation
+SELECT audit_log_filter_set_filter('disabled_general_log', '{"filter":{"class":{"name":"general","event":{"name":"log"}}}}');
+SELECT audit_log_filter_set_filter('disabled_general_error', '{"filter":{"class":{"name":"general","event":{"name":"error"}}}}');
+SELECT audit_log_filter_set_filter('disabled_general_result', '{"filter":{"class":{"name":"general","event":{"name":"result"}}}}');
+SELECT audit_log_filter_set_filter('disabled_conn_preauth', '{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate"}}}}');
+
+--echo #
+--echo # Reduced mode rejects mixed valid + invalid class names in arrays
+SELECT audit_log_filter_set_filter('mixed_general_query', '{"filter":{"class":{"name":["general","query"]}}}');
+SELECT audit_log_filter_set_filter('mixed_connection_parse', '{"filter":{"class":{"name":["connection","parse"]}}}');
+SELECT audit_log_filter_set_filter('mixed_table_access_command', '{"filter":{"class":{"name":["table_access","command"]}}}');
+SELECT audit_log_filter_set_filter('mixed_message_auth', '{"filter":{"class":{"name":["message","authentication"]}}}');
+
+--echo #
+--echo # Reduced mode logs only the reduced event-class subset
+SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+SELECT audit_log_filter_set_user('%', 'log_all');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+SELECT audit_log_filter_flush();
+
+# Export datadir and log file name as environment variables for the perl block
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--let audit_filter_log_path = $audit_filter_log_path
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let audit_filter_log_name = $audit_filter_log_name
+
+perl;
+  use strict;
+  use warnings;
+  use JSON::PP ();
+
+  my $log_dir = $ENV{audit_filter_log_path};
+  my $log_name = $ENV{audit_filter_log_name};
+  my $full_log_name = "$log_dir/$log_name";
+
+  open(my $fh, '<:encoding(UTF-8)', $full_log_name)
+    or die "Could not open '$full_log_name': $!";
+
+  local $/;
+  my $json_text = <$fh>;
+  close($fh);
+
+  $json_text =~ s/\s+$//;
+  unless ($json_text =~ /\]\s*$/) {
+    $json_text =~ s/,\s*$//;
+    $json_text .= "\n]\n";
+  }
+
+  my $events = JSON::PP::decode_json($json_text);
+  my %allowed = map { $_ => 1 } qw(audit general connection table_access message);
+  my %required = map { $_ => 1 } qw(general connection table_access message);
+  my %seen;
+
+  for my $event (@{$events}) {
+    next if ref($event) ne 'HASH' || !exists $event->{class};
+    my $class = $event->{class};
+    die "Unexpected class '$class' observed in REDUCED mode\n"
+      if !$allowed{$class};
+    $seen{$class} = 1;
+  }
+
+  for my $class (sort keys %required) {
+    die "Expected class '$class' was not observed in REDUCED mode\n"
+      if !$seen{$class};
+  }
+
+  print "OK\n";
+EOF
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence.inc
@@ -3,29 +3,39 @@
 # classes and subclasses by logging all events in one pass and then
 # printing one pretty sample record per observed event type.
 #
-# Covered here:
-#   audit: startup, shutdown
-#   general: log, error, result, status
-#   connection: connect, disconnect, change_user, pre_authenticate
-#   table_access: read, insert, update, delete
-#   global_variable: get, set
-#   command: start, end
-#   query: start, nested_start, status_end, nested_status_end
-#   stored_program: execute
-#   authentication: flush, authid_create (currently missing),
-#                   credential_change, authid_rename, authid_drop
-#   message: internal, user
-#   parse: preparse, postparse
+# The expected set of event types depends on the
+# audit_log_filter.event_mode server variable:
 #
---source suite/query_rewrite_plugins/include/have_ddl_rewriter.inc
+#   FULL mode:
+#     audit: startup, shutdown
+#     general: log, error, result, status
+#     connection: connect, disconnect, change_user, pre_authenticate
+#     table_access: read, insert, update, delete
+#     global_variable: get, set
+#     command: start, end
+#     query: start, nested_start, status_end, nested_status_end
+#     stored_program: execute
+#     authentication: flush, authid_create (currently missing),
+#                     credential_change, authid_rename, authid_drop
+#     message: internal, user
+#     parse: preparse, postparse
+#
+#   REDUCED mode:
+#     audit: startup, shutdown
+#     general: status
+#     connection: connect, disconnect, change_user
+#     table_access: read, insert, update, delete
+#     message: internal, user
+#
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
---let $audit_filter_log_path = `SELECT @@global.datadir`
---remove_files_wildcard $audit_filter_log_path audit_event_classes_subclasses_json*
 --source ../inc/audit_comp_install.inc
+--let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let $audit_event_mode = `SELECT @@global.audit_log_filter.event_mode`
 --let audit_filter_log_path = $audit_filter_log_path
 --let audit_filter_log_name = $audit_filter_log_name
+--let audit_event_mode = $audit_event_mode
 
 --disable_query_log
 --disable_result_log
@@ -72,9 +82,16 @@ disconnect setup_conn;
 connection default;
 
 SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
+if ($audit_event_mode == 'FULL')
+{
 SELECT audit_log_filter_set_filter('log_pre_auth',
   '{"filter":{"class":{"name":"connection","event":{"name":"pre_authenticate","log":true}}}}');
 SELECT audit_log_filter_set_user('%', 'log_pre_auth');
+}
+if ($audit_event_mode == 'REDUCED')
+{
+SELECT audit_log_filter_set_user('%', 'log_all');
+}
 SELECT audit_log_filter_set_user('audit_user@localhost', 'log_all');
 
 --disable_query_log
@@ -341,6 +358,8 @@ perl;
     $samples{$key} = clone_and_mask($ev, '');
   }
 
+  my $mode = $ENV{audit_event_mode} // 'FULL';
+
   my @expected = (
     'audit/startup',
     'general/log',
@@ -376,11 +395,34 @@ perl;
     'audit/shutdown',
   );
 
-  # Keep auth_authid_create visible in the report even though the
-  # current tree does not emit it for CREATE USER.
-  my %known_missing = map { $_ => 1 } (
-    'authentication/auth_authid_create',
-  );
+  # auth_authid_create is expected but the current tree does not emit it.
+  my %known_missing = ('authentication/auth_authid_create' => 1);
+
+  if ($mode eq 'REDUCED') {
+    my @disabled = qw(
+      general/log
+      general/error
+      general/result
+      connection/pre_authenticate
+      global_variable/variable_get
+      global_variable/variable_set
+      command/command_start
+      command/command_end
+      query/query_start
+      query/query_nested_start
+      query/query_status_end
+      query/query_nested_status_end
+      stored_program/execute
+      authentication/auth_flush
+      authentication/auth_authid_create
+      authentication/auth_credential_change
+      authentication/auth_authid_rename
+      authentication/auth_authid_drop
+      parse/preparse
+      parse/postparse
+    );
+    $known_missing{$_} = 1 for @disabled;
+  }
 
   my $all_ok = 1;
 

--- a/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_full-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_full-master.opt
@@ -1,0 +1,4 @@
+--loose-audit_log_filter.file=verify_event_occurrence_full.log
+--loose-audit_log_filter.format=JSON
+--loose-audit_log_filter.event_mode=FULL
+$DDL_REWRITER_OPT

--- a/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_full.test
+++ b/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_full.test
@@ -1,0 +1,4 @@
+--source suite/query_rewrite_plugins/include/have_ddl_rewriter.inc
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--remove_files_wildcard $audit_filter_log_path verify_event_occurrence_full*
+--source verify_event_occurrence.inc

--- a/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_reduced-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_reduced-master.opt
@@ -1,0 +1,4 @@
+--loose-audit_log_filter.file=verify_event_occurrence_reduced.log
+--loose-audit_log_filter.format=JSON
+--loose-audit_log_filter.event_mode=REDUCED
+$DDL_REWRITER_OPT

--- a/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_reduced.test
+++ b/mysql-test/suite/component_audit_log_filter/t/verify_event_occurrence_reduced.test
@@ -1,0 +1,4 @@
+--source suite/query_rewrite_plugins/include/have_ddl_rewriter.inc
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--remove_files_wildcard $audit_filter_log_path verify_event_occurrence_reduced*
+--source verify_event_occurrence.inc

--- a/mysql-test/suite/component_audit_log_filter/t/writer_buffer_size_overflow.test
+++ b/mysql-test/suite/component_audit_log_filter/t/writer_buffer_size_overflow.test
@@ -1,6 +1,7 @@
 --source include/have_component_audit_log.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
+SET GLOBAL audit_log_filter.event_mode=FULL;
 
 # The Audit_log_filter_buffer_size_overflow status variable should catch when
 # statement was too big to fit buffer.
@@ -9,7 +10,7 @@ SELECT audit_log_filter_set_filter('log_query', '{"filter": {"class": {"name": "
 SELECT audit_log_filter_set_user('%', 'log_query');
 
 # Test it with default audit_log_strategy
---let $restart_parameters="restart: --audit_log_filter.buffer_size=4096"
+--let $restart_parameters="restart: --audit_log_filter.buffer_size=4096 --audit_log_filter.event_mode=FULL"
 --source include/restart_mysqld.inc
 
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_events_lost';
@@ -25,7 +26,7 @@ SHOW GLOBAL STATUS LIKE 'Audit_log_filter_events_lost';
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_event_max_drop_size';
 
 # Test it with audit_log_filter_strategy = PERFORMANCE
---let $restart_parameters="restart: --audit_log_filter.buffer_size=4096 --audit_log_filter.strategy=PERFORMANCE"
+--let $restart_parameters="restart: --audit_log_filter.buffer_size=4096 --audit_log_filter.strategy=PERFORMANCE --audit_log_filter.event_mode=FULL"
 --source include/restart_mysqld.inc
 
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_events_lost';

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13812,7 +13812,7 @@ ER_AUDIT_TABLE_READ_FIELD_FAILURE
   eng "Failed to read %s.%s"
 
 ER_AUDIT_TABLE_FILTER_WRONG_FORMAT
-  eng "audit_log_filter name: %s, filter: %s has wrong format"
+  eng "audit_log_filter name: %s, filter: %s has wrong format, consider using audit_log_filter.event_mode=FULL"
 
 ER_AUDIT_TABLE_FILTER_INSERT_COMMIT_FAILURE
   eng "Failed to insert filtering rule '%s', '%s', commit failed"
@@ -13928,6 +13928,12 @@ ER_AUDIT_KEYRING_KEY_NOT_FOUND
 
 ER_AUDIT_KEYRING_OPTIONS_REMOVE_FAILURE
   eng "Failed to remove options with ID: %s"
+
+ER_AUDIT_PARSE_SKIP_DISABLED_EVENT_CLASS
+  eng "Skipping disabled event class '%s' in filter '%s'"
+
+ER_AUDIT_PARSE_SKIP_DISABLED_EVENT_SUBCLASS
+  eng "Skipping disabled event '%s/%s' in filter '%s'"
 
 #
 # End of Audit Log Filter error log messages

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13767,6 +13767,168 @@ ER_AUDIT_PARSE_EMPTY_ARRAY
 ER_AUDIT_PARSE_UNEXPECTED_KEY
   eng "Wrong JSON filter '%s' format, unexpected key '%s'"
 
+# 48180
+ER_AUDIT_INIT_EXCEPTION
+  eng "Exception in audit_log_filter_init: %s"
+
+ER_AUDIT_DEINIT_EXCEPTION
+  eng "Exception in audit_log_filter_deinit: %s"
+
+ER_AUDIT_FILTER_RULE_NOT_FOUND
+  eng "Failed to find '%s' filtering rule"
+
+ER_AUDIT_UNSUPPORTED_EVENT_CLASS
+  eng "Unsupported audit event class with ID %i received"
+
+ER_AUDIT_BLOCKED_EVENT
+  eng "Blocked audit event '%s' with class %i"
+
+ER_AUDIT_NOTIFY_EVENT_EXCEPTION
+  eng "Caught exception in notify_event: %s"
+
+ER_AUDIT_SECURITY_CONTEXT_FIELD_FAILURE
+  eng "Can not get %s from security context"
+
+ER_AUDIT_TABLE_OPEN_FAILURE
+  eng "Failed to get an opened %s table"
+
+ER_AUDIT_TABLE_CHECK_FIELDS_FAILURE
+  eng "Failed to check %s table fields"
+
+ER_AUDIT_TABLE_INDEX_SCAN_INIT_FAILURE
+  eng "Failed to init index scan of %s table"
+
+# 48190
+ER_AUDIT_TABLE_INDEX_ACCESS_INIT_FAILURE
+  eng "Failed to init index access of %s table"
+
+ER_AUDIT_TABLE_FULL_SCAN_INIT_FAILURE
+  eng "Failed to init full scan of %s table"
+
+ER_AUDIT_TABLE_FULL_SCAN_END_FAILURE
+  eng "Failed to end full scan of %s table"
+
+ER_AUDIT_TABLE_READ_FIELD_FAILURE
+  eng "Failed to read %s.%s"
+
+ER_AUDIT_TABLE_FILTER_WRONG_FORMAT
+  eng "audit_log_filter name: %s, filter: %s has wrong format"
+
+ER_AUDIT_TABLE_FILTER_INSERT_COMMIT_FAILURE
+  eng "Failed to insert filtering rule '%s', '%s', commit failed"
+
+ER_AUDIT_TABLE_FILTER_DELETE_FAILURE
+  eng "Failed to delete filter with the name '%s'"
+
+ER_AUDIT_TABLE_FILTER_DELETE_COMMIT_FAILURE
+  eng "Failed to delete filter with the name '%s', commit failed"
+
+ER_AUDIT_TABLE_USER_DELETE_FILTER_FAILURE
+  eng "Failed to delete record for filter '%s'"
+
+ER_AUDIT_TABLE_USER_DELETE_FILTER_COMMIT_FAILURE
+  eng "Failed to delete record for filter '%s', commit failed"
+
+# 48200
+ER_AUDIT_TABLE_USER_DELETE_USER_FAILURE
+  eng "Failed to delete record for user '%s@%s'"
+
+ER_AUDIT_TABLE_USER_DELETE_USER_COMMIT_FAILURE
+  eng "Failed to delete record for user '%s@%s', commit failed"
+
+ER_AUDIT_TABLE_USER_ASSIGN_FILTER_FAILURE
+  eng "Failed to assign '%s' filtering rule for user '%s@%s'"
+
+ER_AUDIT_TABLE_USER_ASSIGN_FILTER_COMMIT_FAILURE
+  eng "Failed to assign '%s' filtering rule for user '%s@%s', commit failed"
+
+ER_AUDIT_ENCRYPTION_OPTIONS_FETCH_FAILURE
+  eng "Failed to fetch options for id %s"
+
+ER_AUDIT_ENCRYPTION_EMPTY_PASSWORD
+  eng "Empty password for id %s"
+
+ER_AUDIT_ENCRYPTION_BAD_ITERATIONS
+  eng "Bad iterations count for id %s"
+
+ER_AUDIT_ENCRYPTION_EMPTY_SALT
+  eng "Empty salt for id %s"
+
+ER_AUDIT_ENCRYPTION_PBKDF2_ERROR
+  eng "PKCS5_PBKDF2_HMAC error: %s"
+
+ER_AUDIT_ENCRYPTION_CIPHER_INIT_ERROR
+  eng "EVP_CipherInit_ex error: %s"
+
+# 48210
+ER_AUDIT_ENCRYPTION_ENCRYPT_FINAL_ERROR
+  eng "EVP_EncryptFinal error: %s"
+
+ER_AUDIT_ENCRYPTION_ENCRYPT_UPDATE_ERROR
+  eng "EVP_EncryptUpdate error: %s"
+
+ER_AUDIT_ENCRYPTION_INVALID_OPTIONS
+  eng "Invalid options provided for id %s"
+
+ER_AUDIT_ENCRYPTION_DECRYPT_UPDATE_ERROR
+  eng "EVP_DecryptUpdate error: %s"
+
+ER_AUDIT_ENCRYPTION_DECRYPT_FINAL_ERROR
+  eng "EVP_DecryptFinal error: %s"
+
+ER_AUDIT_LOG_FILE_WRITER_CREATE_FAILURE
+  eng "Failed to create Audit Log Filter file writer (%s)"
+
+ER_AUDIT_LOG_DIR_LIST_FAILURE
+  eng "Failed to list audit filter log directory '%s'"
+
+ER_AUDIT_LOG_ROTATE_INTERNAL_FAILURE
+  eng "Failed to rotate audit filter log: %i, %s"
+
+ER_AUDIT_LOG_FILE_INSPECT_FAILURE
+  eng "Failed to inspect audit filter log path '%s': %s"
+
+ER_AUDIT_LOG_FILE_PREPARE_FAILURE
+  eng "Failed to prepare audit filter log '%s' for appending"
+
+# 48220
+ER_AUDIT_LOG_DIR_LISTING_FAILURE
+  eng "Failed to list audit log directory '%s': %s"
+
+ER_AUDIT_LOG_DIR_ITERATE_FAILURE
+  eng "Failed to iterate audit log directory '%s': %s"
+
+ER_AUDIT_LOG_FOOTER_REMOVE_FAILURE
+  eng "Failed to remove footer from audit log '%s': %s"
+
+ER_AUDIT_LOG_FILE_NAME_PARSE_FAILURE
+  eng "Skipping audit log file with unparseable name '%s': %s"
+
+ER_AUDIT_LOG_FILE_NAME_UNKNOWN_PARSE_FAILURE
+  eng "Skipping audit log file with unparseable name '%s'"
+
+ER_AUDIT_LOG_FILE_OPEN_READ_FAILURE
+  eng "Failed to open file for reading: %s"
+
+ER_AUDIT_LOG_FILE_READ_FAILURE
+  eng "Failed to read: %s"
+
+ER_AUDIT_COMPRESSION_INIT_FAILURE
+  eng "Failed to init compressing: %i"
+
+ER_AUDIT_DECOMPRESSION_INIT_FAILURE
+  eng "Failed to init decompressing: %i"
+
+ER_AUDIT_UDF_REGISTER_FAILURE
+  eng "Failed to register %s UDF"
+
+# 48230
+ER_AUDIT_KEYRING_KEY_NOT_FOUND
+  eng "No data found for key '%s'"
+
+ER_AUDIT_KEYRING_OPTIONS_REMOVE_FAILURE
+  eng "Failed to remove options with ID: %s"
+
 #
 # End of Audit Log Filter error log messages
 #
@@ -13775,7 +13937,7 @@ ER_AUDIT_PARSE_UNEXPECTED_KEY
 #
 # Start of Percona Server 8.4 error log messages
 #
-start-error-number 48200
+start-error-number 48300
 
 #
 # End of Percona Server 8.4 error log messages
@@ -13785,7 +13947,7 @@ start-error-number 48200
 #
 # Start of Percona Server 9.7 error log messages
 #
-start-error-number 48300
+start-error-number 48400
 
 #
 # End of Percona Server 9.7 error log messages


### PR DESCRIPTION
### 1. Fix broken ER_LOG_PRINTF_MSG calls in audit log filter component

ER_LOG_PRINTF_MSG takes a single literal string and does not perform
printf-style formatting. 71 call sites passed format specifiers (%s,
%i) with extra arguments that were silently ignored, producing raw
"%s" / "%i" in log output instead of the intended values.

Replace each broken call with a dedicated ER_AUDIT_* error code whose
message definition carries the correct format string (52 new codes,
1 reused existing ER_AUDIT_UDF_SET_FILTER_FAILURE). Consolidate five
"Failed to read %s.<field>" patterns into a single
ER_AUDIT_TABLE_READ_FIELD_FAILURE with "Failed to read %s.%s".

Shift Percona Server 8.4 / 9.7 reserved ranges from 48200/48300 to
48300/48400 to accommodate the new 48180-48231 audit error numbers.

### 2. Add audit_log_filter.event_mode variable (REDUCED/FULL)

Introduce an enum system variable audit_log_filter.event_mode that
controls which event types are processed by the audit log filter.
The variable can be changed at runtime.

REDUCED (default) limits logging to a subset of events:
  general/status, connection/connect, connection/disconnect,
  connection/change_user, table_access/*, message/*.

FULL preserves the existing behaviour of logging all event types.

In REDUCED mode, disabled event classes (global_variable, command, query,
stored_program, authentication, parse) and disabled subclasses
(general/log, general/error, general/result, connection/pre_authenticate)
are silently skipped at the notify_event entry point and rejected with a
descriptive error during filter-rule validation.

Update filter_definition_fields.md to document per-class and per-event
REDUCED mode availability.

Rename test to validate_event_mode_reduced and extend it with cases for
disabled subclasses (general/log, general/error, general/result,
connection/pre_authenticate) and mixed valid+invalid class name arrays.

### 3. Add event_mode-aware MTR tests for audit log filter

Extract audit_event_classes_subclasses_json.test into a reusable
verify_event_occurrence.inc that checks all 31 event types and adapts
to the active event_mode: FULL prints every sample, REDUCED prints
the enabled subset and marks disabled classes as MISSING.

In REDUCED mode the disabled set includes both fully disabled classes
(global_variable, command, query, stored_program, authentication,
parse) and partially disabled subclasses (general/log, general/error,
general/result, connection/pre_authenticate). The pre_authenticate
filter is only created in FULL mode.

Two wrapper tests drive the include:
  verify_event_occurrence_full  (event_mode=FULL)
  verify_event_occurrence_reduced (event_mode=REDUCED)

Pin event_mode=FULL in nine existing tests that depend on event
classes disabled in REDUCED mode.

### 4. Skip disabled classes instead of rejecting the rule on filter reload

Filters created with audit_log_filter.event_mode=FULL that reference
now-disabled classes could be silently dropped on reload under the
default event_mode=REDUCED, which could disable auditing after upgrade,
restart, or audit_log_filter_flush().

Add a skip_disabled_events parameter to AuditRuleParser::parse().
When loading persisted filters the parser silently skips disabled event
classes/subclasses (logging a WARNING) instead of rejecting the whole
filter; the UDF set_filter path stays strict.

Propagate filter parse errors as std::string& through load_filters() up
to audit_log_filter_flush() so real failures are reported to the caller.

Reload the rule registry automatically when event_mode changes.
The sysvar update callback cannot call load() directly because SET
GLOBAL holds LOCK_plugin and load() opens a table (creating a THD that
re-acquires the same lock, causing a deadlock).  Instead, the callback
invalidates the registry (a lock-free atomic store); the next
lookup_rule_name() call — which runs in the audited connection's own THD
context — triggers the actual reload.
