### PR TITLE
PS-10339 [9.x]: Make audit_log_filter.format=NEW follow upstream format more closely

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -13,7 +13,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
-#define ALLOW_COMPONENT_INCLUDE // for my_io.h and plugin.h
+#define ALLOW_COMPONENT_INCLUDE  // for my_io.h and plugin.h
 #include "components/audit_log_filter/audit_log_filter.h"
 #include "components/audit_log_filter/audit_filter.h"
 #include "components/audit_log_filter/audit_keyring.h"
@@ -570,6 +570,14 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
     set_extended_info(thd, sctx, *rec);
   }
 
+  if (auto rec = std::get_if<AuditRecordQuery>(&record)) {
+    set_extended_info(thd, sctx, *rec);
+  }
+
+  if (auto rec = std::get_if<AuditRecordMessage>(&record)) {
+    set_extended_info(thd, sctx, *rec);
+  }
+
   if (auto rec = std::get_if<AuditRecordTableAccess>(&record)) {
     set_extended_info(thd, sctx, *rec);
   }
@@ -918,6 +926,36 @@ bool AuditLogFilter::set_extended_info(MYSQL_THD thd,
   get_security_context_option(sctx, "ip", extra.ip);
   get_security_context_option(sctx, "external_user", extra.external_user);
   get_security_context_option(sctx, "proxy_user", extra.proxy_user);
+
+  return true;
+}
+
+bool AuditLogFilter::set_extended_info(MYSQL_THD, Security_context_handle sctx,
+                                       AuditRecordQuery &record) {
+  if (!sctx) return false;
+
+  auto &extra = record.extended_info;
+
+  get_security_context_option(sctx, "user", extra.user);
+  get_security_context_option(sctx, "host", extra.host);
+  get_security_context_option(sctx, "ip", extra.ip);
+  get_security_context_option(sctx, "external_user", extra.external_user);
+  get_security_context_option(sctx, "proxy_user", extra.proxy_user);
+
+  return true;
+}
+
+bool AuditLogFilter::set_extended_info(MYSQL_THD thd, Security_context_handle,
+                                       AuditRecordMessage &record) {
+  if (!thd) return false;
+
+  auto &extra = record.extended_info;
+
+  mysql_cstring_with_length sql_command;
+  if (!mysql_service_mysql_thd_attributes->get(thd, "sql_command",
+                                               &sql_command)) {
+    extra.sql_command = {sql_command.str, sql_command.length};
+  }
 
   return true;
 }

--- a/components/audit_log_filter/audit_log_filter.h
+++ b/components/audit_log_filter/audit_log_filter.h
@@ -194,6 +194,10 @@ class AuditLogFilter {
   bool set_extended_info(MYSQL_THD thd, Security_context_handle sctx,
                          AuditRecordTableAccess &record);
   bool set_extended_info(MYSQL_THD thd, Security_context_handle sctx,
+                         AuditRecordQuery &record);
+  bool set_extended_info(MYSQL_THD thd, Security_context_handle sctx,
+                         AuditRecordMessage &record);
+  bool set_extended_info(MYSQL_THD thd, Security_context_handle sctx,
                          AuditRecordGeneral &record);
 
   /**

--- a/components/audit_log_filter/log_record_formatter/base.cc
+++ b/components/audit_log_filter/log_record_formatter/base.cc
@@ -57,7 +57,7 @@ const std::string_view kAuditEventNameGeneralResult{"Result"};
 const std::string_view kAuditEventNameGeneralStatus{"Status"};
 
 const std::string_view kAuditEventNameConnect{"Connect"};
-const std::string_view kAuditEventNameDisconnect{"Disconnect"};
+const std::string_view kAuditEventNameDisconnect{"Quit"};
 const std::string_view kAuditEventNameChangeUser{"Change user"};
 const std::string_view kAuditEventNamePreAuth{"Pre Authenticate"};
 
@@ -100,8 +100,8 @@ const std::string_view kAuditEventNameMessageUser{"User"};
 const std::string_view kAuditEventNameParsePreparse{"Preparse"};
 const std::string_view kAuditEventNameParsePostparse{"Postparse"};
 
-const std::string_view kAuditEventNameAuditStart{"Startup"};
-const std::string_view kAuditEventNameAuditStop{"Shutdown"};
+const std::string_view kAuditEventNameAuditStart{"Audit"};
+const std::string_view kAuditEventNameAuditStop{"NoAudit"};
 
 const std::string_view kAuditNameUnknown{"unknown"};
 

--- a/components/audit_log_filter/log_record_formatter/new.cc
+++ b/components/audit_log_filter/log_record_formatter/new.cc
@@ -13,6 +13,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
+#define ALLOW_COMPONENT_INCLUDE  // for my_io.h and plugin.h
 #include "components/audit_log_filter/log_record_formatter/new.h"
 #include "components/audit_log_filter/audit_record.h"
 
@@ -26,6 +27,7 @@
 #include <mysql/components/services/defs/event_tracking_query_defs.h>
 #include <mysql/components/services/defs/event_tracking_stored_program_defs.h>
 #include <mysql/components/services/defs/event_tracking_table_access_defs.h>
+#include <sql/mysqld.h>
 
 #include <cassert>
 #include <chrono>
@@ -38,23 +40,29 @@ AuditRecordString LogRecordFormatterNew::apply(
   std::stringstream result;
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
 
+  const auto &sqltext = (audit_record.extended_info.digest.empty()
+                             ? audit_record.extended_info.query
+                             : audit_record.extended_info.digest);
+
   /* clang-format off */
-  // TODO: For AuditRecordGeneral with JSON format, we added "command" and "sql_command" fields.
-  //       We also need to update the fields according to https://perconadev.atlassian.net/browse/PS-10339.
-  //       Same as JSON format: user field appears as "root" for upstream.
   result << "  <AUDIT_RECORD>\n"
-         << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
+         << "    <NAME>" << audit_record.extended_info.command << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
+         << "    <COMMAND_CLASS>" << audit_record.extended_info.sql_command << "</COMMAND_CLASS>\n"
          << "    <CONNECTION_ID>" << audit_record.event->connection_id << "</CONNECTION_ID>\n"
          << "    <HOST>" << make_escaped_string(&audit_record.event->host) << "</HOST>\n"
          << "    <IP>" << make_escaped_string(&audit_record.event->ip) << "</IP>\n"
          << "    <USER>" << make_escaped_string(&audit_record.event->user) << "</USER>\n"
+         << "    <OS_LOGIN>" << make_escaped_string(audit_record.extended_info.external_user) << "</OS_LOGIN>\n"
          << "    <STATUS>" << audit_record.event->error_code << "</STATUS>\n"
-         << "    <SQLTEXT>" << (audit_record.extended_info.digest.empty() ? make_escaped_string(audit_record.extended_info.query)
-                                                                          : make_escaped_string(audit_record.extended_info.digest)) << "</SQLTEXT>\n"
-         << "  </AUDIT_RECORD>\n";
+         << "    <STATUS_CODE>" << (audit_record.event->error_code ? 1 : 0) << "</STATUS_CODE>\n";
+
+  if (!sqltext.empty()) {
+    result << "    <SQLTEXT>" << make_escaped_string(sqltext) << "</SQLTEXT>\n";
+  }
+
+  result << "  </AUDIT_RECORD>\n";;
   /* clang-format on */
 
   return result.str();
@@ -70,19 +78,24 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
+         << "    <COMMAND_CLASS>connect</COMMAND_CLASS>\n"
          << "    <CONNECTION_ID>" << audit_record.event->connection_id << "</CONNECTION_ID>\n"
          << "    <HOST>" << make_escaped_string(&audit_record.event->host) << "</HOST>\n"
          << "    <IP>" << make_escaped_string(&audit_record.event->ip) << "</IP>\n"
          << "    <USER>" << make_escaped_string(&audit_record.event->user) << "</USER>\n"
          << "    <OS_LOGIN>" << make_escaped_string(&audit_record.event->external_user) << "</OS_LOGIN>\n"
-         << "    <PRIV_USER>" << make_escaped_string(&audit_record.event->priv_user) << "</PRIV_USER>\n"
-         << "    <PROXY_USER>" << make_escaped_string(&audit_record.event->proxy_user) << "</PROXY_USER>\n"
-         << "    <DB>" << make_escaped_string(&audit_record.event->database) << "</DB>\n"
          << "    <STATUS>" << audit_record.event->status << "</STATUS>\n"
-         << "    <CONNECTION_TYPE>" << connection_type_name_to_string(audit_record.event->connection_type) << "</CONNECTION_TYPE>\n"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n"
-         << "  </AUDIT_RECORD>\n";
+         << "    <STATUS_CODE>" << (audit_record.event->status ? 1 : 0) << "</STATUS_CODE>\n"
+         << "    <CONNECTION_TYPE>" << connection_type_name_to_string(audit_record.event->connection_type) << "</CONNECTION_TYPE>\n";
+
+  if (audit_record.event->event_subclass == EVENT_TRACKING_CONNECTION_CONNECT) {
+    result << extra_attrs_to_string(audit_record.extended_info) << "\n"
+           << "    <PRIV_USER>" << make_escaped_string(&audit_record.event->priv_user) << "</PRIV_USER>\n"
+           << "    <PROXY_USER>" << make_escaped_string(&audit_record.event->proxy_user) << "</PROXY_USER>\n"
+           << "    <DB>" << make_escaped_string(&audit_record.event->database) << "</DB>\n";
+  }
+
+  result << "  </AUDIT_RECORD>\n";
   /* clang-format on */
 
   return result.str();
@@ -94,19 +107,20 @@ AuditRecordString LogRecordFormatterNew::apply(
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
 
   /* clang-format off */
-  // TODO: For AuditRecordTableAccess with JSON format, we added <HOST>, <IP>, <USER>, and <PROXY_USER>.
-  //       We also need to update the fields according to https://perconadev.atlassian.net/browse/PS-10339.
-  //       Unlike JSON format, the user field appears as "root[root] @ localhost [127.0.0.1]" for upstream.
   result << "  <AUDIT_RECORD>\n"
          << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
+         << "    <COMMAND_CLASS>" << audit_record.extended_info.sql_command << "</COMMAND_CLASS>\n"
          << "    <CONNECTION_ID>" << audit_record.event->connection_id << "</CONNECTION_ID>\n"
          << "    <SQLTEXT>" << (audit_record.extended_info.digest.empty() ? make_escaped_string(audit_record.extended_info.query)
                                                                           : make_escaped_string(audit_record.extended_info.digest)) << "</SQLTEXT>\n"
          << "    <DB>" << make_escaped_string(&audit_record.event->table_database) << "</DB>\n"
          << "    <TABLE>" << make_escaped_string(&audit_record.event->table_name) << "</TABLE>\n"
+         << user_info_to_string(audit_record.extended_info)
+         << "    <OS_LOGIN>" << make_escaped_string(audit_record.extended_info.external_user) << "</OS_LOGIN>\n"
+         << "    <HOST>" << make_escaped_string(audit_record.extended_info.host) << "</HOST>\n"
+         << "    <IP>" << make_escaped_string(audit_record.extended_info.ip) << "</IP>\n"
          << "  </AUDIT_RECORD>\n";
   /* clang-format on */
 
@@ -224,7 +238,7 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
+         << "    <COMMAND_CLASS>" << audit_record.extended_info.sql_command << "</COMMAND_CLASS>\n"
          << "    <CONNECTION_ID>" << audit_record.event->connection_id << "</CONNECTION_ID>\n"
          << "    <COMPONENT>" << make_escaped_string(&audit_record.event->component) << "</COMPONENT>\n"
          << "    <PRODUCER>" << make_escaped_string(&audit_record.event->producer) << "</PRODUCER>\n"
@@ -283,9 +297,29 @@ AuditRecordString LogRecordFormatterNew::apply(
          << "    <NAME>" << event_subclass_to_string(audit_record.event) << "</NAME>\n"
          << "    <RECORD_ID>" << make_record_id(tp) << "</RECORD_ID>\n"
          << "    <TIMESTAMP>" << make_timestamp(tp) << "</TIMESTAMP>\n"
-         << "    <COMMAND_CLASS>" << event_class_to_string(audit_record.event_class) << "</COMMAND_CLASS>\n"
-         << "    <SERVER_ID>" << audit_record.event->server_id << "</SERVER_ID>\n"
-         << "  </AUDIT_RECORD>\n";
+         << "    <SERVER_ID>" << audit_record.event->server_id << "</SERVER_ID>\n";
+
+
+  if (audit_record.event->event_subclass == INTERNAL_EVENT_TRACKING_AUDIT_AUDIT)
+  {
+    std::stringstream startup_options;
+
+    for (int i = 0; i < orig_argc; ++i) {
+      if (orig_argv[i]) {
+        startup_options << orig_argv[i] << " ";
+      }
+    }
+
+    std::string startup_options_str = startup_options.str();
+    startup_options_str.pop_back();
+
+    result << "    <VERSION>1</VERSION>\n"
+           << "    <STARTUP_OPTIONS>" << make_escaped_string(startup_options_str) << "</STARTUP_OPTIONS>\n"
+           << "    <MYSQL_VERSION>" << server_version << "</MYSQL_VERSION>\n"
+           << "    <OS_VERSION>" << MACHINE_TYPE << "-" << SYSTEM_TYPE << "</OS_VERSION>\n";
+  }
+
+  result << "  </AUDIT_RECORD>\n";
   /* clang-format on */
 
   return result.str();
@@ -326,6 +360,18 @@ std::string LogRecordFormatterNew::extra_attrs_to_string(
     result << "    </CONNECTION_ATTRIBUTES>";
   }
   /* clang-format on */
+
+  return result.str();
+}
+
+std::string LogRecordFormatterNew::user_info_to_string(
+    const ExtendedInfo &info) const {
+  std::stringstream result;
+
+  result << "    <USER>" << make_escaped_string(info.user) << "["
+         << make_escaped_string(info.user) << "] @ "
+         << make_escaped_string(info.host) << " ["
+         << make_escaped_string(info.ip) << "]</USER>\n";
 
   return result.str();
 }

--- a/components/audit_log_filter/log_record_formatter/new.h
+++ b/components/audit_log_filter/log_record_formatter/new.h
@@ -144,6 +144,13 @@ class LogRecordFormatter<AuditLogFormatType::New>
    */
   [[nodiscard]] std::string extra_attrs_to_string(
       const ExtendedInfo &info) const noexcept override;
+
+  /**
+   * @brief Get string representation of user information.
+   * @param info Extended record info
+   * @return Formatted string
+   */
+  [[nodiscard]] std::string user_info_to_string(const ExtendedInfo &info) const;
 };
 
 using LogRecordFormatterNew = LogRecordFormatter<AuditLogFormatType::New>;

--- a/components/audit_log_filter/log_writer/base.cc
+++ b/components/audit_log_filter/log_writer/base.cc
@@ -45,12 +45,14 @@ void LogWriterBase::write(const AuditRecordVariant &record) noexcept {
     const std::string_view event_subclass_name = std::visit(
         [](const auto &rec) { return rec.event_subclass_name; }, record);
 
-    m_formatter->apply_debug_info(event_class_name, event_subclass_name,
-                                  record_str);
+    if (!record_str.empty()) {
+      m_formatter->apply_debug_info(event_class_name, event_subclass_name,
+                                    record_str);
+    }
   });
 
   {
-    std::lock_guard<std::mutex> write_guaard{m_write_mutex};
+    std::lock_guard<std::mutex> write_guard{m_write_mutex};
     write(record_str, true);
   }
 }

--- a/mysql-test/suite/component_audit_log_filter/r/audit_noaudit_events.result
+++ b/mysql-test/suite/component_audit_log_filter/r/audit_noaudit_events.result
@@ -1,1 +1,1 @@
-Tag <NAME>(?:Startup|Shutdown)</NAME> Ok
+Tag <NAME>(?:Audit|NoAudit)</NAME> Ok

--- a/mysql-test/suite/component_audit_log_filter/t/audit_noaudit_events.test
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_noaudit_events.test
@@ -10,7 +10,7 @@
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_comp_install.inc
 
---let $search_tag=<NAME>(?:Startup|Shutdown)</NAME>
+--let $search_tag=<NAME>(?:Audit|NoAudit)</NAME>
 --source check_all_events_with_tag.inc
 
 --source ../inc/audit_comp_uninstall.inc


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10339

- Audit Log Filter's new-style XML writer now follows upstream more closely in terms of both contents and amount of logged information. It will make it easier to migrate from upstream versions of Audit Log Filter.