### PR TITLE
PS-10228 [8.4]: audit_log_filter: default empty filter object to log all events

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -575,6 +575,11 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
 
   if (auto rec = std::get_if<AuditRecordGeneral>(&record)) {
     set_extended_info(thd, sctx, *rec);
+
+    if (SysVars::get_event_mode_type() == AuditLogEventModeType::Reduced &&
+        rec->extended_info.command == "Quit") {
+      return 0;
+    }
   }
 
   if (auto rec = std::get_if<AuditRecordQuery>(&record)) {

--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -122,10 +122,6 @@ bool AuditRuleParser::parse_default_log_action_json(
    */
   bool should_log_unmatched = true;
 
-  if (json_doc["filter"].ObjectEmpty()) {
-    return true;
-  }
-
   if (json_doc["filter"].HasMember("log")) {
     if (!json_doc["filter"]["log"].IsBool()) {
       LogComponentErr(ERROR_LEVEL,

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_default_log_action.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_default_log_action.result
@@ -1,0 +1,86 @@
+#
+# Empty top-level filter object must default to logging all events (same as "log": true).
+SELECT audit_log_filter_set_filter('f_empty', '{"filter": {}}');
+audit_log_filter_set_filter('f_empty', '{"filter": {}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_empty');
+audit_log_filter_set_user('%', 'f_empty')
+OK
+OK: empty filter
+#
+# Explicit "log": true must log general, connection, and table_access events.
+SELECT audit_log_filter_set_filter('f_log_true', '{"filter": {"log": true}}');
+audit_log_filter_set_filter('f_log_true', '{"filter": {"log": true}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_log_true');
+audit_log_filter_set_user('%', 'f_log_true')
+OK
+OK: log true
+#
+# "log": true with only "id" and multi-class list still logs unmatched event classes.
+SELECT audit_log_filter_set_filter('f_log_true_complex', '{"filter": {"log": true, "id": "complex-1", "class": [{"name": "general"}, {"name": "connection"}]}}');
+audit_log_filter_set_filter('f_log_true_complex', '{"filter": {"log": true, "id": "complex-1", "class": [{"name": "general"}, {"name": "connection"}]}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_log_true_complex');
+audit_log_filter_set_user('%', 'f_log_true_complex')
+OK
+OK: log true with id and class list
+#
+# Only "id" (no "log", no "class") matches empty filter: log all.
+SELECT audit_log_filter_set_filter('f_id_only', '{"filter": {"id": "metadata-only"}}');
+audit_log_filter_set_filter('f_id_only', '{"filter": {"id": "metadata-only"}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_id_only');
+audit_log_filter_set_user('%', 'f_id_only')
+OK
+OK: id only
+#
+# No top-level "log" with only "class": general — unmatched events are not logged.
+SELECT audit_log_filter_set_filter('f_class_general_only', '{"filter": {"class": {"name": "general"}}}');
+audit_log_filter_set_filter('f_class_general_only', '{"filter": {"class": {"name": "general"}}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_class_general_only');
+audit_log_filter_set_user('%', 'f_class_general_only')
+OK
+OK: class general only
+#
+# No top-level "log" with class list general+connection — table_access still excluded.
+SELECT audit_log_filter_set_filter('f_class_gen_conn', '{"filter": {"class": [{"name": "general"}, {"name": "connection"}]}}');
+audit_log_filter_set_filter('f_class_gen_conn', '{"filter": {"class": [{"name": "general"}, {"name": "connection"}]}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_class_gen_conn');
+audit_log_filter_set_user('%', 'f_class_gen_conn')
+OK
+OK: class general and connection
+#
+# No top-level "log" with nested event rule — only matching subclasses are logged (REDUCED: general/status).
+SELECT audit_log_filter_set_filter('f_class_general_status', '{"filter": {"class": {"name": "general", "event": {"name": "status", "log": true}}}}');
+audit_log_filter_set_filter('f_class_general_status', '{"filter": {"class": {"name": "general", "event": {"name": "status", "log": true}}}}')
+OK
+SELECT audit_log_filter_set_user('%', 'f_class_general_status');
+audit_log_filter_set_user('%', 'f_class_general_status')
+OK
+OK: class general event status only
+#
+# Cleanup filters
+SELECT audit_log_filter_remove_filter('f_empty');
+audit_log_filter_remove_filter('f_empty')
+OK
+SELECT audit_log_filter_remove_filter('f_log_true');
+audit_log_filter_remove_filter('f_log_true')
+OK
+SELECT audit_log_filter_remove_filter('f_log_true_complex');
+audit_log_filter_remove_filter('f_log_true_complex')
+OK
+SELECT audit_log_filter_remove_filter('f_id_only');
+audit_log_filter_remove_filter('f_id_only')
+OK
+SELECT audit_log_filter_remove_filter('f_class_general_only');
+audit_log_filter_remove_filter('f_class_general_only')
+OK
+SELECT audit_log_filter_remove_filter('f_class_gen_conn');
+audit_log_filter_remove_filter('f_class_gen_conn')
+OK
+SELECT audit_log_filter_remove_filter('f_class_general_status');
+audit_log_filter_remove_filter('f_class_general_status')
+OK

--- a/mysql-test/suite/component_audit_log_filter/t/audit_filter_json_log_expect_classes.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/audit_filter_json_log_expect_classes.inc
@@ -1,0 +1,70 @@
+# ==== Purpose ====
+#
+# After generate_audit_events.inc, read the current JSON audit log and assert
+# which event classes appear. Uses the same path variables as this suite's
+# filter tests (audit_filter_log_path, audit_filter_log_name).
+#
+# ==== Prerequisites ====
+#
+# --let audit_filter_log_path = ...
+# --let audit_filter_log_name = ...
+#
+# ==== Parameters (comma-separated class names, no spaces) ====
+#
+# --let audit_filter_expect_required = general,connection,table_access
+#   Each listed class must appear at least once (optional: leave empty).
+#   Use names without a leading '$' so mysqltest exports them to the perl
+#   process environment.
+#
+# --let audit_filter_expect_absent = table_access,connection
+#   Each listed class must not appear (optional: leave empty).
+#
+# --let audit_filter_expect_for_suffix = empty filter
+#   Used in die messages for missing required classes: "... for <suffix>".
+#
+# --let audit_filter_expect_ok = OK: empty filter
+#   Printed on success (one line, no newline in the value).
+#
+# ==== Usage ====
+#
+# --source audit_filter_json_log_expect_classes.inc
+
+perl;
+  use strict;
+  use warnings;
+  use JSON::PP ();
+
+  sub classes_from_env {
+    my ($k) = @_;
+    my $v = $ENV{$k} // '';
+    return grep { length $_ } split /,/, $v;
+  }
+
+  my $path = $ENV{audit_filter_log_path} . $ENV{audit_filter_log_name};
+  open(my $fh, '<:encoding(UTF-8)', $path) or die "open $path: $!";
+  local $/;
+  my $t = <$fh>;
+  close($fh);
+  $t =~ s/\s+$//;
+  unless ($t =~ /\]\s*$/) {
+    $t =~ s/,\s*$//;
+    $t .= "\n]\n";
+  }
+  my $events = JSON::PP::decode_json($t);
+  my %seen;
+  for my $e (@{$events}) {
+    next if ref($e) ne 'HASH' || !exists $e->{class};
+    $seen{$e->{class}} = 1;
+  }
+
+  my $suffix = $ENV{audit_filter_expect_for_suffix} // '';
+  for my $need (classes_from_env('audit_filter_expect_required')) {
+    die "expected class '$need' for $suffix\n" if !$seen{$need};
+  }
+  for my $bad (classes_from_env('audit_filter_expect_absent')) {
+    die "class '$bad' must not be logged\n" if $seen{$bad};
+  }
+  my $ok = $ENV{audit_filter_expect_ok};
+  die "audit_filter_expect_ok not set\n" if !defined $ok || $ok eq '';
+  print "$ok\n";
+EOF

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_default_log_action-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_default_log_action-master.opt
@@ -1,0 +1,2 @@
+--loose-audit_log_filter.file=filter_definition_default_log_action.log
+--loose-audit_log_filter.format=JSON

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_default_log_action.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_default_log_action.test
@@ -1,0 +1,110 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--let audit_filter_log_path = $audit_filter_log_path
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let audit_filter_log_name = $audit_filter_log_name
+
+--disable_query_log
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
+call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filter '.*' format");
+--enable_query_log
+
+--echo #
+--echo # Empty top-level filter object must default to logging all events (same as "log": true).
+SELECT audit_log_filter_set_filter('f_empty', '{"filter": {}}');
+SELECT audit_log_filter_set_user('%', 'f_empty');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general,connection,table_access
+--let audit_filter_expect_absent =
+--let audit_filter_expect_for_suffix = empty filter
+--let audit_filter_expect_ok = OK: empty filter
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # Explicit "log": true must log general, connection, and table_access events.
+SELECT audit_log_filter_set_filter('f_log_true', '{"filter": {"log": true}}');
+SELECT audit_log_filter_set_user('%', 'f_log_true');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general,connection,table_access
+--let audit_filter_expect_absent =
+--let audit_filter_expect_for_suffix = log true
+--let audit_filter_expect_ok = OK: log true
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # "log": true with only "id" and multi-class list still logs unmatched event classes.
+SELECT audit_log_filter_set_filter('f_log_true_complex', '{"filter": {"log": true, "id": "complex-1", "class": [{"name": "general"}, {"name": "connection"}]}}');
+SELECT audit_log_filter_set_user('%', 'f_log_true_complex');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general,connection,table_access
+--let audit_filter_expect_absent =
+--let audit_filter_expect_for_suffix = top log true with class list
+--let audit_filter_expect_ok = OK: log true with id and class list
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # Only "id" (no "log", no "class") matches empty filter: log all.
+SELECT audit_log_filter_set_filter('f_id_only', '{"filter": {"id": "metadata-only"}}');
+SELECT audit_log_filter_set_user('%', 'f_id_only');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general,connection,table_access
+--let audit_filter_expect_absent =
+--let audit_filter_expect_for_suffix = id-only filter
+--let audit_filter_expect_ok = OK: id only
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # No top-level "log" with only "class": general — unmatched events are not logged.
+SELECT audit_log_filter_set_filter('f_class_general_only', '{"filter": {"class": {"name": "general"}}}');
+SELECT audit_log_filter_set_user('%', 'f_class_general_only');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general
+--let audit_filter_expect_absent = table_access,connection
+--let audit_filter_expect_for_suffix = only class general is listed
+--let audit_filter_expect_ok = OK: class general only
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # No top-level "log" with class list general+connection — table_access still excluded.
+SELECT audit_log_filter_set_filter('f_class_gen_conn', '{"filter": {"class": [{"name": "general"}, {"name": "connection"}]}}');
+SELECT audit_log_filter_set_user('%', 'f_class_gen_conn');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general,connection
+--let audit_filter_expect_absent = table_access
+--let audit_filter_expect_for_suffix = class list general and connection
+--let audit_filter_expect_ok = OK: class general and connection
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # No top-level "log" with nested event rule — only matching subclasses are logged (REDUCED: general/status).
+SELECT audit_log_filter_set_filter('f_class_general_status', '{"filter": {"class": {"name": "general", "event": {"name": "status", "log": true}}}}');
+SELECT audit_log_filter_set_user('%', 'f_class_general_status');
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let audit_filter_expect_required = general
+--let audit_filter_expect_absent = table_access,connection
+--let audit_filter_expect_for_suffix = general/status subclass rule
+--let audit_filter_expect_ok = OK: class general event status only
+--source audit_filter_json_log_expect_classes.inc
+
+--echo #
+--echo # Cleanup filters
+SELECT audit_log_filter_remove_filter('f_empty');
+SELECT audit_log_filter_remove_filter('f_log_true');
+SELECT audit_log_filter_remove_filter('f_log_true_complex');
+SELECT audit_log_filter_remove_filter('f_id_only');
+SELECT audit_log_filter_remove_filter('f_class_general_only');
+SELECT audit_log_filter_remove_filter('f_class_gen_conn');
+SELECT audit_log_filter_remove_filter('f_class_general_status');
+
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc


### PR DESCRIPTION
1. audit_log_filter: default empty filter object to log all events

Remove the early return in parse_default_log_action_json() when the
filter object is empty. The rule still defaulted m_should_log_unmatched
to false, so '{}' never called set_should_log_unmatched(true) and no
events were logged. Empty filter now matches explicit {"log": true}.

Add MTR test filter_definition_default_log_action (JSON log,
audit_log_filter.event_mode default REDUCED): empty filter, explicit log,
id-only, class-only rules, nested general/status subclass rule, and clean
log between scenarios via clean_current_audit_log.inc.

2. Skip general/status Quit command events in REDUCED event mode

The Quit command produces a general/status event that carries no useful
audit information.  In REDUCED mode these events add noise to the log.
After set_extended_info populates the command name from THD attributes,
