### PR TITLE
PS-10873 [8.4]: Fix audit log retry after buffer resize

### DIFF
--- a/plugin/audit_log/audit_log.cc
+++ b/plugin/audit_log/audit_log.cc
@@ -1130,15 +1130,17 @@ static int audit_log_notify(MYSQL_THD thd, mysql_event_class_t event_class,
             log_rec, buflen, event_general->general_command.str,
             event_general->general_time, event_general->general_error_code,
             *event_general, local->db, &len);
-        if (len > buflen) {
-          buflen = len + 1024;
+        while (log_rec == nullptr && len > buflen) {
+          const size_t next_buflen = len + 1024;
+          if (next_buflen <= buflen) break;
+          buflen = next_buflen;
           log_rec = audit_log_general_record(
               get_record_buffer(thd, buflen), buflen,
               event_general->general_command.str, event_general->general_time,
               event_general->general_error_code, *event_general, local->db,
               &len);
-          assert(log_rec);
         }
+        assert(log_rec);
         if (log_rec) audit_log_write(log_rec, len);
         break;
       }


### PR DESCRIPTION
PS-10593 updated `audit_log_general_record()` sizing, but `audit_log_notify()` still assumed a single reallocation was always enough. For charset-heavy queries such as `audit_log_charset`, the first retry can still return `NULL` with a larger required size, and the unconditional `assert(log_rec)` then aborts the server.

Retry buffer growth until `audit_log_general_record()` succeeds or stops requesting a larger buffer. This keeps the new sizing logic from turning underestimated retries into a server crash.