### PR TITLE
PS-10951 [9.x]: Per-session audit filter caching with correct reload/removal semantics

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -515,13 +515,24 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   }
 
   auto current_gen = SysVars::get_filter_rule_generation();
+  auto current_detach_gen = SysVars::get_filter_rule_detach_generation();
   auto *rule_cache = SysVars::get_session_filter_rule(thd);
   const bool can_cache_miss = must_resolve_rule || rule_cache != nullptr;
 
   std::shared_ptr<AuditRule> filter_rule;
+  bool detach_session = rule_cache != nullptr &&
+                        rule_cache->detach_generation != current_detach_gen;
 
-  if (!must_resolve_rule && rule_cache != nullptr &&
-      rule_cache->generation == current_gen) {
+  if (detach_session && !must_resolve_rule) {
+    SysVars::set_session_filter_id(thd, 0);
+    SysVars::set_session_filter_rule(thd, current_gen, current_detach_gen,
+                                     nullptr);
+    return 0;
+  }
+
+  if (!detach_session && !must_resolve_rule && rule_cache != nullptr &&
+      rule_cache->generation == current_gen &&
+      rule_cache->detach_generation == current_detach_gen) {
     filter_rule = rule_cache->rule;
     if (filter_rule == nullptr) {
       return 0;
@@ -579,17 +590,21 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
         // complement forces the next event to resolve again instead of
         // reusing a stale rule or transient miss while reload is still
         // in progress.
-        SysVars::set_session_filter_rule(thd, ~current_gen, nullptr);
+        SysVars::set_session_filter_rule(thd, ~current_gen,
+                                         current_detach_gen, nullptr);
       } else if (can_cache_miss) {
-        SysVars::set_session_filter_rule(thd, current_gen, nullptr);
+        SysVars::set_session_filter_rule(thd, current_gen, current_detach_gen,
+                                         nullptr);
       }
       return 0;
     }
 
     if (may_cache) {
-      SysVars::set_session_filter_rule(thd, current_gen, filter_rule);
+      SysVars::set_session_filter_rule(thd, current_gen, current_detach_gen,
+                                       filter_rule);
     } else {
-      SysVars::set_session_filter_rule(thd, ~current_gen, nullptr);
+      SysVars::set_session_filter_rule(thd, ~current_gen,
+                                       current_detach_gen, nullptr);
     }
   }
 

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -527,30 +527,70 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
       return 0;
     }
   } else {
-    std::string rule_name;
+    auto resolve = [&]() -> bool {
+      std::string rule_name;
+      filter_rule = m_audit_rules_registry->resolve_rule_for_user(
+          user_name, user_host, &rule_name);
 
-    if (!m_audit_rules_registry->lookup_rule_name(user_name, user_host,
-                                                  rule_name)) {
+      if (filter_rule == nullptr) {
+        if (rule_name.empty()) {
+          return false;
+        }
+        LogComponentErr(ERROR_LEVEL, ER_AUDIT_FILTER_RULE_NOT_FOUND,
+                        rule_name.c_str());
+        return false;
+      }
+
+      return true;
+    };
+
+    auto before_load_ver = must_resolve_rule
+                               ? m_audit_rules_registry->load_version()
+                               : uint64_t{0};
+
+    bool resolved = resolve();
+
+    bool may_cache = true;
+    if (must_resolve_rule) {
+      // Read is_reload_in_progress BEFORE load_version so that the
+      // acquire on the loads_in_progress counter establishes a
+      // happens-before with the UDF thread's release-store of
+      // load_version.  If we observe "not in progress", the subsequent
+      // version read is guaranteed to reflect any completed reload.
+      bool reload_pending = m_audit_rules_registry->is_reload_in_progress();
+      auto after_load_ver = m_audit_rules_registry->load_version();
+
+      if (after_load_ver != before_load_ver) {
+        current_gen = SysVars::get_filter_rule_generation();
+        resolved = resolve();
+        reload_pending = m_audit_rules_registry->is_reload_in_progress();
+      }
+
+      if (reload_pending) may_cache = false;
+    }
+
+    if (!resolved) {
       SysVars::set_session_filter_id(thd, 0);
-      if (can_cache_miss) {
+      if (!may_cache) {
+        // Invalidate any prior cache (relevant for CHANGE_USER on an
+        // existing session).  Store ~current_gen as a deliberate
+        // generation mismatch: the cache fast path only hits when the
+        // cached generation equals current_gen, so using the bitwise
+        // complement forces the next event to resolve again instead of
+        // reusing a stale rule or transient miss while reload is still
+        // in progress.
+        SysVars::set_session_filter_rule(thd, ~current_gen, nullptr);
+      } else if (can_cache_miss) {
         SysVars::set_session_filter_rule(thd, current_gen, nullptr);
       }
       return 0;
     }
 
-    filter_rule = m_audit_rules_registry->get_rule(rule_name);
-
-    if (filter_rule == nullptr) {
-      LogComponentErr(ERROR_LEVEL, ER_AUDIT_FILTER_RULE_NOT_FOUND,
-                      rule_name.c_str());
-      SysVars::set_session_filter_id(thd, 0);
-      if (can_cache_miss) {
-        SysVars::set_session_filter_rule(thd, current_gen, nullptr);
-      }
-      return 0;
+    if (may_cache) {
+      SysVars::set_session_filter_rule(thd, current_gen, filter_rule);
+    } else {
+      SysVars::set_session_filter_rule(thd, ~current_gen, nullptr);
     }
-
-    SysVars::set_session_filter_rule(thd, current_gen, filter_rule);
   }
 
   SysVars::set_session_filter_id(thd, filter_rule->get_filter_id());

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -503,21 +503,54 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
     return 0;
   }
 
-  // Get connection specific filtering rule
-  std::string rule_name;
-
-  if (!m_audit_rules_registry->lookup_rule_name(user_name, user_host,
-                                                rule_name)) {
-    SysVars::set_session_filter_id(thd, 0);
-    return 0;
+  bool must_resolve_rule = false;
+  if (event_class == audit_event_class_t::AUDIT_CONNECTION_CLASS) {
+    auto sc =
+        static_cast<const mysql_event_tracking_connection_data *>(event_data)
+            ->event_subclass;
+    if (sc == EVENT_TRACKING_CONNECTION_CONNECT ||
+        sc == EVENT_TRACKING_CONNECTION_CHANGE_USER) {
+      must_resolve_rule = true;
+    }
   }
 
-  auto filter_rule = m_audit_rules_registry->get_rule(rule_name);
+  auto current_gen = SysVars::get_filter_rule_generation();
+  auto *rule_cache = SysVars::get_session_filter_rule(thd);
+  const bool can_cache_miss = must_resolve_rule || rule_cache != nullptr;
 
-  if (filter_rule == nullptr) {
-    LogComponentErr(ERROR_LEVEL, ER_AUDIT_FILTER_RULE_NOT_FOUND,
-                    rule_name.c_str());
-    return 0;
+  std::shared_ptr<AuditRule> filter_rule;
+
+  if (!must_resolve_rule && rule_cache != nullptr &&
+      rule_cache->generation == current_gen) {
+    filter_rule = rule_cache->rule;
+    if (filter_rule == nullptr) {
+      return 0;
+    }
+  } else {
+    std::string rule_name;
+
+    if (!m_audit_rules_registry->lookup_rule_name(user_name, user_host,
+                                                  rule_name)) {
+      SysVars::set_session_filter_id(thd, 0);
+      if (can_cache_miss) {
+        SysVars::set_session_filter_rule(thd, current_gen, nullptr);
+      }
+      return 0;
+    }
+
+    filter_rule = m_audit_rules_registry->get_rule(rule_name);
+
+    if (filter_rule == nullptr) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_FILTER_RULE_NOT_FOUND,
+                      rule_name.c_str());
+      SysVars::set_session_filter_id(thd, 0);
+      if (can_cache_miss) {
+        SysVars::set_session_filter_rule(thd, current_gen, nullptr);
+      }
+      return 0;
+    }
+
+    SysVars::set_session_filter_rule(thd, current_gen, filter_rule);
   }
 
   SysVars::set_session_filter_id(thd, filter_rule->get_filter_id());

--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -516,6 +516,7 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
 
   auto current_gen = SysVars::get_filter_rule_generation();
   auto current_detach_gen = SysVars::get_filter_rule_detach_generation();
+  auto current_removed_gen = SysVars::get_removed_filter_generation();
   auto *rule_cache = SysVars::get_session_filter_rule(thd);
   const bool can_cache_miss = must_resolve_rule || rule_cache != nullptr;
 
@@ -523,16 +524,28 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
   bool detach_session = rule_cache != nullptr &&
                         rule_cache->detach_generation != current_detach_gen;
 
+  if (!detach_session && rule_cache != nullptr &&
+      rule_cache->removed_filter_generation != current_removed_gen) {
+    if (rule_cache->rule != nullptr &&
+        SysVars::is_removed_filter_id(rule_cache->rule->get_filter_id(),
+                                      rule_cache->removed_filter_generation)) {
+      detach_session = true;
+    } else {
+      rule_cache->removed_filter_generation = current_removed_gen;
+    }
+  }
+
   if (detach_session && !must_resolve_rule) {
     SysVars::set_session_filter_id(thd, 0);
     SysVars::set_session_filter_rule(thd, current_gen, current_detach_gen,
-                                     nullptr);
+                                     current_removed_gen, nullptr);
     return 0;
   }
 
   if (!detach_session && !must_resolve_rule && rule_cache != nullptr &&
       rule_cache->generation == current_gen &&
-      rule_cache->detach_generation == current_detach_gen) {
+      rule_cache->detach_generation == current_detach_gen &&
+      rule_cache->removed_filter_generation == current_removed_gen) {
     filter_rule = rule_cache->rule;
     if (filter_rule == nullptr) {
       return 0;
@@ -590,21 +603,21 @@ int AuditLogFilter::notify_event(audit_event_class_t event_class,
         // complement forces the next event to resolve again instead of
         // reusing a stale rule or transient miss while reload is still
         // in progress.
-        SysVars::set_session_filter_rule(thd, ~current_gen,
-                                         current_detach_gen, nullptr);
+        SysVars::set_session_filter_rule(thd, ~current_gen, current_detach_gen,
+                                         current_removed_gen, nullptr);
       } else if (can_cache_miss) {
         SysVars::set_session_filter_rule(thd, current_gen, current_detach_gen,
-                                         nullptr);
+                                         current_removed_gen, nullptr);
       }
       return 0;
     }
 
     if (may_cache) {
       SysVars::set_session_filter_rule(thd, current_gen, current_detach_gen,
-                                       filter_rule);
+                                       current_removed_gen, filter_rule);
     } else {
-      SysVars::set_session_filter_rule(thd, ~current_gen,
-                                       current_detach_gen, nullptr);
+      SysVars::set_session_filter_rule(thd, ~current_gen, current_detach_gen,
+                                       current_removed_gen, nullptr);
     }
   }
 

--- a/components/audit_log_filter/audit_rule_registry.cc
+++ b/components/audit_log_filter/audit_rule_registry.cc
@@ -25,18 +25,65 @@ namespace audit_log_filter {
 namespace {
 const std::string kDefaultUserName = "%";
 const std::string kDefaultHostName = "%";
+
+void log_load_failure(const std::string &error_msg) {
+  if (error_msg.empty()) {
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to load filtering rules");
+    return;
+  }
+
+  const std::string log_message =
+      "Failed to load filtering rules: " + error_msg;
+  LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, log_message.c_str());
+}
 }  // namespace
 
 std::shared_ptr<AuditRule> AuditRuleRegistry::get_rule(
     const std::string &rule_name) noexcept {
   std::shared_lock lock(m_registry_mutex);
 
-  if (m_audit_filter_rules.count(rule_name) == 0) {
-    return nullptr;
+  auto it = m_audit_filter_rules.find(rule_name);
+  return it == m_audit_filter_rules.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<AuditRule> AuditRuleRegistry::resolve_rule_for_user(
+    const std::string &user_name, const std::string &host_name,
+    std::string *rule_name) noexcept {
+  if (rule_name != nullptr) {
+    rule_name->clear();
   }
 
-  auto it = m_audit_filter_rules.find(rule_name);
-  return it->second;
+  if (!m_is_initialised) {
+    m_is_initialised = true;
+    std::string error_msg;
+    if (!load(error_msg)) {
+      log_load_failure(error_msg);
+      // fail only when there is no prior good snapshot; otherwise keep using
+      // the old one
+      if (load_version() == 0) {
+        return nullptr;
+      }
+    }
+  }
+
+  std::shared_lock lock(m_registry_mutex);
+
+  auto user_it = m_audit_users.find(std::make_pair(user_name, host_name));
+  if (user_it == m_audit_users.end()) {
+    user_it =
+        m_audit_users.find(std::make_pair(kDefaultUserName, kDefaultHostName));
+    if (user_it == m_audit_users.end()) {
+      return nullptr;
+    }
+  }
+
+  if (rule_name != nullptr) {
+    *rule_name = user_it->second;
+  }
+
+  auto rule_it = m_audit_filter_rules.find(user_it->second);
+  return rule_it == m_audit_filter_rules.end() ? nullptr : rule_it->second;
 }
 
 bool AuditRuleRegistry::lookup_rule_name(const std::string &user_name,
@@ -46,8 +93,10 @@ bool AuditRuleRegistry::lookup_rule_name(const std::string &user_name,
     m_is_initialised = true;
     std::string error_msg;
     if (!load(error_msg)) {
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Failed to load filtering rules");
+      log_load_failure(error_msg);
+      if (load_version() == 0) {
+        return false;
+      }
     }
   }
 
@@ -71,6 +120,8 @@ bool AuditRuleRegistry::lookup_rule_name(const std::string &user_name,
 void AuditRuleRegistry::invalidate() noexcept { m_is_initialised = false; }
 
 bool AuditRuleRegistry::load(std::string &error_message) noexcept {
+  m_loads_in_progress.fetch_add(1, std::memory_order_release);
+
   audit_table::AuditLogFilter audit_log_filter{
       SysVars::get_config_database_name()};
   audit_table::AuditLogUser audit_log_user{SysVars::get_config_database_name()};
@@ -87,9 +138,20 @@ bool AuditRuleRegistry::load(std::string &error_message) noexcept {
     std::unique_lock lock(m_registry_mutex);
     m_audit_users.swap(tmp_users);
     m_audit_filter_rules.swap(tmp_rules);
+    m_load_version.fetch_add(1, std::memory_order_release);
   }
 
+  m_loads_in_progress.fetch_sub(1, std::memory_order_release);
+
   return is_success;
+}
+
+uint64_t AuditRuleRegistry::load_version() const noexcept {
+  return m_load_version.load(std::memory_order_acquire);
+}
+
+bool AuditRuleRegistry::is_reload_in_progress() const noexcept {
+  return m_loads_in_progress.load(std::memory_order_acquire) > 0;
 }
 
 }  // namespace audit_log_filter

--- a/components/audit_log_filter/audit_rule_registry.h
+++ b/components/audit_log_filter/audit_rule_registry.h
@@ -51,6 +51,25 @@ class AuditRuleRegistry {
       const std::string &filter_name) noexcept;
 
   /**
+   * @brief Resolve the filtering rule assigned to a user under one shared-lock
+   *        acquisition.
+   *
+   * Performs both the user-to-rule lookup and the rule lookup against one
+   * consistent registry snapshot, avoiding an intermediate reload between the
+   * two reads.
+   *
+   * @param [in] user_name User name
+   * @param [in] host_name User host name
+   * @param [out] rule_name Resolved filtering rule name, empty if no mapping
+   *                        was found
+   * @return Filtering rule, or nullptr if the user has no assigned rule or if
+   *         the mapping refers to a missing rule
+   */
+  [[nodiscard]] std::shared_ptr<AuditRule> resolve_rule_for_user(
+      const std::string &user_name, const std::string &host_name,
+      std::string *rule_name = nullptr) noexcept;
+
+  /**
    * @brief Lookup filtering rule by user name and user host.
    *
    * @param [in] user_name User name
@@ -64,17 +83,39 @@ class AuditRuleRegistry {
                         std::string &rule_name) noexcept;
 
   /**
-   * @brief Mark the registry as needing a reload on the next rule lookup.
+   * @brief Mark the registry as needing a reload on the next rule resolution.
    *
    * Safe to call from any context (lock-free atomic store). The actual
-   * reload happens inside the next lookup_rule_name() call, which runs
+   * reload happens inside the next rule resolution call, which runs
    * in a THD context where table access is permitted.
    */
   void invalidate() noexcept;
 
+  /**
+   * @brief Registry version, incremented under the exclusive lock every
+   *        time load() successfully swaps in new data.
+   *
+   * Used by CONNECT/CHANGE_USER events to detect a concurrent reload
+   * that may have changed user-to-filter mappings between the pre-resolve
+   * snapshot and the post-resolve check.
+   */
+  [[nodiscard]] uint64_t load_version() const noexcept;
+
+  /**
+   * @brief True while at least one load() call is in progress.
+   *
+   * The counter is incremented before the DB read and decremented after
+   * the version bump.  CONNECT/CHANGE_USER paths use this to suppress
+   * caching when a reload is underway — the resolved rule is used for
+   * the current event only, and the next event re-resolves.
+   */
+  [[nodiscard]] bool is_reload_in_progress() const noexcept;
+
  private:
   std::atomic<bool> m_is_initialised{false};
   std::shared_mutex m_registry_mutex;
+  std::atomic<uint64_t> m_load_version{0};
+  std::atomic<uint32_t> m_loads_in_progress{0};
   audit_table::AuditLogUser::AuditUsersContainer m_audit_users;
   audit_table::AuditLogFilter::AuditRulesContainer m_audit_filter_rules;
 };

--- a/components/audit_log_filter/audit_table/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_table/audit_log_filter.cc
@@ -283,6 +283,45 @@ TableResult AuditLogFilter::check_name_exists(
   return scan_result;
 }
 
+TableResult AuditLogFilter::get_filter_id(const std::string &rule_name,
+                                          uint64_t &filter_id) noexcept {
+  DBUG_EXECUTE_IF("udf_audit_log_filter_get_filter_id_failure",
+                  return TableResult::Fail;);
+
+  auto ta_context = open_table();
+
+  if (ta_context == nullptr) {
+    return TableResult::Fail;
+  }
+
+  TA_key filter_name_key = nullptr;
+  auto scan_result = index_scan_locate_record_by_rule_name(
+      ta_context.get(), &filter_name_key, rule_name);
+
+  if (scan_result != TableResult::Found) {
+    if (scan_result != TableResult::Fail) {
+      index_scan_end(ta_context.get(), filter_name_key);
+    }
+    return scan_result;
+  }
+
+  my_service<SERVICE_TYPE(field_integer_access_v1)> integer_srv(
+      "field_integer_access_v1", SysVars::get_comp_registry_srv());
+  long long found_filter_id = 0;
+
+  if (integer_srv->get(ta_context->ta_session, ta_context->ta_table,
+                       kAuditLogFilterFilterId, &found_filter_id)) {
+    LogComponentErr(ERROR_LEVEL, ER_AUDIT_TABLE_READ_FIELD_FAILURE,
+                    get_table_name(), "filter_id");
+    index_scan_end(ta_context.get(), filter_name_key);
+    return TableResult::Fail;
+  }
+
+  filter_id = static_cast<uint64_t>(found_filter_id);
+  index_scan_end(ta_context.get(), filter_name_key);
+  return TableResult::Found;
+}
+
 TableResult AuditLogFilter::insert_filter(
     const std::string &rule_name, const std::string &rule_definition) noexcept {
   DBUG_EXECUTE_IF("udf_audit_log_filter_insertion_failure",

--- a/components/audit_log_filter/audit_table/audit_log_filter.h
+++ b/components/audit_log_filter/audit_table/audit_log_filter.h
@@ -50,6 +50,16 @@ class AuditLogFilter : public AuditTableBase {
   TableResult check_name_exists(const std::string &rule_name) noexcept;
 
   /**
+   * @brief Get filtering rule ID by rule name.
+   *
+   * @param rule_name Filtering rule name
+   * @param filter_id Returned filtering rule ID
+   * @return Table access result, @ref TableResult
+   */
+  TableResult get_filter_id(const std::string &rule_name,
+                            uint64_t &filter_id) noexcept;
+
+  /**
    * @brief Insert filtering rule.
    *
    * @param rule_name Filtering rule name

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -752,7 +752,7 @@ char *AuditUdf::audit_log_filter_flush_udf(AuditUdf *udf [[maybe_unused]],
   std::string flush_error;
   if (get_audit_log_filter_instance()->on_audit_rule_flush_requested(
           flush_error)) {
-    SysVars::bump_filter_rule_generation();
+    SysVars::bump_filter_rule_detach_generation();
     std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   } else if (!flush_error.empty()) {
     std::snprintf(result, MYSQL_ERRMSG_SIZE, "ERROR: %s", flush_error.c_str());

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -190,6 +190,28 @@ bool check_timestamp_valid(std::string &timestamp_str) {
   return false;
 }
 
+bool reload_audit_rules_or_set_error(char *result,
+                                     unsigned long *length) noexcept {
+  std::string error_msg;
+  if (get_audit_log_filter_instance()->on_audit_rule_flush_requested(
+          error_msg)) {
+    return true;
+  }
+
+  // Force the next lookup to retry loading the freshly committed table state.
+  get_audit_log_filter_instance()->invalidate_audit_rules();
+
+  if (!error_msg.empty()) {
+    std::snprintf(result, MYSQL_ERRMSG_SIZE, "ERROR: %s", error_msg.c_str());
+  } else {
+    std::snprintf(result, MYSQL_ERRMSG_SIZE,
+                  "ERROR: Could not reinitialize audit log filters");
+  }
+
+  *length = std::strlen(result);
+  return false;
+}
+
 }  // namespace
 
 AuditUdf::~AuditUdf() { deinit(); }
@@ -459,8 +481,10 @@ char *AuditUdf::audit_log_filter_remove_filter_udf(
     return result;
   }
 
-  std::string error_msg;
-  get_audit_log_filter_instance()->on_audit_rule_flush_requested(error_msg);
+  SysVars::bump_filter_rule_generation();
+  if (!reload_audit_rules_or_set_error(result, length)) {
+    return result;
+  }
 
   std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   *length = std::strlen(result);
@@ -587,8 +611,9 @@ char *AuditUdf::audit_log_filter_set_user_udf(AuditUdf *udf [[maybe_unused]],
     return result;
   }
 
-  std::string error_msg;
-  get_audit_log_filter_instance()->on_audit_rule_flush_requested(error_msg);
+  if (!reload_audit_rules_or_set_error(result, length)) {
+    return result;
+  }
 
   std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   *length = std::strlen(result);
@@ -674,8 +699,9 @@ char *AuditUdf::audit_log_filter_remove_user_udf(
     return result;
   }
 
-  std::string error_msg;
-  get_audit_log_filter_instance()->on_audit_rule_flush_requested(error_msg);
+  if (!reload_audit_rules_or_set_error(result, length)) {
+    return result;
+  }
 
   std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   *length = std::strlen(result);
@@ -726,6 +752,7 @@ char *AuditUdf::audit_log_filter_flush_udf(AuditUdf *udf [[maybe_unused]],
   std::string flush_error;
   if (get_audit_log_filter_instance()->on_audit_rule_flush_requested(
           flush_error)) {
+    SysVars::bump_filter_rule_generation();
     std::snprintf(result, MYSQL_ERRMSG_SIZE, "OK");
   } else if (!flush_error.empty()) {
     std::snprintf(result, MYSQL_ERRMSG_SIZE, "ERROR: %s", flush_error.c_str());

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -446,7 +446,9 @@ char *AuditUdf::audit_log_filter_remove_filter_udf(
       SysVars::get_config_database_name()};
   audit_table::AuditLogUser audit_log_user{SysVars::get_config_database_name()};
 
-  auto check_result = audit_log_filter.check_name_exists(udf_args->args[0]);
+  uint64_t removed_filter_id = 0;
+  auto check_result =
+      audit_log_filter.get_filter_id(udf_args->args[0], removed_filter_id);
 
   if (check_result == audit_table::TableResult::Fail) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_REMOVE_FILTER_UDF_NAME_CHECK_FAIL);
@@ -481,7 +483,7 @@ char *AuditUdf::audit_log_filter_remove_filter_udf(
     return result;
   }
 
-  SysVars::bump_filter_rule_generation();
+  SysVars::mark_removed_filter_id(removed_filter_id);
   if (!reload_audit_rules_or_set_error(result, length)) {
     return result;
   }

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -36,8 +36,10 @@
 #include <atomic>
 #include <filesystem>
 #include <iomanip>
+#include <mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 namespace audit_log_filter {
 namespace {
@@ -58,6 +60,9 @@ mysql_thd_store_slot session_filter_rule_slot{nullptr};
 
 std::atomic<uint64_t> filter_rule_generation{0};
 std::atomic<uint64_t> filter_rule_detach_generation{0};
+std::atomic<uint64_t> removed_filter_generation{0};
+std::mutex removed_filter_ids_mutex;
+std::unordered_map<uint64_t, uint64_t> removed_filter_ids;
 
 bool has_system_variables_privilege(MYSQL_THD thd) {
   my_service<SERVICE_TYPE(mysql_thd_security_context)> security_context_service(
@@ -834,6 +839,11 @@ void SysVars::deinit() noexcept {
   thd_store_service->set(nullptr, session_filter_id_slot, nullptr);
   thd_store_service->set(nullptr, session_filter_rule_slot, nullptr);
 
+  {
+    std::lock_guard<std::mutex> lock(removed_filter_ids_mutex);
+    removed_filter_ids.clear();
+  }
+
   thd_store_service->unregister_slot(reader_context_thread_slot);
   thd_store_service->unregister_slot(session_filter_id_slot);
   thd_store_service->unregister_slot(session_filter_rule_slot);
@@ -1057,6 +1067,7 @@ SessionFilterRuleCache *SysVars::get_session_filter_rule(
 
 void SysVars::set_session_filter_rule(
     MYSQL_THD thd, uint64_t generation, uint64_t detach_generation,
+    uint64_t current_removed_filter_generation,
     std::shared_ptr<AuditRule> rule) noexcept {
   my_service<SERVICE_TYPE(mysql_thd_store)> thd_store_service(
       "mysql_thd_store", SysVars::get_comp_registry_srv());
@@ -1065,8 +1076,9 @@ void SysVars::set_session_filter_rule(
       thd_store_service->get(thd, session_filter_rule_slot));
 
   if (cache == nullptr) {
-    auto *new_cache = new (std::nothrow)
-        SessionFilterRuleCache{generation, detach_generation, std::move(rule)};
+    auto *new_cache = new (std::nothrow) SessionFilterRuleCache{
+        generation, detach_generation, current_removed_filter_generation,
+        std::move(rule)};
 
     if (new_cache != nullptr) {
       if (thd_store_service->set(thd, session_filter_rule_slot,
@@ -1080,9 +1092,9 @@ void SysVars::set_session_filter_rule(
                       "Failed to allocate session_filter_rule");
     }
   } else {
-    cache->generation = generation;
-    cache->detach_generation = detach_generation;
-    cache->rule = std::move(rule);
+    *cache = SessionFilterRuleCache{generation, detach_generation,
+                                    current_removed_filter_generation,
+                                    std::move(rule)};
   }
 }
 
@@ -1100,6 +1112,25 @@ uint64_t SysVars::get_filter_rule_detach_generation() noexcept {
 
 void SysVars::bump_filter_rule_detach_generation() noexcept {
   filter_rule_detach_generation.fetch_add(1, std::memory_order_release);
+}
+
+uint64_t SysVars::get_removed_filter_generation() noexcept {
+  return removed_filter_generation.load(std::memory_order_acquire);
+}
+
+void SysVars::mark_removed_filter_id(uint64_t filter_id) noexcept {
+  std::lock_guard<std::mutex> lock(removed_filter_ids_mutex);
+  const auto next_generation =
+      removed_filter_generation.load(std::memory_order_relaxed) + 1;
+  removed_filter_ids[filter_id] = next_generation;
+  removed_filter_generation.store(next_generation, std::memory_order_release);
+}
+
+bool SysVars::is_removed_filter_id(uint64_t filter_id,
+                                   uint64_t since_generation) noexcept {
+  std::lock_guard<std::mutex> lock(removed_filter_ids_mutex);
+  const auto it = removed_filter_ids.find(filter_id);
+  return it != removed_filter_ids.end() && it->second > since_generation;
 }
 
 void SysVars::inc_events_total() noexcept {

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -57,6 +57,7 @@ mysql_thd_store_slot session_filter_id_slot{nullptr};
 mysql_thd_store_slot session_filter_rule_slot{nullptr};
 
 std::atomic<uint64_t> filter_rule_generation{0};
+std::atomic<uint64_t> filter_rule_detach_generation{0};
 
 bool has_system_variables_privilege(MYSQL_THD thd) {
   my_service<SERVICE_TYPE(mysql_thd_security_context)> security_context_service(
@@ -1055,7 +1056,7 @@ SessionFilterRuleCache *SysVars::get_session_filter_rule(
 }
 
 void SysVars::set_session_filter_rule(
-    MYSQL_THD thd, uint64_t generation,
+    MYSQL_THD thd, uint64_t generation, uint64_t detach_generation,
     std::shared_ptr<AuditRule> rule) noexcept {
   my_service<SERVICE_TYPE(mysql_thd_store)> thd_store_service(
       "mysql_thd_store", SysVars::get_comp_registry_srv());
@@ -1064,8 +1065,8 @@ void SysVars::set_session_filter_rule(
       thd_store_service->get(thd, session_filter_rule_slot));
 
   if (cache == nullptr) {
-    auto *new_cache =
-        new (std::nothrow) SessionFilterRuleCache{generation, std::move(rule)};
+    auto *new_cache = new (std::nothrow)
+        SessionFilterRuleCache{generation, detach_generation, std::move(rule)};
 
     if (new_cache != nullptr) {
       if (thd_store_service->set(thd, session_filter_rule_slot,
@@ -1080,6 +1081,7 @@ void SysVars::set_session_filter_rule(
     }
   } else {
     cache->generation = generation;
+    cache->detach_generation = detach_generation;
     cache->rule = std::move(rule);
   }
 }
@@ -1090,6 +1092,14 @@ uint64_t SysVars::get_filter_rule_generation() noexcept {
 
 void SysVars::bump_filter_rule_generation() noexcept {
   filter_rule_generation.fetch_add(1, std::memory_order_release);
+}
+
+uint64_t SysVars::get_filter_rule_detach_generation() noexcept {
+  return filter_rule_detach_generation.load(std::memory_order_acquire);
+}
+
+void SysVars::bump_filter_rule_detach_generation() noexcept {
+  filter_rule_detach_generation.fetch_add(1, std::memory_order_release);
 }
 
 void SysVars::inc_events_total() noexcept {

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -50,8 +50,13 @@ constexpr std::string_view kReaderContextSlotName{
     "component_audit_reader_context"};
 constexpr std::string_view kSessionFilterIdSlotName{
     "component_audit_reader_session_filter_id"};
+constexpr std::string_view kSessionFilterRuleSlotName{
+    "component_audit_session_filter_rule"};
 mysql_thd_store_slot reader_context_thread_slot{nullptr};
 mysql_thd_store_slot session_filter_id_slot{nullptr};
+mysql_thd_store_slot session_filter_rule_slot{nullptr};
+
+std::atomic<uint64_t> filter_rule_generation{0};
 
 bool has_system_variables_privilege(MYSQL_THD thd) {
   my_service<SERVICE_TYPE(mysql_thd_security_context)> security_context_service(
@@ -282,6 +287,7 @@ void event_mode_update_func(MYSQL_THD, SYS_VAR *, void *val_ptr,
 
   if (old_val != new_val) {
     get_audit_log_filter_instance()->invalidate_audit_rules();
+    SysVars::bump_filter_rule_generation();
   }
 }
 
@@ -773,6 +779,16 @@ bool SysVars::init() noexcept {
     return false;
   }
 
+  if (thd_store_service->register_slot(
+          kSessionFilterRuleSlotName.data(),
+          [](void *cache) -> int {
+            delete reinterpret_cast<SessionFilterRuleCache *>(cache);
+            return 0;
+          },
+          &session_filter_rule_slot) == 1) {
+    return false;
+  }
+
   if (status_var_registration_srv->register_variable(status_vars) == 1) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_STATUS_VAR_REGISTER_FAILURE);
     return false;
@@ -811,11 +827,15 @@ void SysVars::deinit() noexcept {
       thd_store_service->get(nullptr, reader_context_thread_slot));
   delete reinterpret_cast<ulong *>(
       thd_store_service->get(nullptr, session_filter_id_slot));
+  delete reinterpret_cast<SessionFilterRuleCache *>(
+      thd_store_service->get(nullptr, session_filter_rule_slot));
   thd_store_service->set(nullptr, reader_context_thread_slot, nullptr);
   thd_store_service->set(nullptr, session_filter_id_slot, nullptr);
+  thd_store_service->set(nullptr, session_filter_rule_slot, nullptr);
 
   thd_store_service->unregister_slot(reader_context_thread_slot);
   thd_store_service->unregister_slot(session_filter_id_slot);
+  thd_store_service->unregister_slot(session_filter_rule_slot);
 
   if (status_var_registration_srv->unregister_variable(status_vars) == 1) {
     LogComponentErr(ERROR_LEVEL, ER_AUDIT_STATUS_VAR_UNREGISTER_FAILURE);
@@ -1023,6 +1043,53 @@ void SysVars::set_log_reader_context(MYSQL_THD thd,
 
   thd_store_service->set(thd, reader_context_thread_slot,
                          reinterpret_cast<void *>(context));
+}
+
+SessionFilterRuleCache *SysVars::get_session_filter_rule(
+    MYSQL_THD thd) noexcept {
+  my_service<SERVICE_TYPE(mysql_thd_store)> thd_store_service(
+      "mysql_thd_store", SysVars::get_comp_registry_srv());
+
+  return reinterpret_cast<SessionFilterRuleCache *>(
+      thd_store_service->get(thd, session_filter_rule_slot));
+}
+
+void SysVars::set_session_filter_rule(
+    MYSQL_THD thd, uint64_t generation,
+    std::shared_ptr<AuditRule> rule) noexcept {
+  my_service<SERVICE_TYPE(mysql_thd_store)> thd_store_service(
+      "mysql_thd_store", SysVars::get_comp_registry_srv());
+
+  auto *cache = reinterpret_cast<SessionFilterRuleCache *>(
+      thd_store_service->get(thd, session_filter_rule_slot));
+
+  if (cache == nullptr) {
+    auto *new_cache =
+        new (std::nothrow) SessionFilterRuleCache{generation, std::move(rule)};
+
+    if (new_cache != nullptr) {
+      if (thd_store_service->set(thd, session_filter_rule_slot,
+                                 reinterpret_cast<void *>(new_cache)) == 1) {
+        LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Failed to set session_filter_rule");
+        delete new_cache;
+      }
+    } else {
+      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failed to allocate session_filter_rule");
+    }
+  } else {
+    cache->generation = generation;
+    cache->rule = std::move(rule);
+  }
+}
+
+uint64_t SysVars::get_filter_rule_generation() noexcept {
+  return filter_rule_generation.load(std::memory_order_acquire);
+}
+
+void SysVars::bump_filter_rule_generation() noexcept {
+  filter_rule_generation.fetch_add(1, std::memory_order_release);
 }
 
 void SysVars::inc_events_total() noexcept {

--- a/components/audit_log_filter/sys_vars.h
+++ b/components/audit_log_filter/sys_vars.h
@@ -31,6 +31,7 @@ class AuditRule;
 
 struct SessionFilterRuleCache {
   uint64_t generation;
+  uint64_t detach_generation;
   std::shared_ptr<AuditRule> rule;
 };
 
@@ -380,9 +381,11 @@ class SysVars {
    *
    * @param thd Connection specific THD instance
    * @param generation Current filter rule generation at time of resolution
+   * @param detach_generation Current detach generation at time of resolution
    * @param rule The resolved filter rule (nullptr if no rule applies)
    */
   static void set_session_filter_rule(MYSQL_THD thd, uint64_t generation,
+                                      uint64_t detach_generation,
                                       std::shared_ptr<AuditRule> rule) noexcept;
 
   /**
@@ -399,6 +402,21 @@ class SysVars {
    * Used by flush and remove_filter operations.
    */
   static void bump_filter_rule_generation() noexcept;
+
+  /**
+   * @brief Get the current global detach generation counter.
+   *
+   * @return Current generation value
+   */
+  static uint64_t get_filter_rule_detach_generation() noexcept;
+
+  /**
+   * @brief Increment the global detach generation counter.
+   *
+   * Forces current sessions to detach from their cached filter until the next
+   * connect or change-user operation.
+   */
+  static void bump_filter_rule_detach_generation() noexcept;
 
 #ifndef NDEBUG
   /**

--- a/components/audit_log_filter/sys_vars.h
+++ b/components/audit_log_filter/sys_vars.h
@@ -27,6 +27,13 @@
 
 namespace audit_log_filter {
 
+class AuditRule;
+
+struct SessionFilterRuleCache {
+  uint64_t generation;
+  std::shared_ptr<AuditRule> rule;
+};
+
 struct AuditLogReaderContext;
 class SysVars;
 
@@ -358,6 +365,40 @@ class SysVars {
    */
   static void set_log_reader_context(MYSQL_THD thd,
                                      AuditLogReaderContext *context) noexcept;
+
+  /**
+   * @brief Get the cached filter rule for a session.
+   *
+   * @param thd Connection specific THD instance
+   * @return Pointer to session filter rule cache, or nullptr if not yet cached
+   */
+  static SessionFilterRuleCache *get_session_filter_rule(
+      MYSQL_THD thd) noexcept;
+
+  /**
+   * @brief Cache a filter rule for a session.
+   *
+   * @param thd Connection specific THD instance
+   * @param generation Current filter rule generation at time of resolution
+   * @param rule The resolved filter rule (nullptr if no rule applies)
+   */
+  static void set_session_filter_rule(MYSQL_THD thd, uint64_t generation,
+                                      std::shared_ptr<AuditRule> rule) noexcept;
+
+  /**
+   * @brief Get the current global filter rule generation counter.
+   *
+   * @return Current generation value
+   */
+  static uint64_t get_filter_rule_generation() noexcept;
+
+  /**
+   * @brief Increment the global filter rule generation counter.
+   *
+   * Forces all sessions to re-resolve their filter rule on the next event.
+   * Used by flush and remove_filter operations.
+   */
+  static void bump_filter_rule_generation() noexcept;
 
 #ifndef NDEBUG
   /**

--- a/components/audit_log_filter/sys_vars.h
+++ b/components/audit_log_filter/sys_vars.h
@@ -32,6 +32,7 @@ class AuditRule;
 struct SessionFilterRuleCache {
   uint64_t generation;
   uint64_t detach_generation;
+  uint64_t removed_filter_generation;
   std::shared_ptr<AuditRule> rule;
 };
 
@@ -382,10 +383,13 @@ class SysVars {
    * @param thd Connection specific THD instance
    * @param generation Current filter rule generation at time of resolution
    * @param detach_generation Current detach generation at time of resolution
+   * @param removed_filter_generation Current removed-filter generation at time
+   *                                  of resolution
    * @param rule The resolved filter rule (nullptr if no rule applies)
    */
   static void set_session_filter_rule(MYSQL_THD thd, uint64_t generation,
                                       uint64_t detach_generation,
+                                      uint64_t removed_filter_generation,
                                       std::shared_ptr<AuditRule> rule) noexcept;
 
   /**
@@ -417,6 +421,32 @@ class SysVars {
    * connect or change-user operation.
    */
   static void bump_filter_rule_detach_generation() noexcept;
+
+  /**
+   * @brief Get the current removed-filter generation counter.
+   *
+   * @return Current generation value
+   */
+  static uint64_t get_removed_filter_generation() noexcept;
+
+  /**
+   * @brief Mark a filter ID as removed for existing sessions.
+   *
+   * Sessions still using this cached filter ID will detach on their next
+   * non-connection event.
+   */
+  static void mark_removed_filter_id(uint64_t filter_id) noexcept;
+
+  /**
+   * @brief Check whether a filter ID has been removed.
+   *
+   * @param filter_id Filtering rule ID
+   * @param since_generation The session cache's removed-filter generation
+   * @return true if the filter was removed after since_generation,
+   *         false otherwise
+   */
+  static bool is_removed_filter_id(uint64_t filter_id,
+                                   uint64_t since_generation) noexcept;
 
 #ifndef NDEBUG
   /**

--- a/mysql-test/suite/component_audit_log_filter/r/session_filter_id_update.result
+++ b/mysql-test/suite/component_audit_log_filter/r/session_filter_id_update.result
@@ -37,10 +37,10 @@ audit_log_filter_set_user('user2@localhost', 'user2_2')
 OK
 SELECT audit_log_session_filter_id();
 audit_log_session_filter_id()
-3
+1
 SELECT audit_log_session_filter_id();
 audit_log_session_filter_id()
-4
+2
 #
 # Cleanup
 DROP USER 'user1'@'localhost', 'user2'@'localhost';

--- a/mysql-test/suite/component_audit_log_filter/r/status_var_log_size.result
+++ b/mysql-test/suite/component_audit_log_filter/r/status_var_log_size.result
@@ -4,6 +4,9 @@ OK
 SELECT audit_log_filter_set_user('%', 'log_all');
 audit_log_filter_set_user('%', 'log_all')
 OK
+SELECT 1;
+1
+1
 SELECT audit_log_filter_remove_user('%');
 audit_log_filter_remove_user('%')
 OK

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_flush.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_flush.result
@@ -19,6 +19,7 @@ SET GLOBAL DEBUG='-d,audit_log_filter_fail_filters_flush';
 SELECT audit_log_filter_flush();
 audit_log_filter_flush()
 OK
+No tag <AUDIT_RECORD> Ok
 Tag <EVENT_CLASS_NAME>table_access</EVENT_CLASS_NAME> Ok
 #
 # Check wrong argument number

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_remove_filter.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_remove_filter.result
@@ -19,12 +19,12 @@ ERROR HY000: Can't initialize function 'audit_log_filter_remove_filter'; Wrong a
 SELECT audit_log_filter_remove_filter('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
 ERROR HY000: Can't initialize function 'audit_log_filter_remove_filter'; Wrong argument: filter_name is too long, max length is 255
 #
-# Filter name existence check failure
-SET SESSION debug="+d,udf_audit_log_filter_check_name_failure";
+# Get filter ID failure
+SET SESSION debug="+d,udf_audit_log_filter_get_filter_id_failure";
 SELECT audit_log_filter_remove_filter('filter_1');
 audit_log_filter_remove_filter('filter_1')
 ERROR: Failed to check filtering rule name existence
-SET SESSION debug="-d,udf_audit_log_filter_check_name_failure";
+SET SESSION debug="-d,udf_audit_log_filter_get_filter_id_failure";
 #
 # Remove non existent filter
 SELECT * FROM mysql.audit_log_filter;

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_remove_filter.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_remove_filter.result
@@ -102,4 +102,21 @@ filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;
 username	userhost	filtername
 #
+# Filters reload failure after removing filter
+SELECT audit_log_filter_set_filter('filter_3', '{"filter": {"class": {"name": "connection"}}}');
+audit_log_filter_set_filter('filter_3', '{"filter": {"class": {"name": "connection"}}}')
+OK
+SELECT audit_log_filter_set_user('user4@localhost', 'filter_3');
+audit_log_filter_set_user('user4@localhost', 'filter_3')
+OK
+SET SESSION debug='+d,audit_log_filter_fail_filters_flush';
+SELECT audit_log_filter_remove_filter('filter_3');
+audit_log_filter_remove_filter('filter_3')
+ERROR: Could not reinitialize audit log filters
+SELECT * FROM mysql.audit_log_filter;
+filter_id	name	filter
+SELECT * FROM mysql.audit_log_user;
+username	userhost	filtername
+SET SESSION debug='-d,audit_log_filter_fail_filters_flush';
+#
 # Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_set_user.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_filter_set_user.result
@@ -88,6 +88,20 @@ filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;
 username	userhost	filtername
 #
+# Filters reload failure after setting user
+SET SESSION debug='+d,audit_log_filter_fail_filters_flush';
+SELECT audit_log_filter_set_user('reload_test@localhost', 'log_all');
+audit_log_filter_set_user('reload_test@localhost', 'log_all')
+ERROR: Could not reinitialize audit log filters
+SELECT * FROM mysql.audit_log_filter;
+filter_id	name	filter
+1	log_all	{"filter": {"log": true}}
+2	log_table_access	{"filter": {"class": {"name": "table_access"}}}
+SELECT * FROM mysql.audit_log_user;
+username	userhost	filtername
+reload_test	localhost	log_all
+SET SESSION debug='-d,audit_log_filter_fail_filters_flush';
+#
 # Set filter for default user
 SELECT audit_log_filter_set_user('%', 'log_all');
 audit_log_filter_set_user('%', 'log_all')
@@ -99,6 +113,7 @@ filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;
 username	userhost	filtername
 %	%	log_all
+reload_test	localhost	log_all
 #
 # Set filter for a user
 SELECT audit_log_filter_set_user('root@localhost', 'log_all');
@@ -111,6 +126,7 @@ filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;
 username	userhost	filtername
 %	%	log_all
+reload_test	localhost	log_all
 root	localhost	log_all
 #
 # Update filter for a user
@@ -124,6 +140,7 @@ filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;
 username	userhost	filtername
 %	%	log_all
+reload_test	localhost	log_all
 root	localhost	log_table_access
 #
 # User filter set failure
@@ -138,6 +155,7 @@ filter_id	name	filter
 SELECT * FROM mysql.audit_log_user;
 username	userhost	filtername
 %	%	log_all
+reload_test	localhost	log_all
 root	localhost	log_table_access
 SET SESSION debug="-d,udf_audit_log_user_set_update_filter_failure";
 #

--- a/mysql-test/suite/component_audit_log_filter/r/udf_logging_stopped_on_rule_removal.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_logging_stopped_on_rule_removal.result
@@ -1,13 +1,34 @@
-SELECT audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }');
-audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }')
+CREATE USER 'user1'@'localhost' IDENTIFIED BY '111';
+GRANT ALL PRIVILEGES ON *.* to 'user1'@'localhost';
+SELECT audit_log_filter_set_filter('log_default', '{ "filter": { "log": true } }');
+audit_log_filter_set_filter('log_default', '{ "filter": { "log": true } }')
 OK
-SELECT audit_log_filter_set_user('%', 'log_all');
-audit_log_filter_set_user('%', 'log_all')
+SELECT audit_log_filter_set_filter('log_user', '{ "filter": { "log": true } }');
+audit_log_filter_set_filter('log_user', '{ "filter": { "log": true } }')
+OK
+SELECT audit_log_filter_set_user('%', 'log_default');
+audit_log_filter_set_user('%', 'log_default')
+OK
+SELECT audit_log_filter_set_user('user1@localhost', 'log_user');
+audit_log_filter_set_user('user1@localhost', 'log_user')
 OK
 Tag <AUDIT_RECORD> Ok
-SELECT audit_log_filter_remove_filter('log_all');
-audit_log_filter_remove_filter('log_all')
+SELECT audit_log_filter_remove_filter('log_user');
+audit_log_filter_remove_filter('log_user')
 OK
 No tag <AUDIT_RECORD> Ok
+Tag <AUDIT_RECORD> Ok
+SELECT audit_log_filter_set_filter('log_reused', '{ "filter": { "log": true } }');
+audit_log_filter_set_filter('log_reused', '{ "filter": { "log": true } }')
+OK
+SELECT audit_log_filter_set_user('user1@localhost', 'log_reused');
+audit_log_filter_set_user('user1@localhost', 'log_reused')
+OK
+Tag <AUDIT_RECORD> Ok
+SELECT audit_log_filter_remove_filter('log_default');
+audit_log_filter_remove_filter('log_default')
+OK
+Tag <AUDIT_RECORD> Ok
 #
 # Cleanup
+DROP USER 'user1'@'localhost';

--- a/mysql-test/suite/component_audit_log_filter/r/udf_logging_stopped_on_user_removal.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_logging_stopped_on_user_removal.result
@@ -8,6 +8,7 @@ Tag <AUDIT_RECORD> Ok
 SELECT audit_log_filter_remove_user('%');
 audit_log_filter_remove_user('%')
 OK
+Tag <AUDIT_RECORD> Ok
 No tag <AUDIT_RECORD> Ok
 #
 # Cleanup

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_abort_event.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_abort_event.test
@@ -17,7 +17,6 @@ GRANT SYSTEM_USER ON *.* to 'user2'@'localhost';
 GRANT AUDIT_ABORT_EXEMPT ON *.* to 'user2'@'localhost';
 
 connect(conn1, localhost, user1, 111, test);
-connect(conn2, localhost, user2, 222, test);
 
 --connection conn1
 
@@ -38,6 +37,9 @@ let $filter = {
 eval SELECT audit_log_filter_set_filter('table_readonly', '$filter');
 SELECT audit_log_filter_set_user('%', 'table_readonly');
 
+connect(conn_blocked, localhost, user1, 111, test);
+--connection conn_blocked
+
 --error ER_AUDIT_API_ABORT
 INSERT INTO t1 VALUES (2);
 --error ER_AUDIT_API_ABORT
@@ -55,6 +57,9 @@ DELETE FROM t2 WHERE c2 = 1;
 
 SELECT * FROM t1;
 SELECT * FROM t2;
+
+disconnect conn_blocked;
+--connection conn1
 
 SELECT audit_log_filter_remove_user('%');
 
@@ -80,6 +85,9 @@ let $filter = {
 eval SELECT audit_log_filter_set_filter('no_t1_access', '$filter');
 SELECT audit_log_filter_set_user('%', 'no_t1_access');
 
+connect(conn_blocked, localhost, user1, 111, test);
+--connection conn_blocked
+
 --error ER_AUDIT_API_ABORT
 INSERT INTO t1 VALUES (2);
 INSERT INTO t2 VALUES (2);
@@ -95,6 +103,9 @@ DELETE FROM t2 WHERE c2 = 1;
 --error ER_AUDIT_API_ABORT
 SELECT * FROM t1;
 SELECT * FROM t2;
+
+disconnect conn_blocked;
+--connection conn1
 
 --echo #
 --echo # Check mysql_event_message events may be aborted
@@ -112,8 +123,15 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('abort_message', '$filter');
 SELECT audit_log_filter_set_user('%', 'abort_message');
+
+connect(conn_blocked, localhost, user1, 111, test);
+--connection conn_blocked
+
 --error ER_AUDIT_API_ABORT
 SELECT audit_api_message_emit_udf('component_text', 'producer_text', 'message_text', 'key', 'value') AS 'Message';
+
+disconnect conn_blocked;
+--connection conn1
 
 SELECT audit_log_filter_remove_user('%');
 
@@ -124,6 +142,7 @@ DELETE FROM t2;
 
 SELECT audit_log_filter_set_user('user2@localhost', 'no_t1_access');
 
+connect(conn2, localhost, user2, 222, test);
 --connection conn2
 
 INSERT INTO t1 VALUES (2);

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_default_log_action.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_default_log_action.test
@@ -16,6 +16,8 @@ call mtr.add_suppression("Component audit_log_filter reported: 'Wrong JSON filte
 --echo # Empty top-level filter object must default to logging all events (same as "log": true).
 SELECT audit_log_filter_set_filter('f_empty', '{"filter": {}}');
 SELECT audit_log_filter_set_user('%', 'f_empty');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general,connection,table_access
@@ -28,6 +30,8 @@ SELECT audit_log_filter_set_user('%', 'f_empty');
 --echo # Explicit "log": true must log general, connection, and table_access events.
 SELECT audit_log_filter_set_filter('f_log_true', '{"filter": {"log": true}}');
 SELECT audit_log_filter_set_user('%', 'f_log_true');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general,connection,table_access
@@ -40,6 +44,8 @@ SELECT audit_log_filter_set_user('%', 'f_log_true');
 --echo # "log": true with only "id" and multi-class list still logs unmatched event classes.
 SELECT audit_log_filter_set_filter('f_log_true_complex', '{"filter": {"log": true, "id": "complex-1", "class": [{"name": "general"}, {"name": "connection"}]}}');
 SELECT audit_log_filter_set_user('%', 'f_log_true_complex');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general,connection,table_access
@@ -52,6 +58,8 @@ SELECT audit_log_filter_set_user('%', 'f_log_true_complex');
 --echo # Only "id" (no "log", no "class") matches empty filter: log all.
 SELECT audit_log_filter_set_filter('f_id_only', '{"filter": {"id": "metadata-only"}}');
 SELECT audit_log_filter_set_user('%', 'f_id_only');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general,connection,table_access
@@ -64,6 +72,8 @@ SELECT audit_log_filter_set_user('%', 'f_id_only');
 --echo # No top-level "log" with only "class": general — unmatched events are not logged.
 SELECT audit_log_filter_set_filter('f_class_general_only', '{"filter": {"class": {"name": "general"}}}');
 SELECT audit_log_filter_set_user('%', 'f_class_general_only');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general
@@ -76,6 +86,8 @@ SELECT audit_log_filter_set_user('%', 'f_class_general_only');
 --echo # No top-level "log" with class list general+connection — table_access still excluded.
 SELECT audit_log_filter_set_filter('f_class_gen_conn', '{"filter": {"class": [{"name": "general"}, {"name": "connection"}]}}');
 SELECT audit_log_filter_set_user('%', 'f_class_gen_conn');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general,connection
@@ -88,6 +100,8 @@ SELECT audit_log_filter_set_user('%', 'f_class_gen_conn');
 --echo # No top-level "log" with nested event rule — only matching subclasses are logged (REDUCED: general/status).
 SELECT audit_log_filter_set_filter('f_class_general_status', '{"filter": {"class": {"name": "general", "event": {"name": "status", "log": true}}}}');
 SELECT audit_log_filter_set_user('%', 'f_class_general_status');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let audit_filter_expect_required = general

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_class.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_class.test
@@ -27,6 +27,9 @@ SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';
 --echo #
 --echo # Log 'general' events only
 SELECT audit_log_filter_set_user('%', 'log_general');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -34,6 +37,9 @@ SELECT audit_log_filter_set_user('%', 'log_general');
 --echo #
 --echo # Log 'connection' events only
 SELECT audit_log_filter_set_user('%', 'log_connection');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>connection</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -41,6 +47,9 @@ SELECT audit_log_filter_set_user('%', 'log_connection');
 --echo #
 --echo # Log 'table_access' events only
 SELECT audit_log_filter_set_user('%', 'log_table_access');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>table_access</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -48,6 +57,9 @@ SELECT audit_log_filter_set_user('%', 'log_table_access');
 --echo #
 --echo # Log 'global_variable' events only
 SELECT audit_log_filter_set_user('%', 'log_global_variable');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>global_variable</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -55,6 +67,9 @@ SELECT audit_log_filter_set_user('%', 'log_global_variable');
 --echo #
 --echo # Log 'command' events only
 SELECT audit_log_filter_set_user('%', 'log_command');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>command</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -62,6 +77,9 @@ SELECT audit_log_filter_set_user('%', 'log_command');
 --echo #
 --echo # Log 'query' events only
 SELECT audit_log_filter_set_user('%', 'log_query');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>query</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -69,6 +87,9 @@ SELECT audit_log_filter_set_user('%', 'log_query');
 --echo #
 --echo # Log 'stored_program' events only
 SELECT audit_log_filter_set_user('%', 'log_stored_program');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>stored_program</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -76,6 +97,9 @@ SELECT audit_log_filter_set_user('%', 'log_stored_program');
 --echo #
 --echo # Log 'authentication' events only
 SELECT audit_log_filter_set_user('%', 'log_authentication');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>authentication</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -83,6 +107,9 @@ SELECT audit_log_filter_set_user('%', 'log_authentication');
 --echo #
 --echo # Log 'message' events only
 SELECT audit_log_filter_set_user('%', 'log_message');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>message</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -91,6 +118,9 @@ SELECT audit_log_filter_set_user('%', 'log_message');
 --echo # Enable logging multiple classes with one rule
 SELECT audit_log_filter_set_filter('log_classes_list_1', '{"filter": {"class": [{"name": "general"}, {"name": "connection"}]}}');
 SELECT audit_log_filter_set_user('%', 'log_classes_list_1');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>(?:general|connection)</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -99,6 +129,9 @@ SELECT audit_log_filter_set_user('%', 'log_classes_list_1');
 --echo # Another way to enable logging multiple classes with one rule
 SELECT audit_log_filter_set_filter('log_classes_list_2', '{"filter": {"class": [{"name": ["general", "connection"]}]}}');
 SELECT audit_log_filter_set_user('%', 'log_classes_list_2');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>(?:general|connection)</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_field.test
@@ -27,6 +27,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_query', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_query');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<HOST>localhost</HOST>
 --source check_all_events_with_tag.inc
@@ -49,6 +52,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_conn_type_by_numeric', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_conn_type_by_numeric');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<CONNECTION_TYPE>Socket</CONNECTION_TYPE>
 --source check_all_events_with_tag.inc
@@ -69,6 +75,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_conn_type_by_pseudo', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_conn_type_by_pseudo');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<CONNECTION_TYPE>Socket</CONNECTION_TYPE>
 --source check_all_events_with_tag.inc
@@ -94,6 +103,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_or', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_or');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=[<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t1</TABLE>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t2</TABLE>]
 --source check_all_events_with_tag.inc
@@ -119,6 +131,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_and', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_and');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<DB>test</DB>.*<TABLE>t1</TABLE>
 --source check_all_events_with_tag.inc
@@ -143,6 +158,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_not', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_not');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=[<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t2</TABLE>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t3</TABLE>]
 --source check_all_events_with_tag.inc
@@ -180,6 +198,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_all', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_all');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=[<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t1</TABLE>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t3</TABLE>]
 --source check_all_events_with_tag.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_subclass.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_subclass.test
@@ -25,6 +25,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_log', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_log');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>log</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -42,6 +45,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_result', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_result');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>result</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -59,6 +65,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_status', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_status');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -79,6 +88,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_log_result_1', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_log_result_1');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:log|result)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -98,6 +110,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_log_result_2', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_log_result_2');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:log|result)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -115,6 +130,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_connect_insert', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_connect_insert');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:connect|insert)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -137,6 +155,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_explicit_action', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_explicit_action');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:read|insert)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_inclusive_exclusive.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_inclusive_exclusive.test
@@ -32,6 +32,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_inclusive', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_inclusive');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=(?:<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>|<EVENT_SUBCLASS_NAME>connect</EVENT_SUBCLASS_NAME>)
 --source check_all_events_with_tag.inc
@@ -50,6 +53,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_exclusive', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_exclusive');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=!<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_function_string_find.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_function_string_find.test
@@ -38,6 +38,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_users_access', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_users_access');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 
 SELECT * FROM user_list;
 SELECT * FROM product_list;
@@ -71,6 +74,9 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_users_access_case_sensitive', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_users_access_case_sensitive');
+disconnect default;
+connect(default, localhost, root, , test);
+--source clean_current_audit_log.inc
 
 SELECT * FROM user_list;
 SELECT * FROM product_list;

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
@@ -13,6 +13,9 @@ SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';
 CREATE TABLE t1 (id INT);
 CREATE TABLE t2 (id INT);
 
+connect(conn_admin, localhost, root, , test);
+--connection conn_admin
+
 --echo #
 --echo # Field replacement for all events of "query" class
 let $filter = {
@@ -32,8 +35,15 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('replace_query', '$filter');
 SELECT audit_log_filter_set_user('%', 'replace_query');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
 
 INSERT INTO t1 VALUES (1);
+
+disconnect conn_run;
+--connection conn_admin
 
 --let $search_tag=<EVENT_CLASS_NAME>query</EVENT_CLASS_NAME>.*<SQLTEXT>(?:SELECT `audit_log_filter_set_user` \(\.\.\.\)|INSERT INTO `t1` VALUES \(\?\))</SQLTEXT>
 --source check_all_events_with_tag.inc
@@ -57,11 +67,18 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('replace_parse_query', '$filter');
 SELECT audit_log_filter_set_user('%', 'replace_parse_query');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
 
 INSERT INTO t2 VALUES (1);
 UPDATE t2 SET id = 2 WHERE id = 1;
 SELECT * FROM t2;
 DELETE FROM t2 WHERE id = 2;
+
+disconnect conn_run;
+--connection conn_admin
 
 --let $search_tag=<EVENT_CLASS_NAME>parse</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -90,11 +107,18 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('replace_query_start_end', '$filter');
 SELECT audit_log_filter_set_user('%', 'replace_query_start_end');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
 
 INSERT INTO t2 VALUES (1);
 UPDATE t2 SET id = 2 WHERE id = 1;
 SELECT * FROM t2;
 DELETE FROM t2 WHERE id = 2;
+
+disconnect conn_run;
+--connection conn_admin
 
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:start|status_end)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -132,11 +156,18 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('replace_not_matching_digest', '$filter');
 SELECT audit_log_filter_set_user('%', 'replace_not_matching_digest');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
 
 INSERT INTO t2 VALUES (1);
 UPDATE t2 SET id = 2 WHERE id = 1;
 SELECT * FROM t2;
 DELETE FROM t2 WHERE id = 2;
+
+disconnect conn_run;
+--connection conn_admin
 
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:start|status_end)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -176,11 +207,18 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('replace_matching_digest', '$filter');
 SELECT audit_log_filter_set_user('%', 'replace_matching_digest');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
 
 INSERT INTO t2 VALUES (1);
 UPDATE t2 SET id = 2 WHERE id = 1;
 SELECT * FROM t2;
 DELETE FROM t2 WHERE id = 2;
+
+disconnect conn_run;
+--connection conn_admin
 
 --let $search_tag=<EVENT_SUBCLASS_NAME>start</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -229,11 +267,18 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('replace_for_tables', '$filter');
 SELECT audit_log_filter_set_user('%', 'replace_for_tables');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
 
 INSERT INTO t1 VALUES (1);
 INSERT INTO t2 VALUES (1);
 DELETE FROM t1;
 DELETE FROM t2;
+
+disconnect conn_run;
+--connection conn_admin
 
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:start|status_end)</EVENT_SUBCLASS_NAME>
 --source check_all_events_with_tag.inc
@@ -359,6 +404,9 @@ SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='-d,audit_log_filter_rotate_after_audit_rules_flush';
 
 DROP TABLE t1, t2;
+
+disconnect conn_admin;
+connection default;
 
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/status_var_log_size.test
+++ b/mysql-test/suite/component_audit_log_filter/t/status_var_log_size.test
@@ -7,8 +7,16 @@
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
 
+disconnect default;
+connect(default, localhost, root, , test);
+
 SELECT audit_log_filter_set_filter('log_all', '{"filter": {"log": true}}');
 SELECT audit_log_filter_set_user('%', 'log_all');
+connect(conn_log, localhost, root, , test);
+--connection conn_log
+SELECT 1;
+disconnect conn_log;
+--connection default
 SELECT audit_log_filter_remove_user('%');
 
 --let $expected_current_log_size = query_get_value(SHOW GLOBAL STATUS LIKE 'Audit_log_filter_current_size', Value, 1)
@@ -23,7 +31,11 @@ if ($expected_current_log_size != $expected_total_log_size) {
 
 # Enable logging and generate events to get rotated log files
 SELECT audit_log_filter_set_user('%', 'log_all');
+connect(conn_log, localhost, root, , test);
+--connection conn_log
 --source generate_audit_events.inc
+disconnect conn_log;
+--connection default
 SELECT audit_log_filter_remove_user('%');
 
 --let $expected_current_log_size = query_get_value(SHOW GLOBAL STATUS LIKE 'Audit_log_filter_current_size', Value, 1)

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_flush.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_flush.test
@@ -50,5 +50,10 @@ SELECT audit_log_filter_flush("");
 SET GLOBAL DEBUG='-d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='-d,audit_log_filter_rotate_after_audit_rules_flush';
 
+--disconnect default
+--source include/wait_until_disconnected.inc
+connect(default, localhost, root, , test);
+--connection default
+
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_flush.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_flush.test
@@ -33,12 +33,24 @@ SELECT audit_log_filter_flush();
 --source check_all_events_with_tag.inc
 SET GLOBAL DEBUG='-d,audit_log_filter_fail_filters_flush';
 
-# Changed filter loaded after audit_log_filter_flush() invocation
+# Changed filter is loaded for new sessions, current session is detached
 SELECT audit_log_filter_flush();
 
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+--let $search_tag=!<AUDIT_RECORD>
+--source check_all_events_with_tag.inc
+
+connect(conn2, localhost, root, , test);
+--connection conn2
+
+--source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>table_access</EVENT_CLASS_NAME>
 --source check_all_events_with_tag.inc
+
+--disconnect conn2
+--connection default
 
 --echo #
 --echo # Check wrong argument number

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_remove_filter.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_remove_filter.test
@@ -32,6 +32,7 @@ SELECT audit_log_filter_remove_filter('');
 call mtr.add_suppression("Failed to check filtering rule name existence");
 call mtr.add_suppression("Failed to remove filter 'filter_2' from users table");
 call mtr.add_suppression("Failed to remove filter 'filter_2'");
+call mtr.add_suppression("Failed to load filtering rules");
 --enable_query_log
 
 --echo #
@@ -80,6 +81,16 @@ SET SESSION debug="-d,udf_audit_log_filter_delete_filter_failure";
 SELECT audit_log_filter_remove_filter('filter_2');
 SELECT * FROM mysql.audit_log_filter;
 SELECT * FROM mysql.audit_log_user;
+
+--echo #
+--echo # Filters reload failure after removing filter
+SELECT audit_log_filter_set_filter('filter_3', '{"filter": {"class": {"name": "connection"}}}');
+SELECT audit_log_filter_set_user('user4@localhost', 'filter_3');
+SET SESSION debug='+d,audit_log_filter_fail_filters_flush';
+SELECT audit_log_filter_remove_filter('filter_3');
+SELECT * FROM mysql.audit_log_filter;
+SELECT * FROM mysql.audit_log_user;
+SET SESSION debug='-d,audit_log_filter_fail_filters_flush';
 
 --echo #
 --echo # Cleanup

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_remove_filter.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_remove_filter.test
@@ -36,10 +36,10 @@ call mtr.add_suppression("Failed to load filtering rules");
 --enable_query_log
 
 --echo #
---echo # Filter name existence check failure
-SET SESSION debug="+d,udf_audit_log_filter_check_name_failure";
+--echo # Get filter ID failure
+SET SESSION debug="+d,udf_audit_log_filter_get_filter_id_failure";
 SELECT audit_log_filter_remove_filter('filter_1');
-SET SESSION debug="-d,udf_audit_log_filter_check_name_failure";
+SET SESSION debug="-d,udf_audit_log_filter_get_filter_id_failure";
 
 --echo #
 --echo # Remove non existent filter

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_set_user.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_filter_set_user.test
@@ -75,6 +75,7 @@ SELECT audit_log_filter_set_user('*@localhost', 'filter_1');
 call mtr.add_suppression("Failed to check filtering rule name existence");
 call mtr.add_suppression("Unknown filtering rule name 'filter_1'");
 call mtr.add_suppression("Failed to set 'log_all' filtering rule for user 'root@localhost'");
+call mtr.add_suppression("Failed to load filtering rules");
 --enable_query_log
 
 --echo #
@@ -97,6 +98,14 @@ SELECT audit_log_filter_set_filter('log_all', '{"filter": {"log": true}}');
 SELECT audit_log_filter_set_filter('log_table_access', '{"filter": {"class": {"name": "table_access"}}}');
 SELECT * FROM mysql.audit_log_filter;
 SELECT * FROM mysql.audit_log_user;
+
+--echo #
+--echo # Filters reload failure after setting user
+SET SESSION debug='+d,audit_log_filter_fail_filters_flush';
+SELECT audit_log_filter_set_user('reload_test@localhost', 'log_all');
+SELECT * FROM mysql.audit_log_filter;
+SELECT * FROM mysql.audit_log_user;
+SET SESSION debug='-d,audit_log_filter_fail_filters_flush';
 
 --echo #
 --echo # Set filter for default user

--- a/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_rule_removal.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_rule_removal.test
@@ -5,24 +5,108 @@
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
 
-SELECT audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }');
-SELECT audit_log_filter_set_user('%', 'log_all');
+CREATE USER 'user1'@'localhost' IDENTIFIED BY '111';
+GRANT ALL PRIVILEGES ON *.* to 'user1'@'localhost';
 
-# Verify logging works after default filtering rule assignment
---source generate_audit_events.inc
+SELECT audit_log_filter_set_filter('log_default', '{ "filter": { "log": true } }');
+SELECT audit_log_filter_set_filter('log_user', '{ "filter": { "log": true } }');
+SELECT audit_log_filter_set_user('%', 'log_default');
+SELECT audit_log_filter_set_user('user1@localhost', 'log_user');
+
+connect(keep_conn, localhost, user1, 111, test);
+
+# Verify logging works after user-specific filtering rule assignment
+--connection keep_conn
+--source clean_current_audit_log.inc
+--disable_result_log
+--disable_query_log
+DROP TABLE IF EXISTS t_rule_removal_keep;
+CREATE TABLE t_rule_removal_keep (c1 INT);
+INSERT INTO t_rule_removal_keep VALUES (1);
+DROP TABLE t_rule_removal_keep;
+--enable_query_log
+--enable_result_log
 --let $search_tag=<AUDIT_RECORD>
 --source check_all_events_with_tag.inc
 
-# Remove filtering rule
-SELECT audit_log_filter_remove_filter('log_all');
+# Remove user-specific filtering rule
+--connection default
+SELECT audit_log_filter_remove_filter('log_user');
 
-# Clean current log and make sure no more events are logged
+# Current session is detached and must not fall back to the default filter
+--connection keep_conn
 --source clean_current_audit_log.inc
---source generate_audit_events.inc
+--disable_result_log
+--disable_query_log
+DROP TABLE IF EXISTS t_rule_removal_detached;
+CREATE TABLE t_rule_removal_detached (c1 INT);
+INSERT INTO t_rule_removal_detached VALUES (1);
+DROP TABLE t_rule_removal_detached;
+--enable_query_log
+--enable_result_log
 --let $search_tag=!<AUDIT_RECORD>
 --source check_all_events_with_tag.inc
 
+--disconnect keep_conn
+--connection default
+
+# New sessions use the default filter after the explicit filter is removed
+connect(new_conn, localhost, user1, 111, test);
+--connection new_conn
+--source clean_current_audit_log.inc
+--disable_result_log
+--disable_query_log
+DROP TABLE IF EXISTS t_rule_removal_new;
+CREATE TABLE t_rule_removal_new (c1 INT);
+INSERT INTO t_rule_removal_new VALUES (1);
+DROP TABLE t_rule_removal_new;
+--enable_query_log
+--enable_result_log
+--let $search_tag=<AUDIT_RECORD>
+--source check_all_events_with_tag.inc
+
+--disconnect new_conn
+--connection default
+
+# Reusing a removed FILTER_ID must not detach an unrelated session later
+SELECT audit_log_filter_set_filter('log_reused', '{ "filter": { "log": true } }');
+SELECT audit_log_filter_set_user('user1@localhost', 'log_reused');
+
+connect(reused_conn, localhost, user1, 111, test);
+--connection reused_conn
+--source clean_current_audit_log.inc
+--disable_result_log
+--disable_query_log
+DROP TABLE IF EXISTS t_rule_removal_reused_before;
+CREATE TABLE t_rule_removal_reused_before (c1 INT);
+INSERT INTO t_rule_removal_reused_before VALUES (1);
+DROP TABLE t_rule_removal_reused_before;
+--enable_query_log
+--enable_result_log
+--let $search_tag=<AUDIT_RECORD>
+--source check_all_events_with_tag.inc
+
+--connection default
+SELECT audit_log_filter_remove_filter('log_default');
+
+--connection reused_conn
+--source clean_current_audit_log.inc
+--disable_result_log
+--disable_query_log
+DROP TABLE IF EXISTS t_rule_removal_reused_after;
+CREATE TABLE t_rule_removal_reused_after (c1 INT);
+INSERT INTO t_rule_removal_reused_after VALUES (1);
+DROP TABLE t_rule_removal_reused_after;
+--enable_query_log
+--enable_result_log
+--let $search_tag=<AUDIT_RECORD>
+--source check_all_events_with_tag.inc
+
+--disconnect reused_conn
+--connection default
+
 --echo #
 --echo # Cleanup
+DROP USER 'user1'@'localhost';
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_user_removal.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_user_removal.test
@@ -13,10 +13,33 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 --let $search_tag=<AUDIT_RECORD>
 --source check_all_events_with_tag.inc
 
-# Remove user
+# Open a connection whose CONNECT event resolves the default filter.
+# Its per-session cache will retain the rule after remove_user().
+--source include/count_sessions.inc
+connect(keep_conn, localhost, root, , test);
+
+# Remove the default user mapping via the admin session
+--connection default
 SELECT audit_log_filter_remove_user('%');
 
-# Clean current log and make sure no more events are logged
+# The pre-existing connection still logs (per-session cache preserved)
+--connection keep_conn
+--source clean_current_audit_log.inc
+--disable_result_log
+--disable_query_log
+CREATE TABLE t_keep_check (c1 INT);
+INSERT INTO t_keep_check VALUES (1);
+DROP TABLE t_keep_check;
+--enable_query_log
+--enable_result_log
+--let $search_tag=<AUDIT_RECORD>
+--source check_all_events_with_tag.inc
+
+--disconnect keep_conn
+--connection default
+--source include/wait_until_count_sessions.inc
+
+# New connections are no longer logged (no mapping for new sessions)
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=!<AUDIT_RECORD>

--- a/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_user_removal.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_user_removal.test
@@ -40,6 +40,8 @@ DROP TABLE t_keep_check;
 --source include/wait_until_count_sessions.inc
 
 # New connections are no longer logged (no mapping for new sessions)
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=!<AUDIT_RECORD>

--- a/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
+++ b/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
@@ -54,26 +54,36 @@ SELECT * FROM mysql.audit_log_filter;
 SET GLOBAL audit_log_filter.event_mode=REDUCED;
 SELECT audit_log_filter_flush();
 SELECT audit_log_filter_set_user('%', 'mixed_rule');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "general"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_subclass_rule');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="event": "status"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_conn_command_rule');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "connection"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_ta_sp_rule');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "table_access"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_conn_subclass_rule');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="event": "connect"
@@ -93,6 +103,8 @@ SELECT audit_log_filter_set_filter('query_only_rule', '{"filter":{"class":{"name
 SET GLOBAL audit_log_filter.event_mode=REDUCED;
 SELECT audit_log_filter_set_user('%', 'query_only_rule');
 SET GLOBAL audit_log_filter.event_mode=FULL;
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "query"
@@ -104,6 +116,8 @@ SET GLOBAL audit_log_filter.event_mode=REDUCED;
 --echo # Reduced mode logs only the reduced event-class subset
 SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
 SELECT audit_log_filter_set_user('%', 'log_all');
+disconnect default;
+connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 SELECT audit_log_filter_flush();


### PR DESCRIPTION
### Summary
Introduce per-session filter rule caching in audit_log_filter so that set_user() / remove_user() no longer affect already-connected sessions, and ensure flush() / remove_filter() correctly invalidate or detach stale caches — including under concurrent reload.
- Add SessionFilterRuleCache (stored in a THD store slot) that resolves and caches the filter rule on CONNECT / CHANGE_USER for the lifetime of the session
- set_user() and remove_user() leave existing sessions unaffected; only new connections pick up changes
- flush() bumps a detach generation so existing sessions stop logging until they reconnect or execute CHANGE_USER
- remove_filter() tracks removed filter IDs and detaches only sessions that still cache the specific removed filter, leaving unrelated sessions intact
- Close a CONNECT/CHANGE_USER race window where concurrent flush() or remove_filter() could cause a stale or mid-reload rule to be cached — the event path now snapshots the registry version, re-resolves on version mismatch, and suppresses caching while a reload is in progress
- Update MTR tests to reconnect after set_user() to validate per-session cache semantics

### Commits
1. Cache per-session filter rule so set_user does not affect existing sessions Introduce SessionFilterRuleCache and a global generation counter. The rule is resolved on CONNECT/CHANGE_USER and cached for the session lifetime. flush() and remove_filter() bump the counter to force re-resolve; set_user() and remove_user() do not.
2. Update audit_log_filter tests for session rule caching Reconnect test sessions after set_user() so MTR cases validate per-session cache behavior. Move replace_field log rotation to an unfiltered admin session.
3. Close CONNECT/CHANGE_USER race with concurrent filter reload Snapshot the registry version before resolving, re-resolve if it changed, and suppress caching while a reload is still in progress. Resolve the user-to-rule mapping and rule lookup from one registry snapshot so concurrent reloads cannot interleave between the two reads.
4. Detach current sessions after audit_log_filter_flush Introduce a separate detach generation counter. flush() bumps this counter so existing sessions stop logging until the next CONNECT or CHANGE_USER re-resolves against the reloaded registry.
5. Detach only sessions whose cached filter was removed Replace the global generation bump in remove_filter() with per-filter-ID tracking: record the removed filter ID in a removed-filter set. Sessions check whether their cached filter ID appears in the set; only those sessions are detached.

