### PR TITLE
PS-8867 [9.x]: Increase the verbosity of the DataDictionary upgrade p…

### DIFF
--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -117,8 +117,14 @@ bool update_system_tables(THD *thd) {
   bool exists = false;
 
   if (dd::tables::DD_properties::instance().get(
-          thd, "SYSTEM_TABLES", &system_tables_props, &exists) ||
-      !exists) {
+          thd, "SYSTEM_TABLES", &system_tables_props, &exists)) {
+    LogErr(ERROR_LEVEL, ER_FAILED_GET_DD_PROPERTY, "SYSTEM_TABLES");
+    my_error(ER_DD_INIT_FAILED, MYF(0));
+    return true;
+  }
+  if (!exists) {
+    LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+           "DD property SYSTEM_TABLES is missing during DD upgrade");
     my_error(ER_DD_INIT_FAILED, MYF(0));
     return true;
   }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2746,6 +2746,21 @@ static void mysqld_exit(int exit_code) {
   exit(exit_code); /* purecov: inspected */
 }
 
+static const char *get_exit_code_str(int exit_code) {
+  switch (exit_code) {
+    case MYSQLD_SUCCESS_EXIT:
+      return "MYSQLD_SUCCESS_EXIT";
+    case MYSQLD_ABORT_EXIT:
+      return "MYSQLD_ABORT_EXIT";
+    case MYSQLD_FAILURE_EXIT:
+      return "MYSQLD_FAILURE_EXIT";
+    case MYSQLD_RESTART_EXIT:
+      return "MYSQLD_RESTART_EXIT";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 /**
    GTID cleanup destroys objects and reset their pointer.
    Function is reentrant.
@@ -8801,6 +8816,8 @@ static int init_server_components() {
   if (opt_initialize) {
     if (!is_help_or_validate_option()) {
       if (dd::init(dd::enum_dd_init_type::DD_INITIALIZE)) {
+        LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+               "DD init failed: mode=DD_INITIALIZE");
         LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
         unireg_abort(1);
       }
@@ -8819,9 +8836,8 @@ static int init_server_components() {
     */
     if (!is_help_or_validate_option() &&
         dd::init(dd::enum_dd_init_type::DD_RESTART_OR_UPGRADE)) {
-      LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
-
-      if (!dd::upgrade::no_server_upgrade_required()) {
+      const bool upgrade_required = !dd::upgrade::no_server_upgrade_required();
+      if (upgrade_required) {
         dd_init_failed_during_upgrade = true;
       }
 
@@ -8829,6 +8845,22 @@ static int init_server_components() {
       dataset and attempt to restart server. */
       const int exit_code =
           clone_recovery_error ? MYSQLD_RESTART_EXIT : MYSQLD_ABORT_EXIT;
+
+      const char *upgrade_mode_str =
+          get_type(&upgrade_mode_typelib, static_cast<uint>(opt_upgrade_mode));
+
+      std::ostringstream err_msg;
+      err_msg << "DD init failed: mode=DD_RESTART_OR_UPGRADE"
+              << ", upgrade_required=" << (upgrade_required ? "yes" : "no")
+              << ", upgrade_mode=" << upgrade_mode_str
+              << ", clone_recovery_error="
+              << (clone_recovery_error ? "yes" : "no")
+              << ", exit_code=" << get_exit_code_str(exit_code) << " ("
+              << exit_code << ")";
+
+      LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.str().c_str());
+
+      LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
       unireg_abort(exit_code);
     }
   }


### PR DESCRIPTION
…rocess

https://perconadev.atlassian.net/browse/PS-8867

Improved the following error reporting during the Data Dictionary (DD) upgrade and initialization process to facilitate easier troubleshooting.

- Added detailed logging in `mysqld.cc` when `dd::init` fails, providing context such as `upgrade_required`, `upgrade_mode`, and `exit_code`.
- Added error logging in `bootstrapper.cc` if the `SYSTEM_TABLES` DD property is missing or cannot be retrieved.