### PR TITLE
PS-10989 [8.4]: Add JSONL (JSON Lines) output format for audit_log_filter

### DIFF
--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -60,7 +60,8 @@ void AuditLogReader::set_files_to_read_list(
 void AuditLogReader::reset() noexcept { m_reload_requested = true; }
 
 bool AuditLogReader::init() noexcept {
-  if (SysVars::get_format_type() != AuditLogFormatType::Json) {
+  if (SysVars::get_format_type() != AuditLogFormatType::Json &&
+      SysVars::get_format_type() != AuditLogFormatType::Jsonl) {
     // Not supported for other log formats
     return true;
   }

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -774,7 +774,8 @@ void AuditUdf::audit_log_filter_flush_udf_deinit(UDF_INIT *) {}
 bool AuditUdf::audit_log_read_udf_init(AuditUdf *udf [[maybe_unused]],
                                        UDF_INIT *initid, UDF_ARGS *udf_args,
                                        char *message) noexcept {
-  if (SysVars::get_format_type() != AuditLogFormatType::Json) {
+  if (SysVars::get_format_type() != AuditLogFormatType::Json &&
+      SysVars::get_format_type() != AuditLogFormatType::Jsonl) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,
                   "Not supported for log formats other than JSON");
     return true;
@@ -1024,7 +1025,8 @@ bool AuditUdf::audit_log_read_bookmark_udf_init(AuditUdf *udf [[maybe_unused]],
                                                 UDF_INIT *initid,
                                                 UDF_ARGS *udf_args,
                                                 char *message) noexcept {
-  if (SysVars::get_format_type() != AuditLogFormatType::Json) {
+  if (SysVars::get_format_type() != AuditLogFormatType::Json &&
+      SysVars::get_format_type() != AuditLogFormatType::Jsonl) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,
                   "Not supported for log formats other than JSON");
     return true;

--- a/components/audit_log_filter/log_record_formatter.cc
+++ b/components/audit_log_filter/log_record_formatter.cc
@@ -33,6 +33,7 @@ std::unique_ptr<LogRecordFormatterBase> get_log_record_formatter(
       funcs[static_cast<int>(AuditLogFormatType::FormatsCount)] = {
           create_helper<AuditLogFormatType::New>,
           create_helper<AuditLogFormatType::Old>,
+          create_helper<AuditLogFormatType::Json>,
           create_helper<AuditLogFormatType::Json>};
   return (*funcs[static_cast<int>(format_type)])();
 }

--- a/components/audit_log_filter/log_record_formatter/base.h
+++ b/components/audit_log_filter/log_record_formatter/base.h
@@ -62,6 +62,7 @@ enum class AuditLogFormatType {
   New,
   Old,
   Json,
+  Jsonl,
   FormatsCount  // This item must be last in the list
 };
 

--- a/components/audit_log_filter/log_record_formatter/json.cc
+++ b/components/audit_log_filter/log_record_formatter/json.cc
@@ -100,6 +100,23 @@ auto make_unix_timestamp(
              time_point.time_since_epoch())
       .count();
 }
+void format_json_header(std::ostream &out, std::string_view timestamp,
+                        const std::chrono::system_clock::time_point &time_now) {
+  out << "  {\n"
+      << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_unix_timestamp()) {
+    out << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+  }
+}
+
+void format_jsonl_header(
+    std::ostream &out, std::string_view timestamp,
+    const std::chrono::system_clock::time_point &time_now) {
+  out << R"({ "timestamp": ")" << timestamp << R"(", )";
+  if (SysVars::get_format_unix_timestamp()) {
+    out << R"("time": )" << make_unix_timestamp(time_now) << ", ";
+  }
+}
 
 }  // namespace
 
@@ -306,14 +323,7 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
   const auto &extra = audit_record.extended_info;
-
-  /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
-
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
+  const auto event_name = event_subclass_to_string(audit_record.event);
 
   const auto escaped_user = make_escaped_string(extra.user);
   const auto escaped_host = make_escaped_string(extra.host);
@@ -326,21 +336,41 @@ AuditRecordString LogRecordFormatterJson::apply(
                  ? make_escaped_string(extra.query)
                  : make_escaped_string(audit_record.extended_info.digest);
 
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "general",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
-         << R"(    "general_data": {)" << "\n"
-         << R"(      "command": ")" << esc_command << "\",\n";
-  if (!esc_query.empty()) {
-    result << R"(      "sql_command": ")" << esc_sql_command << "\",\n"
-           << R"(      "query": ")" << esc_query << "\",\n";
+  /* clang-format off */
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
+
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "general",)" << "\n"
+           << R"(    "event": ")" <<  event_name << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+           << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
+           << R"(    "general_data": {)" << "\n"
+           << R"(      "command": ")" << esc_command << "\",\n";
+    if (!esc_query.empty()) {
+      result << R"(      "sql_command": ")" << esc_sql_command << "\",\n"
+             << R"(      "query": ")" << esc_query << "\",\n";
+    }
+    result << R"(      "status": )" << audit_record.event->error_code << "\n    }"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "general", )"
+           << R"("event": ")" << event_name << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" }, )"
+           << R"("login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" }, )"
+           << R"("general_data": { "command": ")" << esc_command << R"(", )";
+    if (!esc_query.empty()) {
+      result << R"("sql_command": ")" << esc_sql_command << R"(", )"
+             << R"("query": ")" << esc_query << R"(", )";
+    }
+    result << R"("status": )" << audit_record.event->error_code << " }"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-  result << R"(      "status": )" << audit_record.event->error_code
-         << "\n    }"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -354,14 +384,9 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto time_now = std::chrono::system_clock::now();
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
-
-  /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
-
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
+  const auto event_name = event_subclass_to_string(audit_record.event);
+  const auto conn_type_name =
+      connection_type_name_to_string(audit_record.event->connection_type);
 
   const auto escaped_user = make_escaped_string(&audit_record.event->user);
   const auto escaped_host = make_escaped_string(&audit_record.event->host);
@@ -369,28 +394,46 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto escaped_external_user = make_escaped_string(&audit_record.event->external_user);
   const auto escaped_proxy_user = make_escaped_string(&audit_record.event->proxy_user);
 
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "connection",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
-         << R"(    "connection_data": {)" << "\n"
-         << R"(      "connection_type": ")"
-         << connection_type_name_to_string(audit_record.event->connection_type)
-         << "\"";
+  /* clang-format off */
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (audit_record.event->event_subclass !=
-      EVENT_TRACKING_CONNECTION_DISCONNECT) {
-    result << ",\n"
-           << R"(      "status": )" << audit_record.event->status << ",\n"
-           << R"(      "db": ")"
-           << make_escaped_string(&audit_record.event->database) << "\""
-           << extra_attrs_to_string(audit_record.extended_info, 6, 8);
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "connection",)" << "\n"
+           << R"(    "event": ")" << event_name << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+           << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
+           << R"(    "connection_data": {)" << "\n"
+           << R"(      "connection_type": ")" << conn_type_name << "\"";
+
+    if (audit_record.event->event_subclass != EVENT_TRACKING_CONNECTION_DISCONNECT) {
+      result << ",\n"
+            << R"(      "status": )" << audit_record.event->status << ",\n"
+            << R"(      "db": ")" << make_escaped_string(&audit_record.event->database) << "\""
+            << extra_attrs_to_string(audit_record.extended_info, 6, 8);
+    }
+
+    result << "\n    }\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "connection", )"
+           << R"("event": ")" << event_name << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" }, )"
+           << R"("login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" }, )"
+           << R"("connection_data": { "connection_type": ")" << conn_type_name << R"(")";
+
+    if (audit_record.event->event_subclass != EVENT_TRACKING_CONNECTION_DISCONNECT) {
+      result << R"(, "status": )" << audit_record.event->status
+             << R"(, "db": ")" << make_escaped_string(&audit_record.event->database) << R"(")"
+             << extra_attrs_to_string_jsonl(audit_record.extended_info);
+    }
+
+    result << " } }";
   }
-
-  result
-         << "\n    }\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -418,25 +461,36 @@ AuditRecordString LogRecordFormatterJson::apply(
           : make_escaped_string(audit_record.extended_info.digest);
 
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+    result << R"(    "id": )" << rec_id << ",\n"
+          << R"(    "class": "table_access",)" << "\n"
+          << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+          << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+          << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+          << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
+          << R"(    "table_access_data": {)" << "\n"
+          << R"(      "db": ")" << make_escaped_string(&audit_record.event->table_database) << "\",\n"
+          << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\",\n"
+          << R"(      "query": ")" << esc_query << "\",\n"
+          << R"(      "sql_command": ")" << escaped_sql_command << "\"\n    }"
+          << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "table_access", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" }, )"
+           << R"("login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" }, )"
+           << R"("table_access_data": { "db": ")" << make_escaped_string(&audit_record.event->table_database)
+           << R"(", "table": ")" << make_escaped_string(&audit_record.event->table_name)
+           << R"(", "query": ")" << esc_query
+           << R"(", "sql_command": ")" << escaped_sql_command << R"(" })"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "table_access",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << esc_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << esc_proxy_user << R"(" },)" << "\n"
-         << R"(    "table_access_data": {)" << "\n"
-         << R"(      "db": ")" << make_escaped_string(&audit_record.event->table_database) << "\",\n"
-         << R"(      "table": ")" << make_escaped_string(&audit_record.event->table_name) << "\",\n"
-         << R"(      "query": ")" << esc_query << "\",\n"
-         << R"(      "sql_command": ")" << escaped_sql_command << "\"\n    }"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -452,22 +506,30 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto rec_id = make_record_id();
 
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "global_variable",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "global_variable_data": {)" << "\n"
+           << R"(      "name": ")" << make_escaped_string(&audit_record.event->variable_name) << "\",\n"
+           << R"(      "value": ")" << make_escaped_string(&audit_record.event->variable_value) << "\",\n"
+           << R"(      "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << "\"}"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "global_variable", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("global_variable_data": { "name": ")" << make_escaped_string(&audit_record.event->variable_name)
+           << R"(", "value": ")" << make_escaped_string(&audit_record.event->variable_value)
+           << R"(", "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << R"(" })"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "global_variable",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "global_variable_data": {)" << "\n"
-         << R"(      "name": ")" << make_escaped_string(&audit_record.event->variable_name) << "\",\n"
-         << R"(      "value": ")" << make_escaped_string(&audit_record.event->variable_value) << "\",\n"
-         << R"(      "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << "\"}"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -483,22 +545,30 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto rec_id = make_record_id();
 
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "command",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "command_data": {)" << "\n"
+           << R"(      "name": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(      "status": )" << audit_record.event->status << ",\n"
+           << R"(      "command": ")" << make_escaped_string(&audit_record.event->command) << "\"}"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "command", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("command_data": { "name": ")" << event_subclass_to_string(audit_record.event)
+           << R"(", "status": )" << audit_record.event->status
+           << R"(, "command": ")" << make_escaped_string(&audit_record.event->command) << R"(" })"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "command",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "command_data": {)" << "\n"
-         << R"(      "name": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(      "status": )" << audit_record.event->status << ",\n"
-         << R"(      "command": ")" << make_escaped_string(&audit_record.event->command) << "\"}"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -513,26 +583,36 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
 
+  const auto esc_query =
+      audit_record.extended_info.digest.empty()
+          ? make_escaped_string(&audit_record.event->query)
+          : make_escaped_string(audit_record.extended_info.digest);
+
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "query",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "query_data": {)" << "\n"
+           << R"(      "query": ")" << esc_query << "\",\n"
+           << R"(      "status": )" << audit_record.event->status << ",\n"
+           << R"(      "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << "\"}"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "query", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("query_data": { "query": ")" << esc_query
+           << R"(", "status": )" << audit_record.event->status
+           << R"(, "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << R"(" })"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "query",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "query_data": {)" << "\n"
-         << R"(      "query": ")" << (audit_record.extended_info.digest.empty()
-                                        ? make_escaped_string(&audit_record.event->query)
-                                        : make_escaped_string(audit_record.extended_info.digest)) << "\",\n"
-         << R"(      "status": )" << audit_record.event->status << ",\n"
-         << R"(      "sql_command": ")" << make_escaped_string(audit_record.event->sql_command) << "\"}"
-         << extra_attrs_to_string(audit_record.extended_info)
-         << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -548,22 +628,28 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto rec_id = make_record_id();
 
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "stored_program",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "stored_program_data": {)" << "\n"
+           << R"(      "name": ")" << make_escaped_string(&audit_record.event->name) << "\",\n"
+           << R"(      "db": ")" << make_escaped_string(&audit_record.event->database) << "\"}"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "stored_program", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("stored_program_data": { "name": ")" << make_escaped_string(&audit_record.event->name)
+           << R"(", "db": ")" << make_escaped_string(&audit_record.event->database) << R"(" })"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "stored_program",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "stored_program_data": {)" << "\n"
-         << R"(      "name": ")" << make_escaped_string(&audit_record.event->name) << "\",\n"
-         << R"(      "db": ")" << make_escaped_string(&audit_record.event->database) << "\"}"
-         << extra_attrs_to_string(audit_record.extended_info)
-         << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -578,25 +664,31 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
 
-  /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
-
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
-
   const auto escaped_user = make_escaped_string(&audit_record.event->user);
   const auto escaped_host = make_escaped_string(&audit_record.event->host);
 
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "authentication",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "authentication_data": { "status": )" << audit_record.event->status << " }"
-         << extra_attrs_to_string(audit_record.extended_info)
-         << "\n  }";
+  /* clang-format off */
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
+
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "authentication",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+           << R"(    "authentication_data": { "status": )" << audit_record.event->status << " }"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "authentication", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" }, )"
+           << R"("authentication_data": { "status": )" << audit_record.event->status << " }"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
+  }
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -619,46 +711,70 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto escaped_proxy_user = make_escaped_string(extra.proxy_user);
 
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "message",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+           << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
+           << R"(    "message_data": {)" << "\n"
+           << R"(      "component": ")" << make_escaped_string(&audit_record.event->component) << "\",\n"
+           << R"(      "producer": ")" << make_escaped_string(&audit_record.event->producer) << "\",\n"
+           << R"(      "message": ")" << make_escaped_string(&audit_record.event->message) << "\",\n"
+           << R"(      "map": {)" << "\n";
 
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "message",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-         << R"(    "login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
-         << R"(    "message_data": {)" << "\n"
-         << R"(      "component": ")" << make_escaped_string(&audit_record.event->component) << "\",\n"
-         << R"(      "producer": ")" << make_escaped_string(&audit_record.event->producer) << "\",\n"
-         << R"(      "message": ")" << make_escaped_string(&audit_record.event->message) << "\",\n"
-         << R"(      "map": {)" << "\n";
-
-  for (size_t i = 0; i < audit_record.event->key_value_map_length; ++i) {
-    result << ((i == 0) ? "" : ",\n") << "        \""
-           << make_escaped_string(&audit_record.event->key_value_map[i].key)
-           << "\": ";
-    if (audit_record.event->key_value_map[i].value_type ==
-        EVENT_TRACKING_MESSAGE_VALUE_TYPE_STR) {
-      result << "\""
-             << make_escaped_string(
-                    &audit_record.event->key_value_map[i].value.str)
-             << "\"";
-    } else if (audit_record.event->key_value_map[i].value_type ==
-               EVENT_TRACKING_MESSAGE_VALUE_TYPE_NUM) {
-      result << audit_record.event->key_value_map[i].value.num;
-    } else {
-      result << "\"\"";
+    for (size_t i = 0; i < audit_record.event->key_value_map_length; ++i) {
+      result << ((i == 0) ? "" : ",\n") << "        \""
+            << make_escaped_string(&audit_record.event->key_value_map[i].key)
+            << "\": ";
+      if (audit_record.event->key_value_map[i].value_type == EVENT_TRACKING_MESSAGE_VALUE_TYPE_STR) {
+        result << "\""
+              << make_escaped_string(
+                      &audit_record.event->key_value_map[i].value.str)
+              << "\"";
+      } else if (audit_record.event->key_value_map[i].value_type ==
+                EVENT_TRACKING_MESSAGE_VALUE_TYPE_NUM) {
+        result << audit_record.event->key_value_map[i].value.num;
+      } else {
+        result << "\"\"";
+      }
     }
-  }
 
-  result << "\n      }\n"
-         << "    }" << extra_attrs_to_string(audit_record.extended_info)
-         << "\n  }";
+    result << "\n      }\n"
+           << "    }" << extra_attrs_to_string(audit_record.extended_info)
+           << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "message", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" }, )"
+           << R"("login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" }, )"
+           << R"("message_data": { "component": ")" << make_escaped_string(&audit_record.event->component)
+           << R"(", "producer": ")" << make_escaped_string(&audit_record.event->producer)
+           << R"(", "message": ")" << make_escaped_string(&audit_record.event->message)
+           << R"(", "map": { )";
+
+    for (size_t i = 0; i < audit_record.event->key_value_map_length; ++i) {
+      if (i != 0) result << ", ";
+      result << '"' << make_escaped_string(&audit_record.event->key_value_map[i].key) << R"(": )";
+      if (audit_record.event->key_value_map[i].value_type == EVENT_TRACKING_MESSAGE_VALUE_TYPE_STR) {
+        result << '"' << make_escaped_string(&audit_record.event->key_value_map[i].value.str) << '"';
+      } else if (audit_record.event->key_value_map[i].value_type == EVENT_TRACKING_MESSAGE_VALUE_TYPE_NUM) {
+        result << audit_record.event->key_value_map[i].value.num;
+      } else {
+        result << R"("")";
+      }
+    }
+
+    result << " } }"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
+  }
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -673,25 +789,38 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto timestamp = make_timestamp(time_now);
   const auto rec_id = make_record_id();
 
+  const auto esc_query =
+      audit_record.extended_info.digest.empty()
+          ? make_escaped_string(&audit_record.event->query)
+          : make_escaped_string(audit_record.extended_info.digest);
+  const auto flags =
+      audit_record.event->flags != nullptr ? *audit_record.event->flags : 0;
+
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "parse",)" << "\n"
+           << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
+           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+           << R"(    "parse_data": {)" << "\n"
+           << R"(      "flags": )" << flags << ",\n"
+           << R"(      "query": ")" << esc_query << "\",\n"
+           << R"(      "rewritten_query": ")" << make_escaped_string(audit_record.event->rewritten_query) << "\"}"
+           << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+  } else {
+    format_jsonl_header(result, timestamp, time_now);
+
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "parse", )"
+           << R"("event": ")" << event_subclass_to_string(audit_record.event) << R"(", )"
+           << R"("connection_id": )" << audit_record.event->connection_id << ", "
+           << R"("parse_data": { "flags": )" << flags
+           << R"(, "query": ")" << esc_query
+           << R"(", "rewritten_query": ")" << make_escaped_string(audit_record.event->rewritten_query) << R"(" })"
+           << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
   }
-
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "parse",)" << "\n"
-         << R"(    "event": ")" << event_subclass_to_string(audit_record.event) << "\",\n"
-         << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-         << R"(    "parse_data": {)" << "\n"
-         << R"(      "flags": )" << (audit_record.event->flags != nullptr ? *audit_record.event->flags : 0) << ",\n"
-         << R"(      "query": ")" << (audit_record.extended_info.digest.empty()
-                                          ? make_escaped_string(&audit_record.event->query)
-                                          : make_escaped_string(audit_record.extended_info.digest)) << "\",\n"
-         << R"(      "rewritten_query": ")" << make_escaped_string(audit_record.event->rewritten_query) << "\"}"
-         << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -718,51 +847,79 @@ AuditRecordString LogRecordFormatterJson::apply(
   const auto event_name = event_subclass_to_string(audit_record.event);
 
   /* clang-format off */
-  result << "  {\n"
-         << R"(    "timestamp": ")" << timestamp << "\",\n";
+  if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    format_json_header(result, timestamp, time_now);
 
-  if (SysVars::get_format_unix_timestamp()) {
-    result << R"(    "time": )" << make_unix_timestamp(time_now) << ",\n";
-  }
+    result << R"(    "id": )" << rec_id << ",\n"
+           << R"(    "class": "audit",)" << "\n"
+           << R"(    "event": ")" << event_name << "\"";
 
-  result << R"(    "id": )" << rec_id << ",\n"
-         << R"(    "class": "audit",)" << "\n"
-         << R"(    "event": ")" << event_name << "\"";
+    if (audit_record.event->event_subclass == INTERNAL_EVENT_TRACKING_AUDIT_AUDIT) {
+      result << ",\n"
+             << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
+             << R"(    "account": { "user": ")" << escaped_user
+             << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
+             << R"(    "login": { "user": ")" << escaped_user
+             << R"(", "os": ")" << escaped_external_user
+             << R"(", "ip": ")" << escaped_ip
+             << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
+             << R"(    "startup_data": {)" << "\n"
+             << R"(      "server_id": )" << audit_record.event->server_id << ",\n"
+             << R"(      "os_version": ")" << MACHINE_TYPE "-" SYSTEM_TYPE << "\",\n"
+             << R"(      "mysql_version": ")" << escaped_server_version << "\",\n"
+             << R"(      "args": [)" << "\n";
 
-  if (audit_record.event->event_subclass == INTERNAL_EVENT_TRACKING_AUDIT_AUDIT) {
-    result << ",\n"
-           << R"(    "connection_id": )" << audit_record.event->connection_id << ",\n"
-           << R"(    "account": { "user": ")" << escaped_user
-           << R"(", "host": ")" << escaped_host << R"(" },)" << "\n"
-           << R"(    "login": { "user": ")" << escaped_user
-           << R"(", "os": ")" << escaped_external_user
-           << R"(", "ip": ")" << escaped_ip
-           << R"(", "proxy": ")" << escaped_proxy_user << R"(" },)" << "\n"
-           << R"(    "startup_data": {)" << "\n"
-           << R"(      "server_id": )" << audit_record.event->server_id << ",\n"
-           << R"(      "os_version": ")" << MACHINE_TYPE "-" SYSTEM_TYPE << "\",\n"
-           << R"(      "mysql_version": ")" << escaped_server_version << "\",\n"
-           << R"(      "args": [)" << "\n";
-
-    for (int i = 0; i < orig_argc; ++i) {
-      if (orig_argv[i] != nullptr) {
-        result << ((i == 0) ? "" : ",\n") << R"(        ")"
-               << make_escaped_string(orig_argv[i]) << "\"";
+      for (int i = 0; i < orig_argc; ++i) {
+        if (orig_argv[i] != nullptr) {
+          result << ((i == 0) ? "" : ",\n") << R"(        ")"
+                << make_escaped_string(orig_argv[i]) << "\"";
+        }
       }
+
+      result << "\n"
+            << R"(      ])" << "\n"
+            << R"(    })";
+    } else {
+      result << ",\n"
+            << R"(    "connection_id": )" << audit_record.event->connection_id
+            << ",\n"
+            << R"(    "shutdown_data": { "server_id": )"
+            << audit_record.event->server_id << " }";
     }
 
-    result << "\n"
-           << R"(      ])" << "\n"
-           << R"(    })";
+    result << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
   } else {
-    result << ",\n"
-           << R"(    "connection_id": )" << audit_record.event->connection_id
-           << ",\n"
-           << R"(    "shutdown_data": { "server_id": )"
-           << audit_record.event->server_id << " }";
-  }
+    format_jsonl_header(result, timestamp, time_now);
 
-  result << extra_attrs_to_string(audit_record.extended_info) << "\n  }";
+    result << R"("id": )" << rec_id << ", "
+           << R"("class": "audit", )"
+           << R"("event": ")" << event_name << R"(")";
+
+    if (audit_record.event->event_subclass == INTERNAL_EVENT_TRACKING_AUDIT_AUDIT) {
+      result << R"(, "connection_id": )" << audit_record.event->connection_id << ", "
+             << R"("account": { "user": ")" << escaped_user << R"(", "host": ")" << escaped_host << R"(" }, )"
+             << R"("login": { "user": ")" << escaped_user << R"(", "os": ")" << escaped_external_user
+             << R"(", "ip": ")" << escaped_ip << R"(", "proxy": ")" << escaped_proxy_user << R"(" }, )"
+             << R"("startup_data": { "server_id": )" << audit_record.event->server_id
+             << R"(, "os_version": ")" << MACHINE_TYPE "-" SYSTEM_TYPE
+             << R"(", "mysql_version": ")" << escaped_server_version
+             << R"(", "args": [)";
+
+      for (int i = 0; i < orig_argc; ++i) {
+        if (orig_argv[i] != nullptr) {
+          if (i != 0) result << ", ";
+          result << '"' << make_escaped_string(orig_argv[i]) << '"';
+        }
+      }
+
+      result << "] }";
+    } else {
+      result << R"(, "connection_id": )" << audit_record.event->connection_id
+             << R"(, "shutdown_data": { "server_id": )" << audit_record.event->server_id << " }";
+    }
+
+    result << extra_attrs_to_string_jsonl(audit_record.extended_info) << " }";
+  }
   /* clang-format on */
 
   SysVars::update_log_bookmark(rec_id, timestamp);
@@ -858,6 +1015,27 @@ std::string LogRecordFormatterJson::extra_attrs_to_string(
     }
 
     result << "\n" << tag_padding << "}";
+  }
+
+  return result.str();
+}
+
+std::string LogRecordFormatterJson::extra_attrs_to_string_jsonl(
+    const ExtendedInfo &info) const noexcept {
+  std::stringstream result;
+
+  for (const auto &pair : info.attrs) {
+    result << R"(, ")" << pair.first << R"(": { )";
+
+    bool is_first_attr = true;
+    for (const auto &name_value : pair.second) {
+      if (!is_first_attr) result << ", ";
+      result << '"' << make_escaped_string(name_value.first) << R"(": ")"
+             << make_escaped_string(name_value.second) << '"';
+      is_first_attr = false;
+    }
+
+    result << " }";
   }
 
   return result.str();

--- a/components/audit_log_filter/log_record_formatter/json.h
+++ b/components/audit_log_filter/log_record_formatter/json.h
@@ -312,6 +312,14 @@ class LogRecordFormatter<AuditLogFormatType::Json>
   [[nodiscard]] std::string extra_attrs_to_string(
       const ExtendedInfo &info, std::size_t tag_indent,
       std::size_t value_indent) const noexcept;
+
+  /**
+   * @brief Get compact single-line JSONL representation of extra attributes.
+   * @param info Extended record info
+   * @return JSONL formatted string
+   */
+  [[nodiscard]] std::string extra_attrs_to_string_jsonl(
+      const ExtendedInfo &info) const noexcept;
 };
 
 using LogRecordFormatterJson = LogRecordFormatter<AuditLogFormatType::Json>;

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -221,16 +221,18 @@ void LogWriterFile::write(const std::string &record,
 
 void LogWriterFile::do_write(const std::string &record,
                              bool print_separator) noexcept {
+  size_t written_size = 0;
   if (print_separator && !m_is_log_empty) {
     const auto separator = get_formatter()->get_record_separator();
     m_file_writer->write(separator.c_str(), separator.length());
+    written_size += separator.length();
   }
 
   m_file_writer->write(record.c_str(), record.length());
+  written_size += record.length();
 
-  auto record_size = record.size();
-  SysVars::update_current_log_size(record_size);
-  SysVars::update_total_log_size(record_size);
+  SysVars::update_current_log_size(written_size);
+  SysVars::update_total_log_size(written_size);
 
   if (m_is_log_empty) {
     m_is_log_empty = false;

--- a/components/audit_log_filter/sys_vars.cc
+++ b/components/audit_log_filter/sys_vars.cc
@@ -250,7 +250,8 @@ TYPE_LIB audit_log_filter_event_mode_typelib = {
     "audit_log_filter_event_mode_typelib", audit_log_filter_event_mode_names,
     nullptr};
 
-const char *audit_log_filter_format_names[] = {"NEW", "OLD", "JSON", nullptr};
+const char *audit_log_filter_format_names[] = {"NEW", "OLD", "JSON", "JSONL",
+                                               nullptr};
 TYPE_LIB audit_log_filter_format_typelib = {
     array_elements(audit_log_filter_format_names) - 1,
     "audit_log_filter_format_typelib", audit_log_filter_format_names, nullptr};
@@ -407,7 +408,8 @@ void format_unix_timestamp_update_func(MYSQL_THD, SYS_VAR *, void *val_ptr,
   if (json_with_unix_timestamp != new_val) {
     *static_cast<bool *>(val_ptr) = new_val;
 
-    if (SysVars::get_format_type() == AuditLogFormatType::Json) {
+    if (SysVars::get_format_type() == AuditLogFormatType::Json ||
+        SysVars::get_format_type() == AuditLogFormatType::Jsonl) {
       get_audit_log_filter_instance()->on_audit_log_rotate_requested();
     }
   }

--- a/mysql-test/suite/component_audit_log_filter/r/connection_attributes_jsonl.result
+++ b/mysql-test/suite/component_audit_log_filter/r/connection_attributes_jsonl.result
@@ -1,0 +1,30 @@
+SELECT audit_log_filter_set_filter('log_connect', '{
+"filter": {
+"class": {
+"name": "connection",
+"event": {
+"name": "connect"
+      }
+}
+}
+}');
+audit_log_filter_set_filter('log_connect', '{
+"filter": {
+"class": {
+"name": "connection",
+"event": {
+"name": "connect"
+      }
+}
+}
+}')
+OK
+SELECT audit_log_filter_set_user('%', 'log_connect');
+audit_log_filter_set_user('%', 'log_connect')
+OK
+Tag "connection_attributes": Ok
+Tag "_client_name": Ok
+Tag "_client_version": Ok
+Tag "_platform": Ok
+#
+# Cleanup

--- a/mysql-test/suite/component_audit_log_filter/r/log_format_change.result
+++ b/mysql-test/suite/component_audit_log_filter/r/log_format_change.result
@@ -6,7 +6,9 @@ audit_log_filter_set_user('%', 'log_all')
 OK
 # restart: --audit_log_filter.format=OLD
 # restart: --audit_log_filter.format=JSON
+# restart: --audit_log_filter.format=JSONL
 # restart: --audit_log_filter.format=NEW
+File format Ok
 File format Ok
 File format Ok
 File format Ok

--- a/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_format.result
+++ b/mysql-test/suite/component_audit_log_filter/r/sys_var_audit_log_filter_format.result
@@ -15,3 +15,7 @@ OLD
 SELECT @@global.audit_log_filter.format;
 @@global.audit_log_filter.format
 JSON
+# restart: --audit-log-filter.format=JSONL
+SELECT @@global.audit_log_filter.format;
+@@global.audit_log_filter.format
+JSONL

--- a/mysql-test/suite/component_audit_log_filter/t/check_all_events_with_tag.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/check_all_events_with_tag.inc
@@ -6,7 +6,7 @@
 #
 # --let $audit_filter_log_path = path to dir containing audit filter log
 # --let $audit_filter_log_name = audit filter log file name
-# --let $audit_filter_log_format = [xml|json] audit filter log format
+# --let $audit_filter_log_format = [xml|json|jsonl] audit filter log format
 # --let $search_tag = text to search in audit event record
 # --source check_all_events_with_tag.inc
 #
@@ -17,7 +17,7 @@
 # $audit_filter_log_name
 #   Audit filter log file name.
 # $audit_filter_log_format
-#   Audit filter log format. One of: xml, json. Defaults to xml.
+#   Audit filter log format. One of: xml, json, jsonl. Defaults to xml.
 # $search_tag
 #   Text to search in audit event record. For example, set it to
 #   '<TABLE>table1</TABLE>' in order to make sure each record in the
@@ -108,6 +108,14 @@ perl;
 
         last if ($num_opening_tags > 0 && $num_closing_tags > 0 &&
                  $num_opening_tags == $num_closing_tags);
+      }
+    }
+    elsif ($format eq 'jsonl') {
+      while (my $row = <$fh>) {
+        next if ($row =~ /^\s*[\[\]]\s*$/);
+        next if ($row !~ /\{.*\}/);
+        $result = $row;
+        last;
       }
     }
     else {

--- a/mysql-test/suite/component_audit_log_filter/t/connection_attributes_jsonl-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/connection_attributes_jsonl-master.opt
@@ -1,0 +1,2 @@
+--loose-audit_log_filter.format=JSONL
+--loose-audit_log_filter.file=audit_filter.jsonl.log

--- a/mysql-test/suite/component_audit_log_filter/t/connection_attributes_jsonl.test
+++ b/mysql-test/suite/component_audit_log_filter/t/connection_attributes_jsonl.test
@@ -1,0 +1,38 @@
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+let $filter = {
+  "filter": {
+    "class": {
+      "name": "connection",
+      "event": {
+        "name": "connect"
+      }
+    }
+  }
+};
+
+eval SELECT audit_log_filter_set_filter('log_connect', '$filter');
+SELECT audit_log_filter_set_user('%', 'log_connect');
+
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+--let $audit_filter_log_name = `SELECT @@global.audit_log_filter.file`
+--let $audit_filter_log_format = jsonl
+
+--source clean_current_audit_log.inc
+--source generate_audit_events.inc
+
+--let $search_tag="connection_attributes":
+--source check_all_events_with_tag.inc
+--let $search_tag="_client_name":
+--source check_all_events_with_tag.inc
+--let $search_tag="_client_version":
+--source check_all_events_with_tag.inc
+--let $search_tag="_platform":
+--source check_all_events_with_tag.inc
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/log_format.combinations
+++ b/mysql-test/suite/component_audit_log_filter/t/log_format.combinations
@@ -14,3 +14,12 @@ loose-audit_log_filter.file=audit_filter.json.log
 loose-audit_log_filter.format=JSON
 loose-audit_log_filter.file=audit_filter.json.log
 loose-audit_log_filter.compression=GZIP
+
+[jsonl]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+
+[jsonl_gzip]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+loose-audit_log_filter.compression=GZIP

--- a/mysql-test/suite/component_audit_log_filter/t/log_format_base.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/log_format_base.inc
@@ -25,7 +25,7 @@ if (`SELECT @@global.audit_log_filter.compression = 'GZIP'`) {
 --source decompress_rotated_log.inc
 }
 
---let $audit_filter_log_format = `SELECT IF(STRCMP(SUBSTRING_INDEX(@@global.audit_log_filter.file, "xml", 1), @@global.audit_log_filter.file), "xml", "json")`
+--let $audit_filter_log_format = `SELECT CASE @@global.audit_log_filter.format WHEN 'NEW' THEN 'xml' WHEN 'OLD' THEN 'xml' WHEN 'JSON' THEN 'json' WHEN 'JSONL' THEN 'jsonl' END`
 --source validate_logs_format.inc
 
 --echo #

--- a/mysql-test/suite/component_audit_log_filter/t/log_format_change.test
+++ b/mysql-test/suite/component_audit_log_filter/t/log_format_change.test
@@ -27,10 +27,18 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 
 --source generate_audit_events.inc
 
---let $restart_parameters="restart: --audit_log_filter.format=NEW"
+--let $restart_parameters="restart: --audit_log_filter.format=JSONL"
 --source include/restart_mysqld.inc
 
 --let $new_file_name = $renamed_prefix.json.JSON
+--source rename_rotated_log.inc
+
+--source generate_audit_events.inc
+
+--let $restart_parameters="restart: --audit_log_filter.format=NEW"
+--source include/restart_mysqld.inc
+
+--let $new_file_name = $renamed_prefix.jsonl.JSONL
 --source rename_rotated_log.inc
 
 # Make sure all rotated logs have valid format
@@ -46,6 +54,10 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 --let $audit_filter_log_format = json
 --source validate_logs_format.inc
 
+--let $audit_filter_log_check_one = renamed_audit.jsonl.JSONL
+--let $audit_filter_log_format = jsonl
+--source validate_logs_format.inc
+
 --echo #
 --echo # Cleanup
 --source ../inc/audit_comp_uninstall.inc
@@ -55,3 +67,4 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 --remove_file $audit_filter_log_path$renamed_prefix.xml.NEW
 --remove_file $audit_filter_log_path$renamed_prefix.xml.OLD
 --remove_file $audit_filter_log_path$renamed_prefix.json.JSON
+--remove_file $audit_filter_log_path$renamed_prefix.jsonl.JSONL

--- a/mysql-test/suite/component_audit_log_filter/t/log_format_encrypted.combinations
+++ b/mysql-test/suite/component_audit_log_filter/t/log_format_encrypted.combinations
@@ -18,3 +18,14 @@ loose-audit_log_filter.format=JSON
 loose-audit_log_filter.file=audit_filter.json.log
 loose-audit_log_filter.compression=GZIP
 loose-audit_log_filter.encryption=AES
+
+[jsonl_aes]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+loose-audit_log_filter.encryption=AES
+
+[jsonl_gzip_aes]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+loose-audit_log_filter.compression=GZIP
+loose-audit_log_filter.encryption=AES

--- a/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_format.test
+++ b/mysql-test/suite/component_audit_log_filter/t/sys_var_audit_log_filter_format.test
@@ -18,5 +18,9 @@ SELECT @@global.audit_log_filter.format;
 --source include/restart_mysqld.inc
 SELECT @@global.audit_log_filter.format;
 
+--let $restart_parameters="restart: --audit-log-filter.format=JSONL"
+--source include/restart_mysqld.inc
+SELECT @@global.audit_log_filter.format;
+
 --source ../inc/audit_comp_uninstall.inc
 --source ../inc/audit_tables_cleanup.inc

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_multiple_files.combinations
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_multiple_files.combinations
@@ -6,3 +6,12 @@ loose-audit_log_filter.file=audit_filter.json.log
 loose-audit_log_filter.format=JSON
 loose-audit_log_filter.file=audit_filter.json.log
 loose-audit_log_filter.compression=GZIP
+
+[jsonl]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+
+[jsonl_gzip]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+loose-audit_log_filter.compression=GZIP

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_multiple_files_encrypted.combinations
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_multiple_files_encrypted.combinations
@@ -8,3 +8,14 @@ loose-audit_log_filter.format=JSON
 loose-audit_log_filter.file=audit_filter.json.log
 loose-audit_log_filter.encryption=AES
 loose-audit_log_filter.compression=GZIP
+
+[jsonl_aes]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+loose-audit_log_filter.encryption=AES
+
+[jsonl_aes_gzip]
+loose-audit_log_filter.format=JSONL
+loose-audit_log_filter.file=audit_filter.jsonl.log
+loose-audit_log_filter.encryption=AES
+loose-audit_log_filter.compression=GZIP

--- a/mysql-test/suite/component_audit_log_filter/t/validate_logs_format.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/validate_logs_format.inc
@@ -17,7 +17,7 @@
 # $audit_filter_log_name
 #   The audit log file base name.
 # $audit_filter_log_format
-#   The audit logs format, 'xml' or 'json'.
+#   The audit logs format, 'xml', 'json' or 'jsonl'.
 # $audit_filter_log_check_one
 #   Check only this one log file, if provided.
 
@@ -37,7 +37,7 @@ perl;
   my $format_name = $ENV{'audit_filter_log_format'} or die "Missing audit_filter_log_format\n";
   my $check_one_log_name = $ENV{'audit_filter_log_check_one'};
 
-  die "Bad log format: $format_name\n" if ($format_name !~ m/^xml$|^json$/);
+  die "Bad log format: $format_name\n" if ($format_name !~ m/^xml$|^json$|^jsonl$/);
 
   if ($check_one_log_name) {
     if ($format_name eq "xml") {


### PR DESCRIPTION
Extend the JSON formatter to emit compact, single-line records when the new JSONL format is selected. Each apply() overload now branches on the format type: indented multi-line JSON vs flat single-line JSONL. Shared format_json_header/format_jsonl_header helpers deduplicate the record opening logic, and a new extra_attrs_to_string_jsonl() handles compact attribute serialization.

Wire the Jsonl enum value through sys_vars (format typelib, unix-timestamp rotation trigger), the formatter factory, audit_log_reader, and audit_log_read/audit_log_read_bookmark UDFs so that JSONL is accepted everywhere JSON already is.

Add MTR coverage: JSONL combinations for log_format, log_format_encrypted, and udf_audit_log_read_multiple_files tests; a dedicated connection_attributes_jsonl test; JSONL steps in log_format_change and sys_var_audit_log_filter_format; and JSONL-aware parsing in check_all_events_with_tag.inc and validate_logs_format.inc.