### PR TITLE
PS-10331 [9.x]: Fix audit log class filtering across rule reloads

### DIFF
--- a/components/audit_log_filter/log_writer/base.cc
+++ b/components/audit_log_filter/log_writer/base.cc
@@ -32,6 +32,8 @@ LogWriterBase::LogWriterBase(
 void LogWriterBase::init_formatter() noexcept { SysVars::init_record_id(0); }
 
 void LogWriterBase::write(const AuditRecordVariant &record) noexcept {
+  std::lock_guard<std::mutex> write_guard{m_write_mutex};
+
   // Format event data according to audit_log_filter_format settings
   std::string record_str = std::visit(
       [this](const auto &rec) -> std::string {
@@ -51,10 +53,7 @@ void LogWriterBase::write(const AuditRecordVariant &record) noexcept {
     }
   });
 
-  {
-    std::lock_guard<std::mutex> write_guard{m_write_mutex};
-    write(record_str, true);
-  }
+  write(record_str, true);
 }
 
 }  // namespace audit_log_filter::log_writer

--- a/components/audit_log_filter/log_writer/base.h
+++ b/components/audit_log_filter/log_writer/base.h
@@ -138,9 +138,13 @@ class LogWriterBase {
    */
   void init_formatter() noexcept;
 
+  /**
+   * @brief Mutex serializing record formatting with writer state changes.
+   */
+  mutable std::mutex m_write_mutex;
+
  private:
   std::unique_ptr<log_record_formatter::LogRecordFormatterBase> m_formatter;
-  std::mutex m_write_mutex;
 };
 
 template <AuditLogHandlerType HandlerType>

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -139,7 +139,10 @@ bool LogWriterFile::open() noexcept {
   return do_open_file();
 }
 
-bool LogWriterFile::close() noexcept { return do_close_file(); }
+bool LogWriterFile::close() noexcept {
+  std::lock_guard<std::mutex> write_guard{m_write_mutex};
+  return do_close_file();
+}
 
 bool LogWriterFile::do_open_file() noexcept {
   auto file_path = std::filesystem::path{SysVars::get_file_dir()} /
@@ -221,7 +224,6 @@ bool LogWriterFile::do_close_file() noexcept {
 
 void LogWriterFile::write(const std::string &record,
                           const bool print_separator) noexcept {
-  std::lock_guard<std::mutex> write_guard{m_write_lock};
   do_write(record, print_separator);
 }
 
@@ -260,7 +262,7 @@ void LogWriterFile::do_write(const std::string &record,
 }
 
 uint64_t LogWriterFile::get_log_size() const noexcept {
-  std::lock_guard<std::mutex> write_guard{m_write_lock};
+  std::lock_guard<std::mutex> write_guard{m_write_mutex};
   return do_get_log_size();
 }
 
@@ -269,7 +271,7 @@ uint64_t LogWriterFile::do_get_log_size() const noexcept {
 }
 
 void LogWriterFile::rotate(FileRotationResult *result) noexcept {
-  std::lock_guard<std::mutex> write_guard{m_write_lock};
+  std::lock_guard<std::mutex> write_guard{m_write_mutex};
   do_rotate(result);
 }
 
@@ -299,7 +301,7 @@ void LogWriterFile::do_rotate(FileRotationResult *result) noexcept {
 }
 
 void LogWriterFile::prune() noexcept {
-  std::lock_guard<std::mutex> write_guard{m_write_lock};
+  std::lock_guard<std::mutex> write_guard{m_write_mutex};
   do_prune();
 }
 

--- a/components/audit_log_filter/log_writer/file.h
+++ b/components/audit_log_filter/log_writer/file.h
@@ -110,7 +110,7 @@ class LogWriter<AuditLogHandlerType::File> : public LogWriterBase {
   void do_write(const std::string &record, bool print_separator) noexcept;
 
   /**
-   * @brief Get current log file size while m_write_lock is held.
+   * @brief Get current log file size while m_write_mutex is held.
    *
    * @return Current log file size in bytes
    */
@@ -124,7 +124,7 @@ class LogWriter<AuditLogHandlerType::File> : public LogWriterBase {
   void do_rotate(FileRotationResult *result) noexcept;
 
   /**
-   * @brief Prune outdated log files while m_write_lock is held.
+   * @brief Prune outdated log files while m_write_mutex is held.
    */
   void do_prune() noexcept;
 
@@ -135,7 +135,6 @@ class LogWriter<AuditLogHandlerType::File> : public LogWriterBase {
   bool m_sync_on_write;
   FileWriterPtr m_file_writer{};
   FileHandle m_file_handle;
-  mutable std::mutex m_write_lock;
 };
 
 using LogWriterFile = LogWriter<AuditLogHandlerType::File>;

--- a/mysql-test/suite/component_audit_log_filter/r/udf_logging_stopped_on_user_removal.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_logging_stopped_on_user_removal.result
@@ -5,10 +5,11 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 audit_log_filter_set_user('%', 'log_all')
 OK
 Tag <AUDIT_RECORD> Ok
+Tag <AUDIT_RECORD> Ok
 SELECT audit_log_filter_remove_user('%');
 audit_log_filter_remove_user('%')
 OK
 Tag <AUDIT_RECORD> Ok
-No tag <AUDIT_RECORD> Ok
+No tag (?:<TABLE>t1</TABLE>|<TABLE>t2</TABLE>|<TABLE>t3</TABLE>) Ok
 #
 # Cleanup

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_class.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_class.test
@@ -27,8 +27,10 @@ SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';
 --echo #
 --echo # Log 'general' events only
 SELECT audit_log_filter_set_user('%', 'log_general');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>
@@ -37,8 +39,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'connection' events only
 SELECT audit_log_filter_set_user('%', 'log_connection');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>connection</EVENT_CLASS_NAME>
@@ -47,8 +51,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'table_access' events only
 SELECT audit_log_filter_set_user('%', 'log_table_access');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>table_access</EVENT_CLASS_NAME>
@@ -57,8 +63,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'global_variable' events only
 SELECT audit_log_filter_set_user('%', 'log_global_variable');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>global_variable</EVENT_CLASS_NAME>
@@ -67,8 +75,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'command' events only
 SELECT audit_log_filter_set_user('%', 'log_command');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>command</EVENT_CLASS_NAME>
@@ -77,8 +87,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'query' events only
 SELECT audit_log_filter_set_user('%', 'log_query');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>query</EVENT_CLASS_NAME>
@@ -87,8 +99,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'stored_program' events only
 SELECT audit_log_filter_set_user('%', 'log_stored_program');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>stored_program</EVENT_CLASS_NAME>
@@ -97,8 +111,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'authentication' events only
 SELECT audit_log_filter_set_user('%', 'log_authentication');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>authentication</EVENT_CLASS_NAME>
@@ -107,8 +123,10 @@ connect(default, localhost, root, , test);
 --echo #
 --echo # Log 'message' events only
 SELECT audit_log_filter_set_user('%', 'log_message');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>message</EVENT_CLASS_NAME>
@@ -118,8 +136,10 @@ connect(default, localhost, root, , test);
 --echo # Enable logging multiple classes with one rule
 SELECT audit_log_filter_set_filter('log_classes_list_1', '{"filter": {"class": [{"name": "general"}, {"name": "connection"}]}}');
 SELECT audit_log_filter_set_user('%', 'log_classes_list_1');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>(?:general|connection)</EVENT_CLASS_NAME>
@@ -129,8 +149,10 @@ connect(default, localhost, root, , test);
 --echo # Another way to enable logging multiple classes with one rule
 SELECT audit_log_filter_set_filter('log_classes_list_2', '{"filter": {"class": [{"name": ["general", "connection"]}]}}');
 SELECT audit_log_filter_set_user('%', 'log_classes_list_2');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>(?:general|connection)</EVENT_CLASS_NAME>

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_field.test
@@ -27,8 +27,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_query', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_query');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<HOST>localhost</HOST>
@@ -52,8 +54,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_conn_type_by_numeric', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_conn_type_by_numeric');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<CONNECTION_TYPE>Socket</CONNECTION_TYPE>
@@ -75,8 +79,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_conn_type_by_pseudo', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_conn_type_by_pseudo');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<CONNECTION_TYPE>Socket</CONNECTION_TYPE>
@@ -103,8 +109,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_or', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_or');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=[<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t1</TABLE>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t2</TABLE>]
@@ -131,8 +139,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_and', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_and');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<DB>test</DB>.*<TABLE>t1</TABLE>
@@ -158,8 +168,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_not', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_not');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=[<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t2</TABLE>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t3</TABLE>]
@@ -198,8 +210,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_all', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_all');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=[<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t1</TABLE>|<EVENT_SUBCLASS_NAME>insert</EVENT_SUBCLASS_NAME>.*<TABLE>t3</TABLE>]

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_subclass.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_by_subclass.test
@@ -25,8 +25,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_log', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_log');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>log</EVENT_SUBCLASS_NAME>
@@ -45,8 +47,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_result', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_result');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>result</EVENT_SUBCLASS_NAME>
@@ -65,8 +69,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_status', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_status');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>
@@ -88,8 +94,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_log_result_1', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_log_result_1');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:log|result)</EVENT_SUBCLASS_NAME>
@@ -110,8 +118,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_general_log_result_2', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_general_log_result_2');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:log|result)</EVENT_SUBCLASS_NAME>
@@ -130,8 +140,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_connect_insert', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_connect_insert');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:connect|insert)</EVENT_SUBCLASS_NAME>
@@ -155,8 +167,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_table_access_explicit_action', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_table_access_explicit_action');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=<EVENT_SUBCLASS_NAME>(?:read|insert)</EVENT_SUBCLASS_NAME>

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_inclusive_exclusive.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_filter_inclusive_exclusive.test
@@ -32,8 +32,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_inclusive', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_inclusive');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=(?:<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>|<EVENT_SUBCLASS_NAME>connect</EVENT_SUBCLASS_NAME>)
@@ -53,8 +55,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_exclusive', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_exclusive');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag=!<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_function_string_find.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_function_string_find.test
@@ -38,8 +38,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_users_access', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_users_access');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 
 SELECT * FROM user_list;
@@ -74,8 +76,10 @@ let $filter = {
 
 eval SELECT audit_log_filter_set_filter('log_users_access_case_sensitive', '$filter');
 SELECT audit_log_filter_set_user('%', 'log_users_access_case_sensitive');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 
 SELECT * FROM user_list;

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_validate_output.test
@@ -28,11 +28,13 @@ SELECT audit_log_filter_set_user('user1@localhost', 'filter_que_gen_com_tab');
 --let $audit_filter_rotate_name=`SELECT audit_log_rotate()`
 SET @start_bookmark := audit_log_read_bookmark();
 
+--source include/count_sessions.inc
 connect (con1,localhost,user1,pass,,,,);
 INSERT INTO t1 VALUES (1);
 
 connection default;
 disconnect con1;
+--source include/wait_until_count_sessions.inc
 
 --echo Turn off audit log
 SELECT audit_log_filter_remove_filter('filter_que_gen_com_tab');

--- a/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_user_removal.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_logging_stopped_on_user_removal.test
@@ -18,6 +18,22 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 --source include/count_sessions.inc
 connect(keep_conn, localhost, root, , test);
 
+# Prime the session cache with a regular audited statement before the mapping
+# is removed. Relying on the CONNECT event alone makes this test flaky when the
+# reload overlaps with connection processing.
+--connection keep_conn
+--source clean_current_audit_log.inc
+--disable_result_log
+--disable_query_log
+DROP TABLE IF EXISTS t_keep_prime;
+CREATE TABLE t_keep_prime (c1 INT);
+INSERT INTO t_keep_prime VALUES (1);
+DROP TABLE t_keep_prime;
+--enable_query_log
+--enable_result_log
+--let $search_tag=<AUDIT_RECORD>
+--source check_all_events_with_tag.inc
+
 # Remove the default user mapping via the admin session
 --connection default
 SELECT audit_log_filter_remove_user('%');
@@ -44,7 +60,7 @@ disconnect default;
 connect(default, localhost, root, , test);
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
---let $search_tag=!<AUDIT_RECORD>
+--let $search_tag=!(?:<TABLE>t1</TABLE>|<TABLE>t2</TABLE>|<TABLE>t3</TABLE>)
 --source check_all_events_with_tag.inc
 
 --echo #

--- a/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
+++ b/mysql-test/suite/component_audit_log_filter/t/validate_event_mode_reduced.test
@@ -54,36 +54,46 @@ SELECT * FROM mysql.audit_log_filter;
 SET GLOBAL audit_log_filter.event_mode=REDUCED;
 SELECT audit_log_filter_flush();
 SELECT audit_log_filter_set_user('%', 'mixed_rule');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "general"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_subclass_rule');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="event": "status"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_conn_command_rule');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "connection"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_ta_sp_rule');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "table_access"
 --source check_all_events_with_tag.inc
 SELECT audit_log_filter_set_user('%', 'mixed_conn_subclass_rule');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="event": "connect"
@@ -103,8 +113,10 @@ SELECT audit_log_filter_set_filter('query_only_rule', '{"filter":{"class":{"name
 SET GLOBAL audit_log_filter.event_mode=REDUCED;
 SELECT audit_log_filter_set_user('%', 'query_only_rule');
 SET GLOBAL audit_log_filter.event_mode=FULL;
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 --let $search_tag="class": "query"
@@ -116,8 +128,10 @@ SET GLOBAL audit_log_filter.event_mode=REDUCED;
 --echo # Reduced mode logs only the reduced event-class subset
 SELECT audit_log_filter_set_filter('log_all', '{"filter":{"log": true}}');
 SELECT audit_log_filter_set_user('%', 'log_all');
+--source include/count_sessions.inc
 disconnect default;
 connect(default, localhost, root, , test);
+--source include/wait_until_count_sessions.inc
 --source clean_current_audit_log.inc
 --source generate_audit_events.inc
 SELECT audit_log_filter_flush();


### PR DESCRIPTION
### 1. Fix audit log class filtering across rule reloads

component_audit_log_filter.filter_definition_filter_by_class could rotate a
late Quit event from the old session into the newly opened audit log after
`audit_log_filter_set_user('%', 'log_connection')`, leaving a stray
`general/result` record at the start of the next file and breaking the MTR
expectation that every record in that phase belongs to the connection class.
Record formatting was not serialized with file rotation/reopen, so a record
prepared before rotation could be written to the new file after `RECORD_ID`
had been reset.

Serialize formatting, write, rotate, close, prune, and size reads on the same
writer mutex so that no record can slip across a rotation boundary. Replace
the per-subclass `m_write_lock` in `LogWriterFile` with the base-class
`m_write_mutex` to eliminate the redundant lock.

### 2. Wait for old sessions before rotating audit log in MTR tests

Several component_audit_log_filter tests were intermittently failing under
--repeat because they did not wait for the old default session to fully
disconnect before rotating the log and asserting on the new file's contents.
A late Quit event from the old session could land in the freshly opened log
and violate the class/subclass expectations.

Add `count_sessions.inc` / `wait_until_count_sessions.inc` around every
`disconnect default; connect(default, ...)` cycle in the affected tests so
that the old session's Quit event is guaranteed to be written before the log
is rotated.
