### PR TITLE
PS-9773 [9.x]: Fix audit_log_read() always returning null

### DIFF
--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -33,6 +33,72 @@
 #include <string>
 #include <vector>
 
+namespace {
+
+/**
+  SAX parser handler for audit JSON logs.
+  Saves "timestamp" field from the first encountered event, and stops parsing.
+*/
+class AuditJsonFirstTimestampHandler
+    : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
+                                          AuditJsonFirstTimestampHandler> {
+ public:
+  bool Default() {
+    m_expect_timestamp = false;
+
+    // We want to make sure the first parsed token is "open-array".
+    // If we encounter something else first, we stop parsing.
+    return m_array_open;
+  }
+
+  bool String(const char *str, rapidjson::SizeType length,
+              [[maybe_unused]] bool copy) {
+    if (m_expect_timestamp) {
+      timestamp.assign(str, length);
+      return false;
+    }
+    return Default();
+  }
+
+  bool StartObject() {
+    ++m_depth;
+    return Default();
+  }
+
+  bool Key(const char *str, rapidjson::SizeType length,
+           [[maybe_unused]] bool copy) {
+    // Depth 2 means we're in "[ { ...".
+    m_expect_timestamp =
+        m_depth == 2 && std::string_view(str, length) == "timestamp";
+    return true;
+  }
+
+  bool EndObject([[maybe_unused]] rapidjson::SizeType memberCount) {
+    --m_depth;
+    return Default();
+  }
+
+  bool StartArray() {
+    m_array_open = true;
+    ++m_depth;
+    return Default();
+  }
+
+  bool EndArray([[maybe_unused]] rapidjson::SizeType elementCount) {
+    --m_depth;
+    return Default();
+  }
+
+  std::string timestamp;
+
+ private:
+  int m_depth = 0;
+  bool m_expect_timestamp = false;
+  bool m_array_open = false;
+};
+
+}  // namespace
+
 namespace audit_log_filter {
 
 void AuditLogReader::set_files_to_read_list(
@@ -41,12 +107,14 @@ void AuditLogReader::set_files_to_read_list(
     return;
   }
 
-  std::vector<std::string> tp_list;
+  for (auto item = m_timestamp_to_file_map.cbegin();
+       item != m_timestamp_to_file_map.cend(); ++item) {
+    auto next_item = std::next(item);
+    bool is_last_item = next_item == m_timestamp_to_file_map.cend();
 
-  for (const auto &item : m_timestamp_to_file_map) {
-    if (item.second->first_timestamp >=
-        reader_context->next_event_bookmark.timestamp) {
-      auto *file_info = item.second.get();
+    if (is_last_item || reader_context->next_event_bookmark.timestamp <=
+                            next_item->second->first_timestamp) {
+      auto *file_info = item->second.get();
 
       if (file_info->is_encrypted && file_info->encryption_options == nullptr) {
         continue;
@@ -149,15 +217,8 @@ bool AuditLogReader::init() noexcept {
   }
 
   for (const auto &log_name : new_files) {
-    bool is_current_log =
-        log_name.find(log_current_file_name) != std::string::npos;
     bool is_compressed = log_name.find(".gz") != std::string::npos;
     bool is_encrypted = log_name.find(".enc") != std::string::npos;
-
-    if (is_current_log && is_encrypted) {
-      // TODO: Improve handling of currently opened encrypted log
-      continue;
-    }
 
     auto encryption_options_id =
         audit_keyring::get_options_id_for_file_name(log_name);
@@ -183,23 +244,15 @@ bool AuditLogReader::init() noexcept {
     auto json_reader_guard =
         create_scope_guard([&] { json_reader_stream->close(); });
 
-    rapidjson::Document json_doc;
-    json_doc.ParseStream(*json_reader_stream);
+    rapidjson::Reader json_reader;
+    AuditJsonFirstTimestampHandler first_timestamp_handler;
+    json_reader.Parse(*json_reader_stream, first_timestamp_handler);
 
-    if (json_doc.HasParseError() || json_doc.Empty() || !json_doc.IsArray() ||
-        json_doc.GetArray().Empty()) {
+    if (first_timestamp_handler.timestamp.empty()) {
       continue;
     }
 
-    auto *first_event = json_doc.GetArray().Begin();
-
-    if (!first_event->IsObject() || !first_event->HasMember("timestamp") ||
-        !first_event->GetObject()["timestamp"].IsString()) {
-      continue;
-    }
-
-    file_info->first_timestamp =
-        first_event->GetObject()["timestamp"].GetString();
+    file_info->first_timestamp = first_timestamp_handler.timestamp;
 
     try {
       auto ts = LogFileTimestamp(log_name);
@@ -277,6 +330,13 @@ bool AuditLogReader::read(AuditLogReaderContext *reader_context) noexcept {
       reader_context->reader->IterativeParseNext<rapidjson::kParseDefaultFlags>(
           *reader_context->audit_json_read_stream,
           *reader_context->audit_json_handler);
+
+      // We don't want reading to fail because of EOF during parsing.
+      // This would break reading of currently open log file, as its
+      // top-level array isn't closed yet.
+      if (reader_context->audit_json_read_stream->check_eof_reached()) {
+        break;
+      }
 
       if (reader_context->reader->HasParseError()) {
         return false;

--- a/components/audit_log_filter/audit_log_reader.h
+++ b/components/audit_log_filter/audit_log_reader.h
@@ -34,10 +34,17 @@
 namespace audit_log_filter {
 
 struct AuditLogReaderArgs {
+  enum class Command {
+    ContinueRead,
+    ReadFromBookmark,
+    ReadFromTimestamp,
+    CloseSeq
+  };
+
+  Command command{Command::ContinueRead};
   std::string timestamp{};
   uint64_t id{0};
   uint64_t max_array_length{0};
-  bool close_read_sequence{false};
 };
 
 struct AuditLogReaderContext {

--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -895,8 +895,8 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
           return result;
         }
 
+        reader_args->command = AuditLogReaderArgs::Command::ReadFromTimestamp;
         reader_args->timestamp = json_doc["start"]["timestamp"].GetString();
-        reader_args->id = 0;
       } else if (has_timestamp_tag) {
         if (!json_doc["timestamp"].IsString() || !json_doc["id"].IsUint64()) {
           my_error(ER_UDF_ERROR, MYF(0), "audit_log_read",
@@ -905,6 +905,7 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
           return result;
         }
 
+        reader_args->command = AuditLogReaderArgs::Command::ReadFromBookmark;
         reader_args->timestamp = json_doc["timestamp"].GetString();
         reader_args->id = json_doc["id"].GetUint();
       }
@@ -929,7 +930,7 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
         }
       }
     } else if (json_doc.IsNull()) {
-      reader_args->close_read_sequence = true;
+      reader_args->command = AuditLogReaderArgs::Command::CloseSeq;
     } else {
       my_error(ER_UDF_ERROR, MYF(0), "audit_log_read", "Wrong argument format");
       *error = 1;
@@ -942,7 +943,7 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
   }
 
   if (udf_args->arg_count == 1) {
-    if (reader_args->close_read_sequence) {
+    if (reader_args->command == AuditLogReaderArgs::Command::CloseSeq) {
       if (reader_context != nullptr) {
         log_reader->close_reader_session(reader_context);
         SysVars::set_log_reader_context(thd, nullptr);

--- a/components/audit_log_filter/json_reader/audit_json_handler.cc
+++ b/components/audit_log_filter/json_reader/audit_json_handler.cc
@@ -256,11 +256,19 @@ void AuditJsonHandler::clear_current_event() {
 
 bool AuditJsonHandler::check_reading_start_reached() {
   if (!m_reading_start_reached) {
-    m_reading_start_reached = m_reader_context->next_event_bookmark.timestamp ==
-                                  m_current_event_bookmark.timestamp &&
-                              (m_reader_context->next_event_bookmark.id == 0 ||
-                               m_reader_context->next_event_bookmark.id ==
-                                   m_current_event_bookmark.id);
+    switch (m_reader_context->batch_reader_args->command) {
+      case AuditLogReaderArgs::Command::ReadFromBookmark:
+        m_reading_start_reached =
+            m_reader_context->next_event_bookmark == m_current_event_bookmark;
+        break;
+      case AuditLogReaderArgs::Command::ReadFromTimestamp:
+        m_reading_start_reached =
+            m_reader_context->next_event_bookmark.timestamp <=
+            m_current_event_bookmark.timestamp;
+        break;
+      default:
+        assert(false);
+    }
   }
 
   return m_reading_start_reached;

--- a/components/audit_log_filter/json_reader/file_reader_decompressing.cc
+++ b/components/audit_log_filter/json_reader/file_reader_decompressing.cc
@@ -25,11 +25,7 @@ FileReaderDecompressing::FileReaderDecompressing(
     std::unique_ptr<FileReaderBase> file_reader)
     : FileReaderDecoratorBase(std::move(file_reader)) {}
 
-FileReaderDecompressing::~FileReaderDecompressing() {
-  if (is_opened) {
-    close();
-  }
-}
+FileReaderDecompressing::~FileReaderDecompressing() { close(); }
 
 bool FileReaderDecompressing::init() noexcept {
   return FileReaderDecoratorBase::init();
@@ -66,9 +62,11 @@ bool FileReaderDecompressing::open(FileInfo *file_info) noexcept {
 }
 
 void FileReaderDecompressing::close() noexcept {
-  is_opened = false;
-  inflateEnd(&m_strm);
-  FileReaderDecoratorBase::close();
+  if (is_opened) {
+    is_opened = false;
+    inflateEnd(&m_strm);
+    FileReaderDecoratorBase::close();
+  }
 }
 
 ReadStatus FileReaderDecompressing::read(unsigned char *out_buffer,
@@ -95,7 +93,7 @@ ReadStatus FileReaderDecompressing::read(unsigned char *out_buffer,
 
   *read_size = out_buffer_size - m_strm.avail_out;
 
-  if (ret == Z_STREAM_END) {
+  if (ret == Z_STREAM_END || status == ReadStatus::Eof) {
     status = ReadStatus::Eof;
   } else if (ret != Z_OK) {
     status = ReadStatus::Error;

--- a/components/audit_log_filter/json_reader/file_reader_decrypting.cc
+++ b/components/audit_log_filter/json_reader/file_reader_decrypting.cc
@@ -14,6 +14,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
 #include "components/audit_log_filter/json_reader/file_reader_decrypting.h"
+#include "components/audit_log_filter/log_writer/file_name.h"
 
 #include "components/audit_log_filter/audit_encryption.h"
 #include "components/audit_log_filter/audit_error_log.h"
@@ -160,6 +161,8 @@ bool FileReaderDecrypting::open(FileInfo *file_info) noexcept {
     return false;
   }
 
+  m_is_rotated = log_writer::FileName::from_path(file_info->name).is_rotated();
+
   return true;
 }
 
@@ -200,7 +203,7 @@ ReadStatus FileReaderDecrypting::read(unsigned char *out_buffer,
 
   *read_size = decrypted_size;
 
-  if (status == ReadStatus::Eof) {
+  if (status == ReadStatus::Eof && m_is_rotated) {
     int final_size = 0;
 
     if (EVP_DecryptFinal(m_ctx, out_buffer + decrypted_size, &final_size) !=

--- a/components/audit_log_filter/json_reader/file_reader_decrypting.h
+++ b/components/audit_log_filter/json_reader/file_reader_decrypting.h
@@ -43,6 +43,7 @@ class FileReaderDecrypting final : public FileReaderDecoratorBase {
   std::unique_ptr<unsigned char[]> m_iv;
   std::unique_ptr<unsigned char[]> m_in_buff;
   const size_t m_in_buf_size;
+  bool m_is_rotated = false;
 };
 
 }  // namespace audit_log_filter::json_reader

--- a/components/audit_log_filter/log_writer/file.cc
+++ b/components/audit_log_filter/log_writer/file.cc
@@ -227,6 +227,7 @@ void LogWriterFile::write(const std::string &record,
 
 void LogWriterFile::do_write(const std::string &record,
                              bool print_separator) noexcept {
+  size_t written_size = 0;
   std::string payload;
   if (print_separator && !m_is_log_empty) {
     const auto separator = get_formatter()->get_record_separator();
@@ -238,9 +239,12 @@ void LogWriterFile::do_write(const std::string &record,
   payload.append(record);
 
   m_file_writer->write(payload.c_str(), payload.length());
+  written_size += payload.length();
 
-  SysVars::update_current_log_size(payload.length());
-  SysVars::update_total_log_size(payload.length());
+  written_size += write_padding();
+
+  SysVars::update_current_log_size(written_size);
+  SysVars::update_total_log_size(written_size);
 
   if (m_is_log_empty) {
     m_is_log_empty = false;
@@ -257,6 +261,54 @@ void LogWriterFile::do_write(const std::string &record,
     do_rotate(nullptr);
     do_prune();
   }
+}
+
+size_t LogWriterFile::write_padding() {
+  // This function writes whitespace padding after each logged event when
+  // log file encryption is enabled.
+  // This is necessary in order to make newly logged events be immediately
+  // available for reading by AuditLogReader. Padding pushes internal buffer of
+  // encryption context over the threshold after which EVP_EncryptUpdate is
+  // guaranteed to produce complete encrypted log event.
+
+  size_t written_size = 0;
+
+  // We add padding only for formats supported by audit log reader.
+  // Currently, it's only JSON and JSONL.
+  if (SysVars::get_format_type() != AuditLogFormatType::Json &&
+      SysVars::get_format_type() != AuditLogFormatType::Jsonl) {
+    return written_size;
+  }
+
+  // Padding is only needed for logs encrypted with certain block ciphers.
+  if (SysVars::get_encryption_type() != AuditLogEncryptionType::Aes) {
+    return written_size;
+  }
+
+  auto write_spaces = [&](size_t count) {
+    static constexpr char padding[] = "                                ";
+    m_file_writer->write(padding, count);
+    written_size += count;
+  };
+
+  switch (SysVars::get_compression_type()) {
+    case AuditLogCompressionType::None:
+      // Write two AES 256 CBC blocks worth of spaces.
+      write_spaces(2 * 16);
+      break;
+    case AuditLogCompressionType::Gzip:
+      // Writes need to be done in separate chunks, each producing its own
+      // gzip block. Otherwise, all spaces would get compressed.
+      // Five such chunks are enough to produce needed padding.
+      for (int chunk = 0; chunk < 5; ++chunk) {
+        write_spaces(2);
+      }
+      break;
+    default:
+      assert(false);
+  }
+
+  return written_size;
 }
 
 uint64_t LogWriterFile::get_log_size() const noexcept {

--- a/components/audit_log_filter/log_writer/file.h
+++ b/components/audit_log_filter/log_writer/file.h
@@ -117,6 +117,13 @@ class LogWriter<AuditLogHandlerType::File> : public LogWriterBase {
   [[nodiscard]] uint64_t do_get_log_size() const noexcept;
 
   /**
+   * @brief Write whitespace padding.
+   *
+   * @return Number of written bytes
+   */
+  size_t write_padding();
+
+  /**
    * @brief Implement actual file rotation logic.
    *
    * @param result File rotation result

--- a/components/audit_log_filter/log_writer/file_writer_compressing.cc
+++ b/components/audit_log_filter/log_writer/file_writer_compressing.cc
@@ -53,7 +53,7 @@ void FileWriterCompressing::write(const char *record, size_t size) noexcept {
   m_strm.avail_in = size;
   m_strm.next_in =
       reinterpret_cast<unsigned char *>(const_cast<char *>(record));
-  m_flush = Z_NO_FLUSH;
+  m_flush = Z_SYNC_FLUSH;
 
   do_deflate();
 }

--- a/components/audit_log_filter/sys_vars.h
+++ b/components/audit_log_filter/sys_vars.h
@@ -50,6 +50,10 @@ enum class AuditLogEventModeType { Reduced = 0, Full = 1 };
 struct LogBookmark {
   uint64_t id;
   std::string timestamp;
+
+  friend bool operator==(const LogBookmark &lhs, const LogBookmark &rhs) {
+    return lhs.id == rhs.id && lhs.timestamp == rhs.timestamp;
+  }
 };
 
 class SysVars {

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_basic.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_basic.result
@@ -26,15 +26,17 @@ SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10 10 00"}}');
 ERROR HY000: audit_log_read UDF failed; Wrong JSON argument, bad timestamp format
 SELECT audit_log_read('{"start": {"timestamp": "2022-08-09T10:10:00"}}');
 ERROR HY000: audit_log_read UDF failed; Wrong JSON argument, bad timestamp format
-SELECT audit_log_read('{"start": {"timestamp": " 2022-08-09  "}}');
-audit_log_read('{"start": {"timestamp": " 2022-08-09  "}}')
+SELECT audit_log_read('{"start": {"timestamp": <hidden>}}');
+audit_log_read('{"start": {"timestamp": <hidden>}}')
 [
+{"timestamp": <hidden>, "id": <hidden>, "class": "audit", "event": "startup", "connection_id": <hidden>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "startup_data": <hidden>},
 null
 ]
 
-SELECT audit_log_read('{"start": {"timestamp": "  2022-08-09 10:10:00 "}}');
-audit_log_read('{"start": {"timestamp": "  2022-08-09 10:10:00 "}}')
+SELECT audit_log_read('{"start": {"timestamp": <hidden>}}');
+audit_log_read('{"start": {"timestamp": <hidden>}}')
 [
+{"timestamp": <hidden>, "id": <hidden>, "class": "audit", "event": "startup", "connection_id": <hidden>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "startup_data": <hidden>},
 null
 ]
 
@@ -62,9 +64,10 @@ null
 
 #
 # Find records by a start timestamp
-SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:10:00"}}');
-audit_log_read('{"start": {"timestamp": "2022-08-09 10:10:00"}}')
+SELECT audit_log_read('{"start": {"timestamp": <hidden>}}');
+audit_log_read('{"start": {"timestamp": <hidden>}}')
 [
+{"timestamp": <hidden>, "id": <hidden>, "class": "audit", "event": "startup", "connection_id": <hidden>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "startup_data": <hidden>},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files.result
@@ -68,6 +68,9 @@ audit_log_read(@file2_start_bookmark)
 {"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
 {"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
 {"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:13:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (10)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:14:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (11)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:15:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (12)", "sql_command": "insert"}},
 null
 ]
 
@@ -75,30 +78,33 @@ SELECT audit_log_read('null');
 audit_log_read('null')
 OK
 #
-# Read all from two rotated logs by chunks ("max_array_length": 2)
-SET @file2_start_with_limit_bookmark := JSON_SET(@file2_start_bookmark, '$.max_array_length', 2);
+# Read all from two rotated logs by chunks ("max_array_length": 3)
+SET @file2_start_with_limit_bookmark := JSON_SET(@file2_start_bookmark, '$.max_array_length', 3);
 SELECT @file2_start_with_limit_bookmark;
 @file2_start_with_limit_bookmark
-{"id": 0, "timestamp": "2022-08-09 10:05:00", "max_array_length": 2}
+{"id": 0, "timestamp": "2022-08-09 10:05:00", "max_array_length": 3}
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
 {"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}}
 ]
 
-SELECT audit_log_read('{"max_array_length": 2}');
-audit_log_read('{"max_array_length": 2}')
+SELECT audit_log_read('{"max_array_length": 3}');
+audit_log_read('{"max_array_length": 3}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
-]
-
-SELECT audit_log_read('{"max_array_length": 2}');
-audit_log_read('{"max_array_length": 2}')
-[
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
 {"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}}
+]
+
+SELECT audit_log_read('{"max_array_length": 3}');
+audit_log_read('{"max_array_length": 3}')
+[
+{"timestamp": "2022-08-09 10:13:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (10)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:14:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (11)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:15:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (12)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_multiple_files_encrypted.result
@@ -74,6 +74,9 @@ audit_log_read(@file2_start_bookmark)
 {"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
 {"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
 {"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:13:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (10)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:14:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (11)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:15:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (12)", "sql_command": "insert"}},
 null
 ]
 
@@ -81,30 +84,33 @@ SELECT audit_log_read('null');
 audit_log_read('null')
 OK
 #
-# Read all from two rotated logs by chunks ("max_array_length": 2)
-SET @file2_start_with_limit_bookmark := JSON_SET(@file2_start_bookmark, '$.max_array_length', 2);
+# Read all from two rotated logs by chunks ("max_array_length": 3)
+SET @file2_start_with_limit_bookmark := JSON_SET(@file2_start_bookmark, '$.max_array_length', 3);
 SELECT @file2_start_with_limit_bookmark;
 @file2_start_with_limit_bookmark
-{"id": 0, "timestamp": "2022-08-09 10:05:00", "max_array_length": 2}
+{"id": 0, "timestamp": "2022-08-09 10:05:00", "max_array_length": 3}
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 audit_log_read(@file2_start_with_limit_bookmark)
 [
 {"timestamp": "2022-08-09 10:05:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (4)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}}
+{"timestamp": "2022-08-09 10:06:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (5)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}}
 ]
 
-SELECT audit_log_read('{"max_array_length": 2}');
-audit_log_read('{"max_array_length": 2}')
+SELECT audit_log_read('{"max_array_length": 3}');
+audit_log_read('{"max_array_length": 3}')
 [
-{"timestamp": "2022-08-09 10:07:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (6)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}}
-]
-
-SELECT audit_log_read('{"max_array_length": 2}');
-audit_log_read('{"max_array_length": 2}')
-[
+{"timestamp": "2022-08-09 10:09:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (7)", "sql_command": "insert"}},
 {"timestamp": "2022-08-09 10:10:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (8)", "sql_command": "insert"}},
-{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:11:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (9)", "sql_command": "insert"}}
+]
+
+SELECT audit_log_read('{"max_array_length": 3}');
+audit_log_read('{"max_array_length": 3}')
+[
+{"timestamp": "2022-08-09 10:13:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (10)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:14:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (11)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:15:00", "id": 2, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (12)", "sql_command": "insert"}},
 null
 ]
 

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_basic.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_basic.test
@@ -2,6 +2,13 @@
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
 
+--let $audit_filter_log_path = `SELECT @@global.datadir`
+
+# remove old rotated log files
+--remove_files_wildcard $audit_filter_log_path audit_filter.????????T??????*.log
+
+--let $log_event_regex = /"timestamp": "[^"]*?"/"timestamp": <hidden>/ /"id": \d*/"id": <hidden>/ /"connection_id": \d*/"connection_id": <hidden>/ /"startup_data": \{[^\}]*?\}/"startup_data": <hidden>/ /"connection_attributes": \{[^\}]*?\}/"connection_attributes": <hidden>/
+
 --echo #
 --echo # Check wrong argument number
 --error ER_CANT_INITIALIZE_UDF
@@ -33,7 +40,9 @@ SELECT audit_log_read('{"start": {"timestamp": "not a timestamp"}}');
 SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10 10 00"}}');
 --error ER_UDF_ERROR
 SELECT audit_log_read('{"start": {"timestamp": "2022-08-09T10:10:00"}}');
+--replace_regex $log_event_regex
 SELECT audit_log_read('{"start": {"timestamp": " 2022-08-09  "}}');
+--replace_regex $log_event_regex
 SELECT audit_log_read('{"start": {"timestamp": "  2022-08-09 10:10:00 "}}');
 
 --error ER_UDF_ERROR
@@ -51,6 +60,7 @@ SELECT audit_log_read('{"timestamp": "  2022-08-09 10:10:00 ", "id": 0}');
 
 --echo #
 --echo # Find records by a start timestamp
+--replace_regex $log_event_regex
 SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:10:00"}}');
 SELECT audit_log_read('null');
 

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_multiple_files_base.inc
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_multiple_files_base.inc
@@ -61,15 +61,15 @@ SELECT audit_log_read(@file2_start_bookmark);
 SELECT audit_log_read('null');
 
 --echo #
---echo # Read all from two rotated logs by chunks ("max_array_length": 2)
-SET @file2_start_with_limit_bookmark := JSON_SET(@file2_start_bookmark, '$.max_array_length', 2);
+--echo # Read all from two rotated logs by chunks ("max_array_length": 3)
+SET @file2_start_with_limit_bookmark := JSON_SET(@file2_start_bookmark, '$.max_array_length', 3);
 SELECT @file2_start_with_limit_bookmark;
 --replace_regex /"connection_id": \d*/"connection_id": <id>/
 SELECT audit_log_read(@file2_start_with_limit_bookmark);
 --replace_regex /"connection_id": \d*/"connection_id": <id>/
-SELECT audit_log_read('{"max_array_length": 2}');
+SELECT audit_log_read('{"max_array_length": 3}');
 --replace_regex /"connection_id": \d*/"connection_id": <id>/
-SELECT audit_log_read('{"max_array_length": 2}');
+SELECT audit_log_read('{"max_array_length": 3}');
 SELECT audit_log_read('null');
 
 --echo #


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9773

Replace full-document JSON parsing when discovering each log file's first event timestamp with a streaming SAX handler that stops after the first "timestamp" string. That avoids loading large arrays into memory and keeps init() usable on valid-but-growing files.

When reading events, treat EOF reached during incremental parsing as normal and stop the read loop instead of failing. The active audit log file is a top-level JSON array that is not closed until rotation, so treating EOF as a hard parse error broke audit_log_read() on the current file.

Refactor reader arguments: replace the close_read_sequence flag with an explicit Command enum (continue, read from bookmark, read from timestamp, close sequence). Seek-to-start now depends on the command: bookmark mode requires matching timestamp and id; timestamp-only mode starts at the first event whose timestamp is on or after the requested time. Add LogBookmark::operator== for the bookmark comparison.

Adjust set_files_to_read_list() to choose the log file using the interval between consecutive files' first timestamps relative to the next event bookmark, so the correct segment is selected when resuming.

FileWriterCompressing flushes gzip stream after each logged event to make sure FileReaderDecompressing can read events from currently opened log file.

With encryption enabled, log events in JSON and JSONL log files are padded with whitespace block in order to prevent those events from being stuck in internal buffer of encryption context for prolonged amount of time.