### PR TITLE
PS-10331 (2) [8.4]: Bypass page cache for audit log writes via O_DIRECT (part 2)

### DIFF
--- a/mysql-test/suite/component_audit_log_filter/t/direct_io.test
+++ b/mysql-test/suite/component_audit_log_filter/t/direct_io.test
@@ -1,5 +1,6 @@
 --source include/have_component_audit_log.inc
 --source include/linux.inc
+--source include/have_odirect.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
 

--- a/mysql-test/suite/component_audit_log_filter/t/direct_io_close_fallback.test
+++ b/mysql-test/suite/component_audit_log_filter/t/direct_io_close_fallback.test
@@ -1,6 +1,7 @@
 --source include/have_debug.inc
 --source include/have_component_audit_log.inc
 --source include/linux.inc
+--source include/have_odirect.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
 

--- a/mysql-test/suite/component_audit_log_filter/t/direct_io_fallback.test
+++ b/mysql-test/suite/component_audit_log_filter/t/direct_io_fallback.test
@@ -1,6 +1,7 @@
 --source include/have_debug.inc
 --source include/have_component_audit_log.inc
 --source include/linux.inc
+--source include/have_odirect.inc
 --source ../inc/audit_tables_init.inc
 --source ../inc/audit_comp_install.inc
 


### PR DESCRIPTION
Add `--source include/have_odirect.inc` to fix:
```
[9:23 AM]260406 12:24:42 [ 76%] component_audit_log_filter.direct_io     w2  [ fail ]  Found warnings/errors in error log file!
        Test ended at 2026-04-06 12:24:42
include/load_error_log.inc
line
2026-04-06T12:24:32.128135Z 0 [Warning] [MY-011071] [Server] Component audit_log_filter reported: 'Audit Log Filter: O_DIRECT open failed, falling back to buffered I/O'
2026-04-06T12:24:34.937271Z 0 [Warning] [MY-011071] [Server] Component audit_log_filter reported: 'Audit Log Filter: O_DIRECT open failed, falling back to buffered I/O'
2026-04-06T12:24:37.837811Z 0 [Warning] [MY-011071] [Server] Component audit_log_filter reported: 'Audit Log Filter: O_DIRECT open failed, falling back to buffered I/O'
2026-04-06T12:24:37.976754Z 11 [Warning] [MY-011071] [Server] Component audit_log_filter reported: 'Audit Log Filter: O_DIRECT open failed, falling back to buffered I/O'
SET @@GLOBAL.super_read_only = @original_super_read_only;
^ Found warnings in /tmp/work/extract/mysql-test/var/2/log/mysqld.1.err
```