### PR TITLE
PS-10435 [9.x]: Support replace-field action for general and table_access event classes

### DIFF
--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -1331,7 +1331,7 @@ std::shared_ptr<EventFieldActionBase> AuditRuleParser::parse_action_json(
       std::string replaced_field_name = field_json["name"].GetString();
 
       if (!EventFieldActionReplaceField::validate_field_name(
-              replaced_field_name)) {
+              class_name, replaced_field_name)) {
         LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_ACTION_BAD_REPLACE,
                         replaced_field_name.c_str());
         audit_rule->set_parse_error("event field '" + replaced_field_name +

--- a/components/audit_log_filter/event_field_action/replace_field.cc
+++ b/components/audit_log_filter/event_field_action/replace_field.cc
@@ -20,10 +20,22 @@
 #include <mysql/components/services/log_builtins.h>
 #include <mysqld_error.h>
 
+#include <string_view>
 #include <utility>
 #include <variant>
 
 namespace audit_log_filter::event_field_action {
+
+namespace {
+
+constexpr std::string_view kClassNameGeneral{"general"};
+constexpr std::string_view kClassNameTableAccess{"table_access"};
+constexpr std::string_view kClassNameQuery{"query"};
+constexpr std::string_view kClassNameParse{"parse"};
+constexpr std::string_view kFieldNameGeneralQuery{"general_query.str"};
+constexpr std::string_view kFieldNameQuery{"query.str"};
+
+}  // namespace
 
 EventFieldActionReplaceField::EventFieldActionReplaceField(
     std::string field_name,
@@ -35,13 +47,19 @@ EventFieldActionReplaceField::EventFieldActionReplaceField(
       m_replacement_func{std::move(replacement_func)} {}
 
 bool EventFieldActionReplaceField::validate_field_name(
-    const std::string &field_name) noexcept {
+    const std::string &class_name, const std::string &field_name) noexcept {
   /*
    * Applicable to the following fields only:
+   *    general -> general_query.str
+   *    table_access -> query.str
    *    query -> query.str
    *    parse -> query.str
    */
-  return field_name == "query.str";
+  return (class_name == kClassNameGeneral &&
+          field_name == kFieldNameGeneralQuery) ||
+         ((class_name == kClassNameTableAccess ||
+           class_name == kClassNameQuery || class_name == kClassNameParse) &&
+          field_name == kFieldNameQuery);
 }
 
 EventActionType EventFieldActionReplaceField::get_action_type() const noexcept {
@@ -67,21 +85,34 @@ bool EventFieldActionReplaceField::apply(const AuditRecordFieldsList &fields,
     new_value = "...";
   }
 
-  if (std::holds_alternative<AuditRecordQuery>(audit_record)) {
+  if (std::holds_alternative<AuditRecordGeneral>(audit_record)) {
+    auto *rec = std::get_if<AuditRecordGeneral>(&audit_record);
+    if (rec != nullptr) {
+      rec->extended_info.digest = std::move(new_value);
+      return true;
+    }
+  } else if (std::holds_alternative<AuditRecordTableAccess>(audit_record)) {
+    auto *rec = std::get_if<AuditRecordTableAccess>(&audit_record);
+    if (rec != nullptr) {
+      rec->extended_info.digest = std::move(new_value);
+      return true;
+    }
+  } else if (std::holds_alternative<AuditRecordQuery>(audit_record)) {
     auto *rec = std::get_if<AuditRecordQuery>(&audit_record);
     if (rec != nullptr) {
       rec->extended_info.digest = std::move(new_value);
+      return true;
     }
   } else if (std::holds_alternative<AuditRecordParse>(audit_record)) {
     auto *rec = std::get_if<AuditRecordParse>(&audit_record);
     if (rec != nullptr) {
       rec->extended_info.digest = std::move(new_value);
+      return true;
     }
-  } else {
-    LogComponentErr(ERROR_LEVEL, ER_AUDIT_REPLACE_FIELD_UNEXPECTED_EVENT_TYPE);
   }
 
-  return true;
+  LogComponentErr(ERROR_LEVEL, ER_AUDIT_REPLACE_FIELD_UNEXPECTED_EVENT_TYPE);
+  return false;
 }
 
 }  // namespace audit_log_filter::event_field_action

--- a/components/audit_log_filter/event_field_action/replace_field.h
+++ b/components/audit_log_filter/event_field_action/replace_field.h
@@ -39,7 +39,8 @@ class EventFieldActionReplaceField : public EventFieldActionBase {
       std::unique_ptr<event_filter_function::EventFilterFunctionBase>
           replacement_func);
 
-  static bool validate_field_name(const std::string &field_name) noexcept;
+  static bool validate_field_name(const std::string &class_name,
+                                  const std::string &field_name) noexcept;
 
   /**
    * @brief Get action type.

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
@@ -40,6 +40,52 @@ OK
 INSERT INTO t1 VALUES (1);
 Tag <EVENT_CLASS_NAME>query</EVENT_CLASS_NAME>.*<SQLTEXT>(?:SELECT `audit_log_filter_set_user` \(\.\.\.\)|INSERT INTO `t1` VALUES \(\?\))</SQLTEXT> Ok
 #
+# Field replacement for "general/status" events
+SELECT audit_log_filter_set_filter('replace_general_status_query', '{
+"filter": {
+"class": {
+"name": "general",
+"event": {
+"name": "status",
+"log": {
+"field": {
+"name": "general_command.str",
+"value": "Query"
+          }
+},
+"print": {
+"field": {
+"name": "general_query.str",
+"print": false,
+"replace": {"function": {"name": "query_digest"}}
+}
+}
+}
+}
+}
+}');
+audit_log_filter_set_filter('replace_general_status_query', '{
+"filter": {
+"class": {
+"name": "general",
+"event": {
+"name": "status",
+"log": {
+"field": {
+"name": "general_command.str",
+"value": "Query"
+          }
+},
+"print": {
+"field": {
+"name": "general
+OK
+SELECT audit_log_filter_set_user('%', 'replace_general_status_query');
+audit_log_filter_set_user('%', 'replace_general_status_query')
+OK
+INSERT INTO t1 VALUES (2);
+Tag <EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>.*<SQLTEXT>INSERT INTO `t1` VALUES \(\?\)</SQLTEXT> Ok
+#
 # Field replacement for all events of "parse" class
 SELECT audit_log_filter_set_filter('replace_parse_query', '{
 "filter": {
@@ -299,6 +345,45 @@ DELETE FROM t2;
 Tag <EVENT_SUBCLASS_NAME>(?:start|status_end)</EVENT_SUBCLASS_NAME> Ok
 Tag <SQLTEXT>(?:SELECT `audit_log_filter_set_user` \(\.\.\.\)|INSERT INTO `t1` VALUES \(\?\)|INSERT INTO `t2` VALUES \(\?\))</SQLTEXT> Ok
 #
+# Field replacement for table_access events
+SELECT audit_log_filter_set_filter('replace_table_access_query', '{
+"filter": {
+"class": {
+"name": "table_access",
+"print": {
+"field": {
+"name": "query.str",
+"print": false,
+"replace": {"function": {"name": "query_digest"}}
+}
+}
+}
+}
+}');
+audit_log_filter_set_filter('replace_table_access_query', '{
+"filter": {
+"class": {
+"name": "table_access",
+"print": {
+"field": {
+"name": "query.str",
+"print": false,
+"replace": {"function": {"name": "query_digest"}}
+}
+}
+}
+}
+}')
+OK
+SELECT audit_log_filter_set_user('%', 'replace_table_access_query');
+audit_log_filter_set_user('%', 'replace_table_access_query')
+OK
+INSERT INTO t1 VALUES (1);
+UPDATE t1 SET id = 2 WHERE id = 1;
+DELETE FROM t1 WHERE id = 2;
+Tag <EVENT_CLASS_NAME>table_access</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>(?:insert|update|delete)</EVENT_SUBCLASS_NAME> Ok
+Tag <SQLTEXT>(?:INSERT INTO `t1` VALUES \(\?\)|UPDATE `t1` SET `id` = \? WHERE `id` = \?|DELETE FROM `t1` WHERE `id` = \?)</SQLTEXT> Ok
+#
 # Check incorrect replacement rule definitions
 SELECT audit_log_filter_set_filter('incorrect_rule', '{
 "filter": {
@@ -392,7 +477,7 @@ SELECT audit_log_filter_set_filter('incorrect_rule', '{
 "name": "general",
 "print": {
 "field": {
-"name": "query.str",
+"name": "general_query.str",
 "print": [],
 "replace": {
 "function": {
@@ -412,7 +497,7 @@ audit_log_filter_set_filter('incorrect_rule', '{
 "name": "general",
 "print": {
 "field": {
-"name": "query.str",
+"name": "general_query.str",
 "print": [],
 "replace": {
 "function": {

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
@@ -49,6 +49,47 @@ disconnect conn_run;
 --source check_all_events_with_tag.inc
 
 --echo #
+--echo # Field replacement for "general/status" events
+let $filter = {
+  "filter": {
+    "class": {
+      "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": {
+            "name": "general_command.str",
+            "value": "Query"
+          }
+        },
+        "print": {
+          "field": {
+            "name": "general_query.str",
+            "print": false,
+            "replace": {"function": {"name": "query_digest"}}
+          }
+        }
+      }
+    }
+  }
+};
+
+eval SELECT audit_log_filter_set_filter('replace_general_status_query', '$filter');
+SELECT audit_log_filter_set_user('%', 'replace_general_status_query');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
+
+INSERT INTO t1 VALUES (2);
+
+disconnect conn_run;
+--connection conn_admin
+
+--let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>.*<SQLTEXT>INSERT INTO `t1` VALUES \(\?\)</SQLTEXT>
+--source check_all_events_with_tag.inc
+
+--echo #
 --echo # Field replacement for all events of "parse" class
 let $filter = {
   "filter": {
@@ -286,6 +327,42 @@ disconnect conn_run;
 --source check_all_events_with_tag.inc
 
 --echo #
+--echo # Field replacement for table_access events
+let $filter = {
+  "filter": {
+    "class": {
+      "name": "table_access",
+      "print": {
+        "field": {
+          "name": "query.str",
+          "print": false,
+          "replace": {"function": {"name": "query_digest"}}
+        }
+      }
+    }
+  }
+};
+
+eval SELECT audit_log_filter_set_filter('replace_table_access_query', '$filter');
+SELECT audit_log_filter_set_user('%', 'replace_table_access_query');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
+
+INSERT INTO t1 VALUES (1);
+UPDATE t1 SET id = 2 WHERE id = 1;
+DELETE FROM t1 WHERE id = 2;
+
+disconnect conn_run;
+--connection conn_admin
+
+--let $search_tag=<EVENT_CLASS_NAME>table_access</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>(?:insert|update|delete)</EVENT_SUBCLASS_NAME>
+--source check_all_events_with_tag.inc
+--let $search_tag=<SQLTEXT>(?:INSERT INTO `t1` VALUES \(\?\)|UPDATE `t1` SET `id` = \? WHERE `id` = \?|DELETE FROM `t1` WHERE `id` = \?)</SQLTEXT>
+--source check_all_events_with_tag.inc
+
+--echo #
 --echo # Check incorrect replacement rule definitions
 --disable_query_log
 call mtr.add_suppression("Component audit_log_filter reported: 'Wrong argument: incorrect rule definition");
@@ -355,7 +432,7 @@ let $filter = {
         "name": "general",
         "print": {
           "field": {
-            "name": "query.str",
+            "name": "general_query.str",
             "print": [],
             "replace": {
               "function": {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10435

Previously the replace-field filter action only worked with query and parse event classes (field query.str). Extend it to also handle the general class (field general_query.str) and the table_access class (field query.str) by making validate_field_name class-aware and adding the corresponding apply branches. Return false from apply on event-type mismatches instead of silently succeeding.

Add MTR tests for general/status and table_access field replacement.