### PR TITLE
PS-11014 [8.4]: Accept query_digest string shorthand in replace-field filters

### DIFF
--- a/components/audit_log_filter/audit_rule_parser.cc
+++ b/components/audit_log_filter/audit_rule_parser.cc
@@ -1167,13 +1167,18 @@ std::unique_ptr<EventFilterFunctionBase> AuditRuleParser::parse_function(
 
   FunctionArgsList args;
 
-  if (function_json.HasMember("args") &&
-      !parse_function_args_json(function_json["args"], args, class_name,
-                                audit_rule)) {
-    LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_BAD_ARGS_FORMAT,
-                    audit_rule->get_rule_name().c_str());
-    audit_rule->set_parse_error("wrong function args format provided");
-    return nullptr;
+  if (function_json.HasMember("args")) {
+    if (func_type == EventFilterFunctionType::QueryDigest &&
+        function_json["args"].IsString()) {
+      args.push_back({FunctionArgType::String, FunctionArgSourceType::String,
+                      function_json["args"].GetString()});
+    } else if (!parse_function_args_json(function_json["args"], args,
+                                         class_name, audit_rule)) {
+      LogComponentErr(ERROR_LEVEL, ER_AUDIT_PARSE_FUNCTION_BAD_ARGS_FORMAT,
+                      audit_rule->get_rule_name().c_str());
+      audit_rule->set_parse_error("wrong function args format provided");
+      return nullptr;
+    }
   }
 
   if (!validate_filter_function_args(func_type, args, expected_return_type)) {
@@ -1191,8 +1196,12 @@ bool AuditRuleParser::parse_function_args_json(
     const rapidjson::Value &function_args_json, FunctionArgsList &args,
     const std::string &class_name, AuditRule *audit_rule) noexcept {
   /*
-   * Parse 'function' arguments list, must be an array of objects with each
-   * object containing argument type and its value along with the value source
+   * Parse 'function' arguments list in the generic typed-array form. The
+   * query_digest() shorthand using a direct string argument is handled by
+   * parse_function() before this helper is called.
+   *
+   * Arguments must be an array of objects with each object containing
+   * argument type and its value along with the value source.
    *
    * "function": {
    *   "name": "string_find",

--- a/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
+++ b/mysql-test/suite/component_audit_log_filter/r/filter_definition_replace_field.result
@@ -226,6 +226,67 @@ DELETE FROM t2 WHERE id = 2;
 Tag <EVENT_SUBCLASS_NAME>(?:start|status_end)</EVENT_SUBCLASS_NAME> Ok
 Tag <SQLTEXT>(?:SELECT `audit_log_filter_set_user` \(\.\.\.\)|INSERT INTO t2 VALUES \(1\)|UPDATE `t2` SET `id` = \? WHERE `id` = \?|SELECT \* FROM `t2`|DELETE FROM `t2` WHERE `id` = \?)</SQLTEXT> Ok
 #
+# Replace general/status queries with query_digest string shorthand
+SELECT audit_log_filter_set_filter('replace_general_status_shorthand', '{
+"filter": {
+"class": {
+"name": "general",
+"event": {
+"name": "status",
+"log": {
+"field": {
+"name": "general_command.str",
+"value": "Query"
+          }
+},
+"print": {
+"field": {
+"name": "general_query.str",
+"print": {
+"function": {
+"name": "query_digest",
+"args": "SELECT ?"
+              }
+},
+"replace": {
+"function": {
+"name": "query_digest"
+              }
+}
+}
+}
+}
+}
+}
+}');
+audit_log_filter_set_filter('replace_general_status_shorthand', '{
+"filter": {
+"class": {
+"name": "general",
+"event": {
+"name": "status",
+"log": {
+"field": {
+"name": "general_command.str",
+"value": "Query"
+          }
+},
+"print": {
+"field": {
+"name": "gen
+OK
+SELECT audit_log_filter_set_user('%', 'replace_general_status_shorthand');
+audit_log_filter_set_user('%', 'replace_general_status_shorthand')
+OK
+SELECT 1;
+1
+1
+Tag <EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME> Ok
+Tag <SQLTEXT>SELECT 1</SQLTEXT> Ok
+INSERT INTO t1 VALUES (3);
+Tag <EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME> Ok
+Tag <SQLTEXT>INSERT INTO `t1` VALUES \(\?\)</SQLTEXT> Ok
+#
 # Replace for queries matching provided digest
 SELECT audit_log_filter_set_filter('replace_matching_digest', '{
 "filter": {

--- a/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
+++ b/mysql-test/suite/component_audit_log_filter/t/filter_definition_replace_field.test
@@ -216,6 +216,73 @@ disconnect conn_run;
 --source check_all_events_with_tag.inc
 
 --echo #
+--echo # Replace general/status queries with query_digest string shorthand
+let $filter = {
+  "filter": {
+    "class": {
+      "name": "general",
+      "event": {
+        "name": "status",
+        "log": {
+          "field": {
+            "name": "general_command.str",
+            "value": "Query"
+          }
+        },
+        "print": {
+          "field": {
+            "name": "general_query.str",
+            "print": {
+              "function": {
+                "name": "query_digest",
+                "args": "SELECT ?"
+              }
+            },
+            "replace": {
+              "function": {
+                "name": "query_digest"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+eval SELECT audit_log_filter_set_filter('replace_general_status_shorthand', '$filter');
+SELECT audit_log_filter_set_user('%', 'replace_general_status_shorthand');
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
+
+SELECT 1;
+
+disconnect conn_run;
+--connection conn_admin
+
+--let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>
+--source check_all_events_with_tag.inc
+--let $search_tag=<SQLTEXT>SELECT 1</SQLTEXT>
+--source check_all_events_with_tag.inc
+
+--source clean_current_audit_log.inc
+
+connect(conn_run, localhost, root, , test);
+--connection conn_run
+
+INSERT INTO t1 VALUES (3);
+
+disconnect conn_run;
+--connection conn_admin
+
+--let $search_tag=<EVENT_CLASS_NAME>general</EVENT_CLASS_NAME>.*<EVENT_SUBCLASS_NAME>status</EVENT_SUBCLASS_NAME>
+--source check_all_events_with_tag.inc
+--let $search_tag=<SQLTEXT>INSERT INTO `t1` VALUES \(\?\)</SQLTEXT>
+--source check_all_events_with_tag.inc
+
+--echo #
 --echo # Replace for queries matching provided digest
 let $filter = {
   "filter": {


### PR DESCRIPTION
Allow the query_digest() function in audit filter replace-field rules to take its argument as a plain JSON string ("args": "SELECT ?") in addition to the existing typed-array form. This matches the documentation examples and avoids forcing users to wrap a single literal in the verbose object syntax. Add MTR test coverage for the general/status replace path using the shorthand form.