### PR TITLE
PS-11020 [8.0]: MyRocks - concurrent ADD INDEX could pollute L0 or crash the server.

### DIFF
--- a/mysql-test/suite/rocksdb/r/alter_table_add_secondary_key.result
+++ b/mysql-test/suite/rocksdb/r/alter_table_add_secondary_key.result
@@ -1,0 +1,61 @@
+#
+# Test that checks if a bulk_load_fail_if_not_bottommost_level=true doesn't affect secondary index creation badly.
+#
+#
+# Create table t1 for which secondary index will be added later with ALTER
+#
+CREATE TABLE t1 (
+id BIGINT PRIMARY KEY,
+idx_col INT
+) ENGINE=ROCKSDB;
+#
+# Create table t2. It will have index_id smaller than index_id of the secondary index for t1 (that we are going to create).
+# Note: we can't use t1 instead of t2 to insert row while ALTER is running, because there will be MDL SHARED LOCK for t1.
+#
+CREATE TABLE t2 (
+id BIGINT PRIMARY KEY,
+idx_col INT
+) ENGINE=ROCKSDB;
+# Insert row to t1, so the secondary index is not going to be empty.
+INSERT INTO t1 VALUES (1, 100);
+#
+# Start ALTER TABLE ADD INDEX and pause with DEBUG_SYNC after allocating new index_id
+#
+SET DEBUG_SYNC = 'rocksdb_create_key_def_after_index_id_allocated SIGNAL index_id_allocated';
+SET GLOBAL DEBUG = '+d,rocksdb_create_key_def_after_index_id_allocated';
+SET SESSION rocksdb_bulk_load_fail_if_not_bottommost_level = true;
+ALTER TABLE t1 ADD INDEX idx (idx_col);;
+#
+# Waiting for index_id allocated...
+#
+SET DEBUG_SYNC = 'now WAIT_FOR index_id_allocated';
+#
+# Secondary index has received index_id. Creating table t3. It will have index_id greater than index_id of the secondary index for t1.
+#
+SET GLOBAL DEBUG = '-d,rocksdb_create_key_def_after_index_id_allocated';
+CREATE TABLE t3 (
+id BIGINT PRIMARY KEY,
+idx_col INT
+) ENGINE=ROCKSDB;
+#
+# Insert row with corresponding RocksDB key smaller than keys of the secondary index for t1. 
+INSERT INTO t2 VALUES (1, 100);
+# Insert row with corresponding RocksDB key greater than keys of the secondary index for t1. 
+INSERT INTO t3 VALUES (1, 100);
+#
+#
+# Flush memtable and compact SST from L0 to L6. Note: this SST will have range of keys overlapping with the range of keys that will be generated for the secondary index.
+#
+SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now = ON;
+# Now signal the waiting ALTER thread to continue and let it add the index (ingest happens now!)
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	id	A	1	NULL	NULL		SE_SPECIFIC			YES	NULL
+t1	1	idx	1	idx_col	A	1	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
+SELECT SUM(id) FROM t1 USE INDEX (idx);
+SUM(id)
+1
+# Cleanup
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;

--- a/mysql-test/suite/rocksdb/t/alter_table_add_secondary_key.test
+++ b/mysql-test/suite/rocksdb/t/alter_table_add_secondary_key.test
@@ -1,0 +1,116 @@
+--source include/not_valgrind.inc
+--source include/have_rocksdb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+# Set this to non-empty value to see SST files if you needed to debug this mtr test.
+--let $debug_test = 0
+
+--echo #
+--echo # Test that checks if a bulk_load_fail_if_not_bottommost_level=true doesn't affect secondary index creation badly.
+--echo #
+
+--echo #
+--echo # Create table t1 for which secondary index will be added later with ALTER
+--echo #
+CREATE TABLE t1 (
+  id BIGINT PRIMARY KEY,
+  idx_col INT
+) ENGINE=ROCKSDB;
+
+--echo #
+--echo # Create table t2. It will have index_id smaller than index_id of the secondary index for t1 (that we are going to create).
+--echo # Note: we can't use t1 instead of t2 to insert row while ALTER is running, because there will be MDL SHARED LOCK for t1.
+--echo #
+CREATE TABLE t2 (
+  id BIGINT PRIMARY KEY,
+  idx_col INT
+) ENGINE=ROCKSDB;
+
+--echo # Insert row to t1, so the secondary index is not going to be empty.
+INSERT INTO t1 VALUES (1, 100);
+
+--echo #
+--echo # Start ALTER TABLE ADD INDEX and pause with DEBUG_SYNC after allocating new index_id
+--echo #
+--connect (conn_alter, localhost, root,,test)
+--connection conn_alter
+
+# Before the bug fix we could have waited up until finish_index_creation is signaled after table t3 was created.
+# However, after the bug fix, it would never get there because it would wait on this index creation to finish.
+# Therefore instead of waiting for signal to continue, we prefer to inject a sleep.
+# SET DEBUG_SYNC = 'rocksdb_create_key_def_after_index_id_allocated SIGNAL index_id_allocated WAIT_FOR finish_index_creation';
+SET DEBUG_SYNC = 'rocksdb_create_key_def_after_index_id_allocated SIGNAL index_id_allocated';
+SET GLOBAL DEBUG = '+d,rocksdb_create_key_def_after_index_id_allocated';
+
+SET SESSION rocksdb_bulk_load_fail_if_not_bottommost_level = true;
+
+# This will hit the "rocksdb_create_key_def_after_index_id_allocated" sync point and wait:
+--send ALTER TABLE t1 ADD INDEX idx (idx_col);
+
+--connection default
+
+--echo #
+--echo # Waiting for index_id allocated...
+--echo #
+
+SET DEBUG_SYNC = 'now WAIT_FOR index_id_allocated';
+
+--echo #
+--echo # Secondary index has received index_id. Creating table t3. It will have index_id greater than index_id of the secondary index for t1.
+--echo #
+SET GLOBAL DEBUG = '-d,rocksdb_create_key_def_after_index_id_allocated'; # no need to wait after t3 index id allocated
+CREATE TABLE t3 (
+  id BIGINT PRIMARY KEY,
+  idx_col INT
+) ENGINE=ROCKSDB;
+
+--echo #
+--echo # Insert row with corresponding RocksDB key smaller than keys of the secondary index for t1. 
+INSERT INTO t2 VALUES (1, 100);
+--echo # Insert row with corresponding RocksDB key greater than keys of the secondary index for t1. 
+INSERT INTO t3 VALUES (1, 100);
+--echo #
+
+--echo #
+--echo # Flush memtable and compact SST from L0 to L6. Note: this SST will have range of keys overlapping with the range of keys that will be generated for the secondary index.
+--echo #
+SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now = ON;
+
+if ($debug_test)
+{
+  --echo # Current state of the LSM tree (just before the secondary index is created):
+  SELECT CF_NAME, LEVEL, NAME, SMALLEST_KEY, LARGEST_KEY, BEING_COMPACTED, SIZE
+  FROM information_schema.rocksdb_live_files_metadata
+  WHERE CF_NAME = 'default'
+  ORDER BY LEVEL, NAME;
+}
+
+--echo # Now signal the waiting ALTER thread to continue and let it add the index (ingest happens now!)
+# See comment about why we cannot wait on finish_index_creation after the bug fix (earlier in the test).
+# SET DEBUG_SYNC = 'now SIGNAL finish_index_creation';
+--sleep 5
+
+if ($debug_test)
+{
+  --echo # Current state of the LSM tree (after the secondary index has been created):
+  SELECT CF_NAME, LEVEL, NAME, SMALLEST_KEY, LARGEST_KEY, BEING_COMPACTED, SIZE
+  FROM information_schema.rocksdb_live_files_metadata
+  WHERE CF_NAME = 'default'
+  ORDER BY LEVEL, NAME;
+}
+
+--connection conn_alter
+--reap # Reap the ALTER statement (it should now continue from the sync point)
+
+--connection default
+
+SHOW INDEX FROM t1;
+SELECT SUM(id) FROM t1 USE INDEX (idx);
+
+--echo # Cleanup
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+
+--disconnect conn_alter

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11075,7 +11075,7 @@ int ha_rocksdb::acquire_prefix_lock(const Rdb_key_def &kd, Rdb_transaction *tx,
 */
 int ha_rocksdb::check_and_lock_sk(
     const uint key_id, const struct update_row_info &row_info,
-                                  bool *const found) {
+    bool *const found) {
   assert(
       (row_info.old_data == table->record[1] &&
        row_info.new_data == table->record[0]) ||

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2946,12 +2946,15 @@ static bool is_tmp_table(const std::string &tablename) {
 }
 
 static void wait_until_no_conflicting_index_ids_reserved(GL_INDEX_ID index_id) {
-  auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
+  auto local_dict_manager =
+      dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
   std::lock_guard dm_lock(*local_dict_manager);
-  local_dict_manager->wait_until_no_conflicting_index_ids_reserved_for_create(index_id);
+  local_dict_manager->wait_until_no_conflicting_index_ids_reserved_for_create(
+      index_id);
 }
 
-static void wait_until_no_conflicting_index_ids_reserved(const std::vector<GL_INDEX_ID> &index_ids_to_reserve) {
+static void wait_until_no_conflicting_index_ids_reserved(
+    const std::vector<GL_INDEX_ID> &index_ids_to_reserve) {
   for (const auto &index_id : index_ids_to_reserve) {
     wait_until_no_conflicting_index_ids_reserved(index_id);
   }
@@ -3590,13 +3593,12 @@ class Rdb_transaction {
                        TABLE *table_arg = nullptr,
                        char *table_name_arg = nullptr,
                        std::shared_ptr<Rdb_key_def> index = {}) {
-
-    struct Release_index_id_reserved_for_create {                         
+    struct Release_index_id_reserved_for_create {
       std::shared_ptr<Rdb_key_def> index;
 
-      explicit Release_index_id_reserved_for_create(std::shared_ptr<Rdb_key_def> index_arg)
-      : index(index_arg) {
-      }
+      explicit Release_index_id_reserved_for_create(
+          std::shared_ptr<Rdb_key_def> index_arg)
+          : index(index_arg) {}
 
       ~Release_index_id_reserved_for_create() {
         if (index == nullptr) {
@@ -3604,7 +3606,7 @@ class Rdb_transaction {
         }
         const auto index_id = index->get_gl_index_id();
         auto local_dict_manager =
-        dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
+            dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
         std::lock_guard dm_lock(*local_dict_manager);
         local_dict_manager->remove_index_id_reserved_for_create(index_id);
       }
@@ -6476,8 +6478,8 @@ static int rocksdb_init_internal(void *const p) {
 
   if (rdb_has_rocksdb_corruption()) {
     LogPluginErrMsg(ERROR_LEVEL, 0,
-        "There was corruption detected in the RocksDB data files. "
-        "Check error log emitted earlier for more details.");
+                    "There was corruption detected in the RocksDB data files. "
+                    "Check error log emitted earlier for more details.");
     if (rocksdb_allow_to_start_after_corruption) {
       LogPluginErrMsg(INFORMATION_LEVEL, 0,
                       "Set rocksdb_allow_to_start_after_corruption=0 to "
@@ -8431,7 +8433,8 @@ int ha_rocksdb::create_key_defs(
     const TABLE &table_arg, Rdb_tbl_def &tbl_def_arg,
     const std::string &actual_user_table_name, bool is_dd_tbl,
     const TABLE *const old_table_arg /* = nullptr */,
-    const Rdb_tbl_def *const old_tbl_def_arg /* = nullptr */, bool is_secondary_index) const {
+    const Rdb_tbl_def *const old_tbl_def_arg /* = nullptr */,
+    bool is_secondary_index) const {
   DBUG_ENTER_FUNC();
 
   assert(table_arg.s != nullptr);
@@ -8500,7 +8503,8 @@ int ha_rocksdb::create_key_defs(
     */
     for (uint i = 0; i < tbl_def_arg.m_key_count; i++) {
       if (create_key_def(table_arg, i, tbl_def_arg, m_key_descr_arr[i], cfs[i],
-                         ttl_duration, ttl_column, is_dd_tbl, is_secondary_index)) {
+                         ttl_duration, ttl_column, is_dd_tbl,
+                         is_secondary_index)) {
         DBUG_RETURN(HA_EXIT_FAILURE);
       }
     }
@@ -8912,7 +8916,8 @@ int ha_rocksdb::create_key_def(const TABLE &table_arg, uint i,
                                const struct key_def_cf_info &cf_info,
                                uint64 ttl_duration,
                                const std::string &ttl_column,
-                               bool is_dd_tbl /* = false */, bool is_secondary_index) const {
+                               bool is_dd_tbl /* = false */,
+                               bool is_secondary_index) const {
   DBUG_ENTER_FUNC();
 
   assert(new_key_def == nullptr);
@@ -8920,12 +8925,14 @@ int ha_rocksdb::create_key_def(const TABLE &table_arg, uint i,
   uint index_id;
 
   {
-    auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(cf_info.cf_handle->GetID());
+    auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(
+        cf_info.cf_handle->GetID());
     std::lock_guard dm_lock(*local_dict_manager);
     index_id = ddl_manager.get_and_update_next_number(
-        cf_info.cf_handle->GetID(), is_dd_tbl); // FIXME
+        cf_info.cf_handle->GetID(), is_dd_tbl);  // FIXME
     if (is_secondary_index) {
-      local_dict_manager->add_index_id_reserved_for_create(GL_INDEX_ID{cf_info.cf_handle->GetID(), index_id});
+      local_dict_manager->add_index_id_reserved_for_create(
+          GL_INDEX_ID{cf_info.cf_handle->GetID(), index_id});
     }
   }
 
@@ -8934,7 +8941,7 @@ int ha_rocksdb::create_key_def(const TABLE &table_arg, uint i,
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(5s);
   });
- 
+
   const uint16_t index_dict_version = Rdb_key_def::INDEX_INFO_VERSION_LATEST;
   uchar index_type;
   uint16_t kv_version;
@@ -9204,7 +9211,8 @@ int ha_rocksdb::create_table(const std::string &table_name,
                              ulonglong auto_increment_value,
                              const dd::Table *table_def [[maybe_unused]]) {
   DBUG_ENTER_FUNC();
-  std::vector<GL_INDEX_ID> index_ids_to_reserve; // defined here because of gotos in code below
+  std::vector<GL_INDEX_ID>
+      index_ids_to_reserve;  // defined here because of gotos in code below
   int err;
   bool is_dd_tbl = dd::get_dictionary()->is_dd_table_name(
       table_arg.s->db.str, table_arg.s->table_name.str);
@@ -11067,7 +11075,7 @@ int ha_rocksdb::acquire_prefix_lock(const Rdb_key_def &kd, Rdb_transaction *tx,
 */
 int ha_rocksdb::check_and_lock_sk(
     const uint key_id, const struct update_row_info &row_info,
-    bool *const found) {
+                                  bool *const found) {
   assert(
       (row_info.old_data == table->record[1] &&
        row_info.new_data == table->record[0]) ||

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15,6 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #include <cassert>
+#include "my_dbug.h"
 #include "mysqld_error.h"
 #ifdef USE_PRAGMA_IMPLEMENTATION
 #pragma implementation  // gcc: Class implementation
@@ -2944,6 +2945,14 @@ static bool is_tmp_table(const std::string &tablename) {
   }
 }
 
+static void wait_until_no_conflicting_index_ids_reserved(const std::vector<GL_INDEX_ID> &index_ids_to_reserve) {
+  for (const auto &index_id : index_ids_to_reserve) {
+    auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
+    std::lock_guard dm_lock(*local_dict_manager);
+    local_dict_manager->wait_until_no_conflicting_index_ids_reserved_for_create(index_id);
+  }
+}
+
 static int rocksdb_compact_column_family(THD *const thd,
                                          struct SYS_VAR *const var,
                                          void *const var_ptr,
@@ -3575,7 +3584,8 @@ class Rdb_transaction {
   int finish_bulk_load(bool *is_critical_error = nullptr,
                        bool print_client_error = true,
                        TABLE *table_arg = nullptr,
-                       char *table_name_arg = nullptr) {
+                       char *table_name_arg = nullptr,
+                       const std::unordered_set<std::shared_ptr<Rdb_key_def>> *indexes = nullptr) {
     if (m_curr_bulk_load.size() == 0) {
       if (is_critical_error) {
         *is_critical_error = false;
@@ -3980,7 +3990,25 @@ class Rdb_transaction {
           file_count);
     }
 
+    if (indexes != nullptr) {
+      std::vector<GL_INDEX_ID> index_ids_to_reserve;
+      index_ids_to_reserve.reserve(indexes->size());
+      for (auto &index : *indexes) {
+        index_ids_to_reserve.push_back(index->get_gl_index_id());
+      }
+      wait_until_no_conflicting_index_ids_reserved(index_ids_to_reserve);
+    }
+
     const rocksdb::Status s = ingest_bulk_load_files(args);
+
+    if (indexes != nullptr) {
+      for (auto &index : *indexes) {
+          auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(index->get_cf()->GetID());
+          std::lock_guard dm_lock(*local_dict_manager);
+          local_dict_manager->remove_index_id_reserved_for_create(index->get_gl_index_id());
+      }
+    }
+
     if (THDVAR(m_thd, trace_sst_api)) {
       LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
                       "SST Tracing: IngestExternalFile '%zu' files returned %s",
@@ -8385,7 +8413,7 @@ int ha_rocksdb::create_key_defs(
     const TABLE &table_arg, Rdb_tbl_def &tbl_def_arg,
     const std::string &actual_user_table_name, bool is_dd_tbl,
     const TABLE *const old_table_arg /* = nullptr */,
-    const Rdb_tbl_def *const old_tbl_def_arg /* = nullptr */) const {
+    const Rdb_tbl_def *const old_tbl_def_arg /* = nullptr */, bool is_secondary_index) const {
   DBUG_ENTER_FUNC();
 
   assert(table_arg.s != nullptr);
@@ -8454,7 +8482,7 @@ int ha_rocksdb::create_key_defs(
     */
     for (uint i = 0; i < tbl_def_arg.m_key_count; i++) {
       if (create_key_def(table_arg, i, tbl_def_arg, m_key_descr_arr[i], cfs[i],
-                         ttl_duration, ttl_column, is_dd_tbl)) {
+                         ttl_duration, ttl_column, is_dd_tbl, is_secondary_index)) {
         DBUG_RETURN(HA_EXIT_FAILURE);
       }
     }
@@ -8702,7 +8730,7 @@ bool ha_rocksdb::create_inplace_key_defs(
               ->get_stats(gl_index_id),
           index_info.m_index_flags, ttl_rec_offset, ttl_duration);
     } else if (create_key_def(table_arg, i, tbl_def_arg, new_key_descr[i],
-                              cfs[i], ttl_duration, ttl_column)) {
+                              cfs[i], ttl_duration, ttl_column, false, true)) {
       return true;
     }
 
@@ -8866,13 +8894,29 @@ int ha_rocksdb::create_key_def(const TABLE &table_arg, uint i,
                                const struct key_def_cf_info &cf_info,
                                uint64 ttl_duration,
                                const std::string &ttl_column,
-                               bool is_dd_tbl /* = false */) const {
+                               bool is_dd_tbl /* = false */, bool is_secondary_index) const {
   DBUG_ENTER_FUNC();
 
   assert(new_key_def == nullptr);
 
-  const uint index_id = ddl_manager.get_and_update_next_number(
-      cf_info.cf_handle->GetID(), is_dd_tbl);
+  uint index_id;
+
+  {
+    auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(cf_info.cf_handle->GetID());
+    std::lock_guard dm_lock(*local_dict_manager);
+    index_id = ddl_manager.get_and_update_next_number(
+        cf_info.cf_handle->GetID(), is_dd_tbl); // FIXME
+    if (is_secondary_index) {
+      local_dict_manager->add_index_id_reserved_for_create(GL_INDEX_ID{cf_info.cf_handle->GetID(), index_id});
+    }
+  }
+
+  DEBUG_SYNC(ha_thd(), "rocksdb_create_key_def_after_index_id_allocated");
+  DBUG_EXECUTE_IF("rocksdb_create_key_def_after_index_id_allocated", {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(5s);
+  });
+ 
   const uint16_t index_dict_version = Rdb_key_def::INDEX_INFO_VERSION_LATEST;
   uchar index_type;
   uint16_t kv_version;
@@ -9142,7 +9186,7 @@ int ha_rocksdb::create_table(const std::string &table_name,
                              ulonglong auto_increment_value,
                              const dd::Table *table_def [[maybe_unused]]) {
   DBUG_ENTER_FUNC();
-
+  std::vector<GL_INDEX_ID> index_ids_to_reserve; // defined here because of gotos in code below
   int err;
   bool is_dd_tbl = dd::get_dictionary()->is_dd_table_name(
       table_arg.s->db.str, table_arg.s->table_name.str);
@@ -9198,6 +9242,14 @@ int ha_rocksdb::create_table(const std::string &table_name,
         "wait_for mark_cf_dropped_done_in_create_table";
     assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
   });
+
+  index_ids_to_reserve.clear();
+  index_ids_to_reserve.reserve(n_keys);
+  for (size_t i = 0; i < n_keys; i++) {
+    index_ids_to_reserve.push_back(m_key_descr_arr[i]->get_gl_index_id());
+  }
+
+  wait_until_no_conflicting_index_ids_reserved(index_ids_to_reserve);
 
   {
     std::lock_guard<Rdb_dict_manager> dm_lock(*local_dict_manager);
@@ -14384,7 +14436,7 @@ bool ha_rocksdb::prepare_inplace_alter_table(
 
     if (create_key_defs(*altered_table, *new_tdef,
                         "" /*actual_user_table_name*/, false /*is_dd_tbl*/,
-                        table, m_tbl_def)) {
+                        table, m_tbl_def, true)) {
       /* Delete the new key descriptors */
       delete[] new_key_descr;
 
@@ -14505,7 +14557,7 @@ bool ha_rocksdb::rebuild_table_def_from_table(TABLE *altered_table) {
 
   if (create_key_defs(*altered_table, *new_tdef,
                       "" /* actual_user_table_name */, false /* is_dd_tbl */,
-                      table, m_tbl_def)) {
+                      table, m_tbl_def, false)) {
     goto error;
   }
 
@@ -14852,7 +14904,7 @@ int ha_rocksdb::inplace_populate_sk(
 
     bool is_critical_error;
     res = tx->finish_bulk_load(&is_critical_error, true, new_table_arg,
-                               m_table_handler->m_table_name);
+                               m_table_handler->m_table_name, &indexes);
 
     if (res == ER_DUP_ENTRY) {
       assert(new_table_arg->key_info[index->get_keyno()].flags & HA_NOSAME);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2945,11 +2945,15 @@ static bool is_tmp_table(const std::string &tablename) {
   }
 }
 
+static void wait_until_no_conflicting_index_ids_reserved(GL_INDEX_ID index_id) {
+  auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
+  std::lock_guard dm_lock(*local_dict_manager);
+  local_dict_manager->wait_until_no_conflicting_index_ids_reserved_for_create(index_id);
+}
+
 static void wait_until_no_conflicting_index_ids_reserved(const std::vector<GL_INDEX_ID> &index_ids_to_reserve) {
   for (const auto &index_id : index_ids_to_reserve) {
-    auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
-    std::lock_guard dm_lock(*local_dict_manager);
-    local_dict_manager->wait_until_no_conflicting_index_ids_reserved_for_create(index_id);
+    wait_until_no_conflicting_index_ids_reserved(index_id);
   }
 }
 
@@ -3585,11 +3589,38 @@ class Rdb_transaction {
                        bool print_client_error = true,
                        TABLE *table_arg = nullptr,
                        char *table_name_arg = nullptr,
-                       const std::unordered_set<std::shared_ptr<Rdb_key_def>> *indexes = nullptr) {
+                       std::shared_ptr<Rdb_key_def> index = {}) {
+
+    struct Release_index_id_reserved_for_create {                         
+      std::shared_ptr<Rdb_key_def> index;
+
+      explicit Release_index_id_reserved_for_create(std::shared_ptr<Rdb_key_def> index_arg)
+      : index(index_arg) {
+      }
+
+      ~Release_index_id_reserved_for_create() {
+        if (index == nullptr) {
+          return;
+        }
+        const auto index_id = index->get_gl_index_id();
+        auto local_dict_manager =
+        dict_manager.get_dict_manager_selector_non_const(index_id.cf_id);
+        std::lock_guard dm_lock(*local_dict_manager);
+        local_dict_manager->remove_index_id_reserved_for_create(index_id);
+      }
+    } release_index_id_reserved_for_create(index);
+
     if (m_curr_bulk_load.size() == 0) {
       if (is_critical_error) {
         *is_critical_error = false;
       }
+      // We skip the Ensure_cleanup step below - ensure we don't miss
+      // to cleanup any of resources that would otherwise be cleanup
+      // there. We could move Ensure_cleanup earlier but before doing
+      // so, we better ensure it is safe to do so - hence assertions.
+      assert(m_curr_bulk_load_tablename.empty());
+      assert(m_key_merge.empty());
+      assert(m_bulk_load_index_registry.empty());
       return HA_EXIT_SUCCESS;
     }
 
@@ -3990,24 +4021,11 @@ class Rdb_transaction {
           file_count);
     }
 
-    if (indexes != nullptr) {
-      std::vector<GL_INDEX_ID> index_ids_to_reserve;
-      index_ids_to_reserve.reserve(indexes->size());
-      for (auto &index : *indexes) {
-        index_ids_to_reserve.push_back(index->get_gl_index_id());
-      }
-      wait_until_no_conflicting_index_ids_reserved(index_ids_to_reserve);
+    if (index != nullptr) {
+      wait_until_no_conflicting_index_ids_reserved(index->get_gl_index_id());
     }
 
     const rocksdb::Status s = ingest_bulk_load_files(args);
-
-    if (indexes != nullptr) {
-      for (auto &index : *indexes) {
-          auto local_dict_manager = dict_manager.get_dict_manager_selector_non_const(index->get_cf()->GetID());
-          std::lock_guard dm_lock(*local_dict_manager);
-          local_dict_manager->remove_index_id_reserved_for_create(index->get_gl_index_id());
-      }
-    }
 
     if (THDVAR(m_thd, trace_sst_api)) {
       LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
@@ -14904,7 +14922,7 @@ int ha_rocksdb::inplace_populate_sk(
 
     bool is_critical_error;
     res = tx->finish_bulk_load(&is_critical_error, true, new_table_arg,
-                               m_table_handler->m_table_name, &indexes);
+                               m_table_handler->m_table_name, index);
 
     if (res == ER_DUP_ENTRY) {
       assert(new_table_arg->key_info[index->get_keyno()].flags & HA_NOSAME);

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -320,7 +320,8 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
       const TABLE &table_arg, Rdb_tbl_def &tbl_def_arg,
       const std::string &actual_user_table_name, bool is_dd_tbl,
       const TABLE *const old_table_arg = nullptr,
-      const Rdb_tbl_def *const old_tbl_def_arg = nullptr) const;
+      const Rdb_tbl_def *const old_tbl_def_arg = nullptr,
+      bool is_secondary_index = false) const;
 
   int secondary_index_read(const int keyno, uchar *const buf,
                            const rocksdb::Slice *key,
@@ -716,7 +717,7 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
                                    const struct key_def_cf_info &cf_info,
                                    uint64 ttl_duration,
                                    const std::string &ttl_column,
-                                   bool is_dd_tbl = false) const;
+                                   bool is_dd_tbl = false, bool is_index = false) const;
 
   [[nodiscard]] bool create_inplace_key_defs(
       const TABLE &table_arg, Rdb_tbl_def &tbl_def_arg,

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5484,6 +5484,7 @@ bool Rdb_dict_manager::init(rocksdb::TransactionDB *const rdb_dict,
   assert(cf_manager != nullptr);
 
   mysql_mutex_init(0, &m_mutex, MY_MUTEX_INIT_FAST);
+  mysql_cond_init(0, &m_index_id_reserved_for_create_cond);
 
   m_db = rdb_dict;
 
@@ -5602,6 +5603,32 @@ void Rdb_dict_manager::delete_with_prefix(
   dump_index_id(&key_writer, dict_type, gl_index_id);
 
   delete_key(batch, key_writer.to_slice());
+}
+
+void Rdb_dict_manager::add_index_id_reserved_for_create(const GL_INDEX_ID &gl_index_id) {
+  assert_lock_held();
+  m_index_id_reserved_for_create.insert(gl_index_id);
+}
+
+void Rdb_dict_manager::remove_index_id_reserved_for_create(const GL_INDEX_ID &gl_index_id) {
+  assert_lock_held();
+  m_index_id_reserved_for_create.erase(gl_index_id);
+  mysql_cond_signal(&m_index_id_reserved_for_create_cond);
+}
+
+bool Rdb_dict_manager::has_conflicting_index_id_reserved_for_create(const GL_INDEX_ID &gl_index_id) const {
+  assert_lock_held();
+  auto is_conflicting = [&](const GL_INDEX_ID &other) {
+    return other.cf_id == gl_index_id.cf_id && other.index_id < gl_index_id.index_id;
+  };
+  return std::any_of(m_index_id_reserved_for_create.begin(), m_index_id_reserved_for_create.end(), is_conflicting);
+}
+
+void Rdb_dict_manager::wait_until_no_conflicting_index_ids_reserved_for_create(const GL_INDEX_ID &gl_index_id) const {
+  assert_lock_held();
+  while (has_conflicting_index_id_reserved_for_create(gl_index_id)) {
+    mysql_cond_wait(&m_index_id_reserved_for_create_cond, &m_mutex);
+  }
 }
 
 void Rdb_dict_manager::add_or_update_index_cf_mapping(

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -15,6 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #pragma once
 
+#include "mysql/components/services/bits/mysql_cond_bits.h"
 #define ROCKSDB_INCLUDE_VALIDATE_TABLES 1
 
 /* C++ standard header files */
@@ -1634,7 +1635,7 @@ class Rdb_ddl_manager : public Ensure_initialized {
 */
 class Rdb_dict_manager : public Ensure_initialized {
  private:
-  mysql_mutex_t m_mutex;
+  mutable mysql_mutex_t m_mutex;
   rocksdb::TransactionDB *m_db = nullptr;
   rocksdb::ColumnFamilyHandle *m_system_cfh = nullptr;
   /* Utility to put INDEX_INFO and CF_DEFINITION */
@@ -1644,6 +1645,21 @@ class Rdb_dict_manager : public Ensure_initialized {
 
   uchar m_key_buf_max_dd_index_id[Rdb_key_def::INDEX_NUMBER_SIZE] = {0};
   rocksdb::Slice m_key_slice_max_dd_index_id;
+
+  /* We prefer to track index id reservations for create index operations
+  in a separate set (not the one that tracks ongoing index operations).
+  This is because we don't want to add ongoing index create operations
+  to RocksDB earlier than necessary. The bulk load operations might
+  work on temporary files alone up until they need to ingest the data
+  into RocksDB, and at that point ongoing index create operations are
+  currently added to RocksDB. Before that happens this set tracks the
+  index ids reserved for future create index operations that are being
+  used in concurrent bulk load operations. Note, that in case of crash,
+  any unfinished temporary SST files will be dropped. */
+  std::unordered_set<GL_INDEX_ID> m_index_id_reserved_for_create;
+
+  /* Condition variable to wait until index id reservations are removed. */
+  mutable mysql_cond_t m_index_id_reserved_for_create_cond;
 
   static void dump_index_id(uchar *const netbuf,
                             Rdb_key_def::DATA_DICT_TYPE dict_type,
@@ -1681,6 +1697,7 @@ class Rdb_dict_manager : public Ensure_initialized {
 
   inline void cleanup() {
     if (!initialized) return;
+    mysql_cond_destroy(&m_index_id_reserved_for_create_cond);
     mysql_mutex_destroy(&m_mutex);
   }
 
@@ -1688,7 +1705,7 @@ class Rdb_dict_manager : public Ensure_initialized {
 
   inline void unlock() { RDB_MUTEX_UNLOCK_CHECK(m_mutex); }
 
-  inline void assert_lock_held() { mysql_mutex_assert_owner(&m_mutex); }
+  inline void assert_lock_held() const { mysql_mutex_assert_owner(&m_mutex); }
 
   inline rocksdb::ColumnFamilyHandle *get_system_cf() const {
     return m_system_cfh;
@@ -1704,6 +1721,12 @@ class Rdb_dict_manager : public Ensure_initialized {
   void delete_key(rocksdb::WriteBatchBase *batch,
                   const rocksdb::Slice &key) const;
   rocksdb::Iterator *new_iterator() const;
+
+  /* Index id reservation for create index (@see m_index_id_reserved_for_create) */
+  void add_index_id_reserved_for_create(const GL_INDEX_ID &gl_index_id);
+  void remove_index_id_reserved_for_create(const GL_INDEX_ID &gl_index_id);
+  bool has_conflicting_index_id_reserved_for_create(const GL_INDEX_ID &gl_index_id) const;
+  void wait_until_no_conflicting_index_ids_reserved_for_create(const GL_INDEX_ID &gl_index_id) const;
 
   /* Internal Index id => CF */
   void add_or_update_index_cf_mapping(

--- a/storage/rocksdb/rdb_sst_partitioner_factory.h
+++ b/storage/rocksdb/rdb_sst_partitioner_factory.h
@@ -315,6 +315,10 @@ class Rdb_bulk_load_index_registry {
     return success;
   }
 
+  bool empty() const {
+    return m_partitioner_factories.empty() && m_cf_indexes.empty();
+  }
+
   /**
    * returns true when we have index registered in
    * sst partitioner factory


### PR DESCRIPTION
Problem:

Concurrent ADD INDEX could lead to L0 level being polluted with the bulk-loaded data that was supposed to go to LMAX. Moreover, if the user has set rocksdb_bulk_load_fail_if_not_bottommost_level session variable to true, the server could crash when concurrently running ADD INDEX.

The same issues occurred when ADD INDEX was running while a new table was concurrently created.

Solution:

Serialize bulk loads together with all index id allocations so they could ingest SST files only having a guarantee that all RocksDB keys are the highest when inserted (to avoid the risk of collision with overlapping key ranges in merged SST files that include both smaller and higher index id values).

Wait when ingesting bulk-loaded SST, or when creating a table, until all bulk loads for the smaller index id are finished.