### PR TITLE
PS-11297 [8.0]: Patch-1: Avoid calling validate() in non-debug in rec_offs_*()

### DIFF
--- a/storage/innobase/include/rem0wrec.h
+++ b/storage/innobase/include/rem0wrec.h
@@ -153,7 +153,7 @@ void validate_rec_offset(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   /* Returns nonzero if the extern bit is set in nth field of rec. */
   return rec_offs_base(offsets)[1 + n] & REC_OFFS_EXTERNAL;
 }

--- a/storage/innobase/rem/rem0wrec.cc
+++ b/storage/innobase/rem/rem0wrec.cc
@@ -127,7 +127,7 @@ ulint rec_offs_nth_sql_null(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   return (rec_offs_nth_sql_null_low(offsets, n));
 }
 
@@ -137,7 +137,7 @@ ulint rec_offs_nth_default(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   return (rec_offs_nth_default_low(offsets, n));
 }
 
@@ -147,7 +147,7 @@ ulint rec_offs_nth_size(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   return (rec_offs_nth_size_low(offsets, n));
 }
 


### PR DESCRIPTION
release-8.0.42-33:

```
mysql> select state, count(*), avg(duration) as mean_duration, stddev(duration) as std_duration from information_schema.profiling where duration>0.001 group by state;
+-----------+----------+---------------+----------------------+
| state     | count(*) | mean_duration | std_duration         |
+-----------+----------+---------------+----------------------+
| executing |      100 |  0.7254109600 | 0.012709309582286532 |
+-----------+----------+---------------+----------------------+
1 row in set, 1 warning (0.00 sec)
```

release-8.0.28-20:

```
mysql> select state, count(*), avg(duration) as mean_duration, stddev(duration) as std_duration from information_schema.profiling where duration>0.001 group by state;
+-----------+----------+---------------+-----------------------+
| state     | count(*) | mean_duration | std_duration          |
+-----------+----------+---------------+-----------------------+
| executing |      100 |  0.6543798700 | 0.0035004976122117314 |
+-----------+----------+---------------+-----------------------+
1 row in set, 1 warning (0.00 sec)
```

Regression: ~10.87%

1. The ut_d(validate) patch for rem0wrec*.

release-8.0.42-33 + fix (ut_d(validate))

```
mysql> select state, count(*), avg(duration) as mean_duration, stddev(duration) as std_duration from information_schema.profiling where duration>0.001 group by state;
+-----------+----------+---------------+----------------------+
| state     | count(*) | mean_duration | std_duration         |
+-----------+----------+---------------+----------------------+
| executing |      100 |  0.6927929400 | 0.010106977520327243 |
+-----------+----------+---------------+----------------------+
1 row in set, 1 warning (0.01 sec)
```

Regression after fix: ~5.87%  (46% reduced). Also please note that this patch does not apply to 8.0.28 beacuse there was no rem0wrec* and in rem0rec* all validate() were already in ut_d(). So this fix indeed addresses part of regression that has been introduced between these two versions (it's not a side optimization).


Interesting finding: mysql client from 8.0.28 is slower - avg=0.69 for release-8.0.28-20 when using client from 8.0.28. That's out of scope for this examination. All results for this PR (including those above) are executed by the same mysql client version - the one from release-8.0.42-33.