### PR TITLE
PS-9616 [8.4] Inconsistent DDL behaviour for ALTER TABLE with INPLACE/INSTANT

### DIFF
--- a/mysql-test/suite/percona_innodb/r/ps_9616.result
+++ b/mysql-test/suite/percona_innodb/r/ps_9616.result
@@ -1,0 +1,233 @@
+# utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 2 steps
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar (10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+ALGORITHM=INPLACE;
+ALTER TABLE test_table COLLATE=utf8mb4_0900_ai_ci, ALGORITHM=INPLACE;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 1 step
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INPLACE;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# with indexed columns
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+INDEX(`field1`),
+INDEX(`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar (10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+ALGORITHM=INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+ALTER TABLE test_table COLLATE=utf8mb4_0900_ai_ci, ALGORITHM=INPLACE;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+  KEY `field1` (`field1`),
+  KEY `field2` (`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 1 step
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+INDEX(`field1`),
+INDEX(`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+  KEY `field1` (`field1`),
+  KEY `field2` (`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+DROP TABLE test_table;
+# ADD INDEX + AUTO_INCREMENT= in 1 step
+CREATE TABLE test_table (a INT, b INT) ENGINE=InnoDB;
+ALTER TABLE test_table ADD INDEX idx_b(b), AUTO_INCREMENT=7, ALGORITHM=INPLACE;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  KEY `idx_b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# DROP INDEX + COLLATE= in 1 step
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+INDEX(`field1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+DROP INDEX field1,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INPLACE;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+#
+# Same operations with ALGORITHM=INSTANT (pure metadata changes)
+#
+# utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 2 steps, INSTANT
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar (10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+ALGORITHM=INSTANT;
+ALTER TABLE test_table COLLATE=utf8mb4_0900_ai_ci, ALGORITHM=INSTANT;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 1 step, INSTANT
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INSTANT;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# indexed columns collation change with INSTANT must still be rejected
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+`field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+INDEX(`field1`),
+INDEX(`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+  KEY `field1` (`field1`),
+  KEY `field2` (`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+DROP TABLE test_table;
+# ADD INDEX + AUTO_INCREMENT= with INSTANT must be rejected (index work required)
+CREATE TABLE test_table (a INT, b INT) ENGINE=InnoDB;
+ALTER TABLE test_table ADD INDEX idx_b(b), AUTO_INCREMENT=7, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# DROP INDEX + COLLATE= with INSTANT must be rejected (index work required)
+CREATE TABLE `test_table`
+(
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+INDEX(`field1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+ALTER TABLE test_table
+DROP INDEX field1,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  KEY `field1` (`field1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+DROP TABLE test_table;
+# standalone AUTO_INCREMENT= with INSTANT (non-rebuild CREATE OPTION)
+CREATE TABLE test_table (a INT AUTO_INCREMENT PRIMARY KEY, b INT) ENGINE=InnoDB;
+ALTER TABLE test_table AUTO_INCREMENT=100, ALGORITHM=INSTANT;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `a` int NOT NULL AUTO_INCREMENT,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB AUTO_INCREMENT=100 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE test_table;
+# partitioned table: non-indexed column COLLATE change with INSTANT
+CREATE TABLE `test_table`
+(
+`id` int NOT NULL,
+`field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+PARTITION BY HASH(`id`) PARTITIONS 4;
+ALTER TABLE test_table
+MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+COLLATE=utf8mb4_0900_ai_ci,
+ALGORITHM=INSTANT;
+SHOW CREATE TABLE test_table;
+Table	Create Table
+test_table	CREATE TABLE `test_table` (
+  `id` int NOT NULL,
+  `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY HASH (`id`)
+PARTITIONS 4 */
+DROP TABLE test_table;

--- a/mysql-test/suite/percona_innodb/t/ps_9616.test
+++ b/mysql-test/suite/percona_innodb/t/ps_9616.test
@@ -1,0 +1,241 @@
+--echo # utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 2 steps
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
+# ha_alter_info->handler_flags = ALTER_COLUMN_EQUAL_PACK_LENGTH & ALTER_COLUMN_DEFAULT
+ALTER TABLE test_table
+    MODIFY field1 varchar (10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ALGORITHM=INPLACE;
+
+# ha_alter_info->handler_flags = CHANGE_CREATE_OPTION
+ALTER TABLE test_table COLLATE=utf8mb4_0900_ai_ci, ALGORITHM=INPLACE;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 1 step
+# before the patch, this innodb created a new table
+# check with SET GLOBAL innodb_print_ddl_logs = ON; SET GLOBAL log_error_verbosity = 3;
+
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+# ha_alter_info->handler_flags = ALTER_COLUMN_EQUAL_PACK_LENGTH & ALTER_COLUMN_DEFAULT & CHANGE_CREATE_OPTION
+ALTER TABLE test_table
+    MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INPLACE;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+--echo # with indexed columns
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    INDEX(`field1`),
+    INDEX(`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE test_table
+    MODIFY field1 varchar (10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ALGORITHM=INPLACE;
+
+ALTER TABLE test_table COLLATE=utf8mb4_0900_ai_ci, ALGORITHM=INPLACE;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 1 step
+# before the patch, innodb created a new table
+# check with SET GLOBAL innodb_print_ddl_logs = ON; SET GLOBAL log_error_verbosity = 3;
+
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    INDEX(`field1`),
+    INDEX(`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE test_table
+    MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INPLACE;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+# Verify that combining ADD INDEX with AUTO_INCREMENT= does not crash the
+# server (regression: INNOBASE_INPLACE_NO_REBUILD incorrectly masked ADD_INDEX,
+# causing prepare/alter to early-exit while commit tried to find the unbuilt index).
+--echo # ADD INDEX + AUTO_INCREMENT= in 1 step
+CREATE TABLE test_table (a INT, b INT) ENGINE=InnoDB;
+
+ALTER TABLE test_table ADD INDEX idx_b(b), AUTO_INCREMENT=7, ALGORITHM=INPLACE;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+# Verify that combining DROP INDEX with COLLATE= in one INPLACE
+# step does not silently discard the index drop.
+--echo # DROP INDEX + COLLATE= in 1 step
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    INDEX(`field1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+ALTER TABLE test_table
+    DROP INDEX field1,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INPLACE;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo #
+--echo # Same operations with ALGORITHM=INSTANT (pure metadata changes)
+--echo #
+
+--echo # utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 2 steps, INSTANT
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+# ha_alter_info->handler_flags = ALTER_COLUMN_EQUAL_PACK_LENGTH & ALTER_COLUMN_DEFAULT
+ALTER TABLE test_table
+    MODIFY field1 varchar (10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ALGORITHM=INSTANT;
+
+# ha_alter_info->handler_flags = CHANGE_CREATE_OPTION
+ALTER TABLE test_table COLLATE=utf8mb4_0900_ai_ci, ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # utf8mb4_general_ci ===>>> utf8mb4_0900_ai_ci ### in 1 step, INSTANT
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+# ha_alter_info->handler_flags = ALTER_COLUMN_EQUAL_PACK_LENGTH & ALTER_COLUMN_DEFAULT & CHANGE_CREATE_OPTION
+ALTER TABLE test_table
+    MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # indexed columns collation change with INSTANT must still be rejected
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `field2` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    INDEX(`field1`),
+    INDEX(`field2`(10))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE test_table
+    MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    MODIFY field2 text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # ADD INDEX + AUTO_INCREMENT= with INSTANT must be rejected (index work required)
+CREATE TABLE test_table (a INT, b INT) ENGINE=InnoDB;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE test_table ADD INDEX idx_b(b), AUTO_INCREMENT=7, ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # DROP INDEX + COLLATE= with INSTANT must be rejected (index work required)
+CREATE TABLE `test_table`
+(
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    INDEX(`field1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE test_table
+    DROP INDEX field1,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # standalone AUTO_INCREMENT= with INSTANT (non-rebuild CREATE OPTION)
+CREATE TABLE test_table (a INT AUTO_INCREMENT PRIMARY KEY, b INT) ENGINE=InnoDB;
+
+ALTER TABLE test_table AUTO_INCREMENT=100, ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;
+
+
+--echo # partitioned table: non-indexed column COLLATE change with INSTANT
+CREATE TABLE `test_table`
+(
+    `id` int NOT NULL,
+    `field1` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+PARTITION BY HASH(`id`) PARTITIONS 4;
+
+ALTER TABLE test_table
+    MODIFY field1 varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+    COLLATE=utf8mb4_0900_ai_ci,
+    ALGORITHM=INSTANT;
+
+SHOW CREATE TABLE test_table;
+
+DROP TABLE test_table;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -931,10 +931,12 @@ static inline bool is_instant(const Alter_inplace_info *ha_alter_info) {
     return (false);
   }
 
-  Alter_inplace_info::HA_ALTER_FLAGS alter_inplace_flags =
-      ha_alter_info->handler_flags & ~(INNOBASE_INPLACE_IGNORE);
+  bool has_change_create_option =
+      (ha_alter_info->handler_flags & ~INNOBASE_INPLACE_IGNORE &
+       ~Alter_inplace_info::ALTER_COLUMN_EQUAL_PACK_LENGTH) ==
+      Alter_inplace_info::CHANGE_CREATE_OPTION;
 
-  if (alter_inplace_flags == Alter_inplace_info::CHANGE_CREATE_OPTION &&
+  if (has_change_create_option &&
       !(ha_alter_info->create_info->used_fields &
         (HA_CREATE_USED_ROW_FORMAT | HA_CREATE_USED_KEY_BLOCK_SIZE |
          HA_CREATE_USED_TABLESPACE))) {
@@ -1102,6 +1104,40 @@ enum_alter_inplace_result ha_innobase::check_if_supported_inplace_alter(
       case Instant_Type::INSTANT_COLUMN_RENAME:
         ha_alter_info->handler_trivial_ctx = instant_type_to_int(instant_type);
         return HA_ALTER_INPLACE_INSTANT;
+    }
+  }
+
+  /* A change of only the column collation (ALTER_COLUMN_EQUAL_PACK_LENGTH is
+  set instead of ALTER_STORED_COLUMN_TYPE precisely when the column is not
+  indexed) and/or CREATE OPTIONs that do not require a table rebuild
+  (table-level COLLATE, AUTO_INCREMENT, COMMENT, ...) is a metadata-only change.
+  It is already performed in-place without rebuilding the table, so report it as
+  INSTANT in order to accept an explicit ALGORITHM=INSTANT request.
+
+  Note we deliberately do NOT set handler_trivial_ctx here: is_instant() stays
+  false so the regular no-rebuild commit path runs, which correctly updates the
+  in-memory column metadata (length/charset), AUTO_INCREMENT and other CREATE
+  OPTIONs. Routing these through the instant commit executor would skip those
+  fix-ups. error_if_not_empty is excluded because the SQL layer forbids INSTANT
+  in that case (see assert in mysql_inplace_alter_table()). */
+  {
+    const Alter_inplace_info::HA_ALTER_FLAGS meta_only_flags =
+        ha_alter_info->handler_flags & ~INNOBASE_INPLACE_IGNORE;
+    /** CREATE OPTIONs which are not pure metadata as far as ALGORITHM=INSTANT
+     is concerned. Engine attributes are opaque values a (secondary) engine may
+     need to act on, so an explicit ALGORITHM=INSTANT for them must be
+     rejected, (see main.engine_attribute / main.engine_attribute_debug). */
+    const uint64_t INNOBASE_NON_INSTANT_CREATE_OPTIONS =
+        HA_CREATE_USED_ENGINE_ATTRIBUTE |
+        HA_CREATE_USED_SECONDARY_ENGINE_ATTRIBUTE;
+    if (meta_only_flags != 0 && !ha_alter_info->error_if_not_empty &&
+        (meta_only_flags &
+         ~(Alter_inplace_info::ALTER_COLUMN_EQUAL_PACK_LENGTH |
+           Alter_inplace_info::CHANGE_CREATE_OPTION)) == 0 &&
+        !(ha_alter_info->create_info->used_fields &
+          INNOBASE_NON_INSTANT_CREATE_OPTIONS) &&
+        !innobase_need_rebuild(ha_alter_info)) {
+      return HA_ALTER_INPLACE_INSTANT;
     }
   }
 
@@ -5960,7 +5996,8 @@ bool ha_innobase::prepare_inplace_alter_table_impl(
   }
 
   if (!(ha_alter_info->handler_flags & INNOBASE_ALTER_DATA) ||
-      ((ha_alter_info->handler_flags & ~INNOBASE_INPLACE_IGNORE) ==
+      ((ha_alter_info->handler_flags & ~INNOBASE_INPLACE_IGNORE &
+        ~Alter_inplace_info::ALTER_COLUMN_EQUAL_PACK_LENGTH) ==
            Alter_inplace_info::CHANGE_CREATE_OPTION &&
        !innobase_need_rebuild(ha_alter_info))) {
     if (heap) {
@@ -6002,9 +6039,8 @@ bool ha_innobase::prepare_inplace_alter_table_impl(
       }
       return dd_prepare_inplace_alter_table(m_user_thd, ctx->old_table,
                                             ctx->new_table, old_dd_tab);
-    } else {
-      return false;
     }
+    return false;
   }
 
   /* If we are to build a full-text search index, check whether
@@ -6214,7 +6250,8 @@ bool ha_innobase::inplace_alter_table_impl(TABLE *altered_table,
     return all_ok();
   }
 
-  if (((ha_alter_info->handler_flags & ~INNOBASE_INPLACE_IGNORE) ==
+  if (((ha_alter_info->handler_flags & ~INNOBASE_INPLACE_IGNORE &
+        ~Alter_inplace_info::ALTER_COLUMN_EQUAL_PACK_LENGTH) ==
            Alter_inplace_info::CHANGE_CREATE_OPTION &&
        !innobase_need_rebuild(ha_alter_info))) {
     return all_ok();


### PR DESCRIPTION
PS-9616 [8.4] Inconsistent DDL behaviour for ALTER TABLE with INPLACE/INSTANT
https://perconadev.atlassian.net/browse/PS-9616

Changing the COLLATE attribute of a non-indexed column (and/or the
table's default COLLATE) is a metadata-only change: the stored bytes
are unchanged and, since the column is not indexed, no index reordering
is required. InnoDB, however, handled these operations inconsistently.

INPLACE: when the column COLLATE change and the table-level COLLATE=
change were issued in a single ALTER statement, InnoDB switched to
rebuilding the table even though a rebuild is unnecessary. The
algorithm-selection checks only recognised CHANGE_CREATE_OPTION on its
own and did not account for ALTER_COLUMN_EQUAL_PACK_LENGTH being present
at the same time. Fix the checks in innobase_need_rebuild() and in the
prepare/inplace phases to mask out ALTER_COLUMN_EQUAL_PACK_LENGTH as
well, so the combined statement is done in-place without a rebuild.
Indexed columns are unaffected: they set ALTER_STORED_COLUMN_TYPE
instead of ALTER_COLUMN_EQUAL_PACK_LENGTH and continue to be rejected
("Cannot change column type").

INSTANT: the same metadata-only changes were rejected under
ALGORITHM=INSTANT even though they touch no data.
ha_innobase::check_if_supported_inplace_alter() now reports
HA_ALTER_INPLACE_INSTANT when the only handler flags are a subset of
{ALTER_COLUMN_EQUAL_PACK_LENGTH, CHANGE_CREATE_OPTION} and the change
needs no rebuild (innobase_need_rebuild() is false, which already
excludes ROW_FORMAT, KEY_BLOCK_SIZE and TABLESPACE changes).

Crucially this does NOT set handler_trivial_ctx, so is_instant() stays
false and the regular no-rebuild commit path runs (commit_get_autoinc /
commit_try_norebuild / innobase_rename_or_enlarge_columns_cache). That
path correctly updates the in-memory column metadata (length/charset),
AUTO_INCREMENT and other CREATE OPTIONs. The instant commit executor
(commit_instant_ddl) is built only for genuine no-change / rename /
virtual / add-drop-column cases and must not be used here, as it would
skip those fix-ups (e.g. leaving col->len stale and tripping the rem0rec
length assertion, or ignoring AUTO_INCREMENT=). Reporting INSTANT while
executing in-place is explicitly sanctioned by the SQL layer, which
treats HA_ALTER_INPLACE_INSTANT and HA_ALTER_INPLACE_NO_LOCK
identically. Partitioned tables are covered automatically:
ha_innopart::check_if_supported_inplace_alter() delegates to the
ha_innobase implementation for the non-instant case.