### PR TITLE
PS-9704 [8.0]: Escape all RFC 4515 special chars in LDAP filter substitutions

### DIFF
--- a/plugin/auth_ldap/src/connection.cc
+++ b/plugin/auth_ldap/src/connection.cc
@@ -22,6 +22,37 @@
 #include "plugin/auth_ldap/include/plugin_log.h"
 
 namespace {
+
+// RFC 4515 §3 requires these five octets to be escaped as \XX
+// when they appear in an LDAP filter assertion value:
+//   NUL (0x00), LPAREN (0x28), RPAREN (0x29), ASTERISK (0x2a), ESC (0x5c)
+std::string ldap_filter_escape(const std::string &input) {
+  std::string out;
+  out.reserve(input.size() * 3);  // worst case every byte becomes "\XX"
+
+  for (char c : input) {
+    switch (c) {
+      case '(':
+        out += "\\28";
+        break;
+      case ')':
+        out += "\\29";
+        break;
+      case '*':
+        out += "\\2a";
+        break;
+      case '\\':
+        out += "\\5c";
+        break;
+      default:
+        out.push_back(c);
+        break;
+    }
+  }
+
+  return out;
+}
+
 // example of this callback is in the OpenLDAP's
 // servers/slapd/back-meta/bind.c (meta_back_default_urllist)
 int cb_urllist_proc(LDAP * /* ld */, LDAPURLDesc **urllist, LDAPURLDesc **url,
@@ -247,7 +278,7 @@ std::string Connection::search_dn(const std::string &user_name,
 
   std::string str;
   std::ostringstream log_stream;
-  std::string filter = user_search_attr + "=" + user_name;
+  std::string filter = user_search_attr + "=" + ldap_filter_escape(user_name);
 
   log_stream << "search_dn(" << base_dn << ", " << filter << ")";
   log_srv_dbg(log_stream.str());
@@ -306,10 +337,10 @@ groups_t Connection::search_groups(const std::string &user_name,
 
   groups_t list;
   std::stringstream log_stream;
-  std::string filter = std::regex_replace(group_search_filter,
-                                          std::regex("\\{UA\\}"), user_name);
-  std::string escaped_user_dn =
-      std::regex_replace(user_dn, std::regex("\\\\\""), "\\\\\"");
+  std::string escaped_user_name = ldap_filter_escape(user_name);
+  std::string escaped_user_dn = ldap_filter_escape(user_dn);
+  std::string filter = std::regex_replace(
+      group_search_filter, std::regex("\\{UA\\}"), escaped_user_name);
   filter = std::regex_replace(filter, std::regex("\\{UD\\}"), escaped_user_dn);
 
   LDAPMessage *l_result;

--- a/plugin/auth_ldap/tests/mtr/asterisk_test_user.ldif
+++ b/plugin/auth_ldap/tests/mtr/asterisk_test_user.ldif
@@ -1,0 +1,6 @@
+dn: cn=Test*User,ou=people,dc=planetexpress,dc=com
+objectClass: inetOrgPerson
+cn: Test*User
+sn: User
+uid: testasteriskuser
+userPassword: testpass123

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple_quote_dn-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple_quote_dn-master.opt
@@ -1,0 +1,6 @@
+$AUTH_LDAP_OPT $AUTH_LDAP_LOAD
+--authentication_ldap_simple_server_host='$MTR_LDAP_HOST'
+--authentication_ldap_simple_server_port=$MTR_LDAP_PORT
+--authentication_ldap_simple_fallback_server_host='$MTR_LDAP_FALLBACK_HOST'
+--authentication_ldap_simple_fallback_server_port=$MTR_LDAP_FALLBACK_PORT
+--authentication_ldap_simple_bind_root_pwd='GoodNewsEveryone'

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple_quote_dn.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple_quote_dn.result
@@ -1,0 +1,48 @@
+SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
+SET GLOBAL authentication_ldap_simple_group_search_filter = '(&(objectClass=groupOfNames)(member={UD}))';
+CREATE ROLE 'test_dn_role';
+SET GLOBAL authentication_ldap_simple_group_role_mapping = 'dn_test_group=test_dn_role';
+SET GLOBAL authentication_ldap_simple_log_status = 6;
+SET @old_sql_mode = @@SESSION.sql_mode;
+SET SESSION sql_mode = REPLACE(REPLACE(@@SESSION.sql_mode, 'NO_BACKSLASH_ESCAPES', ''), ',,', ',');
+CREATE USER normaluser IDENTIFIED WITH authentication_ldap_simple BY 'cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com';
+# Test 1: Normal user - role should be granted
+SHOW GRANTS FOR 'normaluser';
+Grants for normaluser@%
+GRANT USAGE ON *.* TO `normaluser`@`%`
+GRANT `test_dn_role`@`%` TO `normaluser`@`%`
+CREATE USER quoteduser IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test\\"User,ou=people,dc=planetexpress,dc=com';
+# Test 2: Quoted-DN user - role should be granted
+SHOW GRANTS FOR 'quoteduser';
+Grants for quoteduser@%
+GRANT USAGE ON *.* TO `quoteduser`@`%`
+GRANT `test_dn_role`@`%` TO `quoteduser`@`%`
+CREATE USER parentheses_user IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test(User),ou=people,dc=planetexpress,dc=com';
+# Test 3: Parentheses-DN user - role should be granted
+SHOW GRANTS FOR 'parentheses_user';
+Grants for parentheses_user@%
+GRANT USAGE ON *.* TO `parentheses_user`@`%`
+GRANT `test_dn_role`@`%` TO `parentheses_user`@`%`
+CREATE USER asterisk_user IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test*User,ou=people,dc=planetexpress,dc=com';
+# Test 4: Asterisk-DN user - role should be granted
+SHOW GRANTS FOR 'asterisk_user';
+Grants for asterisk_user@%
+GRANT USAGE ON *.* TO `asterisk_user`@`%`
+GRANT `test_dn_role`@`%` TO `asterisk_user`@`%`
+CREATE USER backslash_user IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test\\5cUser,ou=people,dc=planetexpress,dc=com';
+# Test 5: Backslash-DN user - role should be granted
+SHOW GRANTS FOR 'backslash_user';
+Grants for backslash_user@%
+GRANT USAGE ON *.* TO `backslash_user`@`%`
+GRANT `test_dn_role`@`%` TO `backslash_user`@`%`
+DROP USER normaluser;
+DROP USER quoteduser;
+DROP USER parentheses_user;
+DROP USER asterisk_user;
+DROP USER backslash_user;
+DROP ROLE test_dn_role;
+SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
+SET GLOBAL authentication_ldap_simple_log_status = 1;
+SET GLOBAL authentication_ldap_simple_group_role_mapping = '';
+SET GLOBAL authentication_ldap_simple_group_search_filter = '(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))';
+SET SESSION sql_mode = @old_sql_mode;

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple_quote_dn.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple_quote_dn.test
@@ -1,0 +1,235 @@
+# Test: Validate LDAP group-role mapping when user DN contains characters
+# that are special in LDAP filter syntax (RFC 4515).
+#
+# Background:
+#   The plugin substitutes {UD} with the authenticated user's DN in
+#   authentication_ldap_simple_group_search_filter.  Per RFC 4515 §3,
+#   five ASCII octets must be escaped as \XX hex when they appear inside
+#   an LDAP filter assertion value:
+#     NUL (0x00), '(' (0x28), ')' (0x29), '*' (0x2a), '\' (0x5c)
+#
+# Purpose of this test:
+#   Verify that role mapping works for all of these users in the same LDAP group:
+#   1. Normal DN (no special chars in CN)
+#   2. DN containing double quote  (cn=Test"User)
+#   3. DN containing parentheses   (cn=Test(User))
+#   4. DN containing asterisk       (cn=Test*User)
+#   5. DN containing backslash      (cn=Test\5cUser — LDAP-escaped form of Test\User)
+#
+# Expected result:
+#   All five users authenticate successfully and are granted test_dn_role.
+#
+# Requires docker-test-openldap:
+#   https://github.com/rroemhild/docker-test-openldap
+
+--source include/count_sessions.inc
+
+# -----------------------------------------------------------------
+# LDAP Setup: add users with special chars in CN and a groupOfNames group
+# -----------------------------------------------------------------
+--perl EOF
+  use strict;
+  use warnings;
+
+  sub run_cmd {
+    my @cmd = @_;
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+    if ($pid == 0) {
+      open(STDOUT, '>', '/dev/null');
+      open(STDERR, '>', '/dev/null');
+      exec(@cmd) or exit(127);
+    }
+    waitpid($pid, 0);
+    return $? >> 8;
+  }
+
+  my $host     = $ENV{'MTR_LDAP_HOST'} || 'localhost';
+  my $port     = $ENV{'MTR_LDAP_PORT'} || '389';
+  my $ldap_uri = "ldap://$host:$port";
+  my $admin_dn = 'cn=admin,dc=planetexpress,dc=com';
+  my $admin_pw = 'GoodNewsEveryone';
+  my $test_dir = $ENV{'MYSQL_TEST_DIR'} . '/../plugin/auth_ldap/tests/mtr';
+  my $user_ldif         = "$test_dir/quote_test_user.ldif";
+  my $paren_user_ldif   = "$test_dir/paren_test_user.ldif";
+  my $asterisk_user_ldif = "$test_dir/asterisk_test_user.ldif";
+  my $backslash_user_ldif = "$test_dir/backslash_test_user.ldif";
+  my $group_ldif        = "$test_dir/test_group.ldif";
+
+  # Remove leftover entries from any previous failed run
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=dn_test_group,ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test\"User,ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test(User),ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test*User,ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test\5cUser,ou=people,dc=planetexpress,dc=com');
+
+  # Create the test entries
+  my $rc;
+  $rc = run_cmd("ldapadd", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+                "-w", $admin_pw, "-f", $user_ldif);
+  die "ldapadd (quote user) failed rc=$rc" if $rc != 0;
+
+  $rc = run_cmd("ldapadd", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+                "-w", $admin_pw, "-f", $paren_user_ldif);
+  die "ldapadd (paren user) failed rc=$rc" if $rc != 0;
+
+  $rc = run_cmd("ldapadd", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+                "-w", $admin_pw, "-f", $asterisk_user_ldif);
+  die "ldapadd (asterisk user) failed rc=$rc" if $rc != 0;
+
+  $rc = run_cmd("ldapadd", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+                "-w", $admin_pw, "-f", $backslash_user_ldif);
+  die "ldapadd (backslash user) failed rc=$rc" if $rc != 0;
+
+  $rc = run_cmd("ldapadd", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+                "-w", $admin_pw, "-f", $group_ldif);
+  die "ldapadd (group) failed rc=$rc" if $rc != 0;
+EOF
+
+# -----------------------------------------------------------------
+# MySQL Setup
+# -----------------------------------------------------------------
+SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
+
+# Use a DN-based filter so {UD} substitution is exercised
+SET GLOBAL authentication_ldap_simple_group_search_filter = '(&(objectClass=groupOfNames)(member={UD}))';
+
+CREATE ROLE 'test_dn_role';
+SET GLOBAL authentication_ldap_simple_group_role_mapping = 'dn_test_group=test_dn_role';
+
+SET GLOBAL authentication_ldap_simple_log_status = 6;
+
+# Ensure backslash escapes in SQL string literals are interpreted as expected
+SET @old_sql_mode = @@SESSION.sql_mode;
+SET SESSION sql_mode = REPLACE(REPLACE(@@SESSION.sql_mode, 'NO_BACKSLASH_ESCAPES', ''), ',,', ',');
+
+# -----------------------------------------------------------------
+# Test 1: Normal user whose DN has no special characters.
+#   Expected: role IS granted.
+# -----------------------------------------------------------------
+CREATE USER normaluser IDENTIFIED WITH authentication_ldap_simple BY 'cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com';
+
+--connect (con_normal,localhost,normaluser,hermes,,,,CLEARTEXT)
+--echo # Test 1: Normal user - role should be granted
+SHOW GRANTS FOR 'normaluser';
+--disconnect con_normal
+--connection default
+
+# -----------------------------------------------------------------
+# Test 2: User whose DN contains a double-quote.
+#   Expected: role IS granted.
+# -----------------------------------------------------------------
+CREATE USER quoteduser IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test\\"User,ou=people,dc=planetexpress,dc=com';
+
+--connect (con_quoted,localhost,quoteduser,testpass123,,,,CLEARTEXT)
+--echo # Test 2: Quoted-DN user - role should be granted
+SHOW GRANTS FOR 'quoteduser';
+--disconnect con_quoted
+--connection default
+
+# -----------------------------------------------------------------
+# Test 3: User whose DN contains parentheses.
+#   Expected: role IS granted.
+# -----------------------------------------------------------------
+CREATE USER parentheses_user IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test(User),ou=people,dc=planetexpress,dc=com';
+
+--connect (con_parentheses,localhost,parentheses_user,testpass123,,,,CLEARTEXT)
+--echo # Test 3: Parentheses-DN user - role should be granted
+SHOW GRANTS FOR 'parentheses_user';
+--disconnect con_parentheses
+--connection default
+
+# -----------------------------------------------------------------
+# Test 4: User whose DN contains an asterisk.
+#   Expected: role IS granted.
+# -----------------------------------------------------------------
+CREATE USER asterisk_user IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test*User,ou=people,dc=planetexpress,dc=com';
+
+--connect (con_asterisk,localhost,asterisk_user,testpass123,,,,CLEARTEXT)
+--echo # Test 4: Asterisk-DN user - role should be granted
+SHOW GRANTS FOR 'asterisk_user';
+--disconnect con_asterisk
+--connection default
+
+# -----------------------------------------------------------------
+# Test 5: User whose DN contains a backslash.
+#   The LDAP DN uses \5c to represent a literal backslash in the CN.
+#   Expected: role IS granted.
+# -----------------------------------------------------------------
+CREATE USER backslash_user IDENTIFIED WITH authentication_ldap_simple BY 'cn=Test\\5cUser,ou=people,dc=planetexpress,dc=com';
+
+--connect (con_backslash,localhost,backslash_user,testpass123,,,,CLEARTEXT)
+--echo # Test 5: Backslash-DN user - role should be granted
+SHOW GRANTS FOR 'backslash_user';
+--disconnect con_backslash
+--connection default
+
+# -----------------------------------------------------------------
+# MySQL Cleanup
+# -----------------------------------------------------------------
+DROP USER normaluser;
+DROP USER quoteduser;
+DROP USER parentheses_user;
+DROP USER asterisk_user;
+DROP USER backslash_user;
+DROP ROLE test_dn_role;
+SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
+SET GLOBAL authentication_ldap_simple_log_status = 1;
+SET GLOBAL authentication_ldap_simple_group_role_mapping = '';
+SET GLOBAL authentication_ldap_simple_group_search_filter = '(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))';
+SET SESSION sql_mode = @old_sql_mode;
+
+# -----------------------------------------------------------------
+# LDAP Cleanup
+# -----------------------------------------------------------------
+--perl EOF
+  use strict;
+  use warnings;
+
+  sub run_cmd {
+    my @cmd = @_;
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+    if ($pid == 0) {
+      open(STDOUT, '>', '/dev/null');
+      open(STDERR, '>', '/dev/null');
+      exec(@cmd) or exit(127);
+    }
+    waitpid($pid, 0);
+    return $? >> 8;
+  }
+
+  my $host     = $ENV{'MTR_LDAP_HOST'} || 'localhost';
+  my $port     = $ENV{'MTR_LDAP_PORT'} || '389';
+  my $ldap_uri = "ldap://$host:$port";
+  my $admin_dn = 'cn=admin,dc=planetexpress,dc=com';
+  my $admin_pw = 'GoodNewsEveryone';
+
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=dn_test_group,ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test\"User,ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test(User),ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test*User,ou=people,dc=planetexpress,dc=com');
+  run_cmd("ldapdelete", "-x", "-H", $ldap_uri, "-D", $admin_dn,
+          "-w", $admin_pw,
+          'cn=Test\5cUser,ou=people,dc=planetexpress,dc=com');
+EOF
+
+--source include/wait_until_count_sessions.inc

--- a/plugin/auth_ldap/tests/mtr/backslash_test_user.ldif
+++ b/plugin/auth_ldap/tests/mtr/backslash_test_user.ldif
@@ -1,0 +1,6 @@
+dn: cn=Test\5cUser,ou=people,dc=planetexpress,dc=com
+objectClass: inetOrgPerson
+cn: Test\5cUser
+sn: User
+uid: testbackslashuser
+userPassword: testpass123

--- a/plugin/auth_ldap/tests/mtr/paren_test_user.ldif
+++ b/plugin/auth_ldap/tests/mtr/paren_test_user.ldif
@@ -1,0 +1,6 @@
+dn: cn=Test(User),ou=people,dc=planetexpress,dc=com
+objectClass: inetOrgPerson
+cn: Test(User)
+sn: User
+uid: testparenuser
+userPassword: testpass123

--- a/plugin/auth_ldap/tests/mtr/quote_test_user.ldif
+++ b/plugin/auth_ldap/tests/mtr/quote_test_user.ldif
@@ -1,0 +1,6 @@
+dn: cn=Test\"User,ou=people,dc=planetexpress,dc=com
+objectClass: inetOrgPerson
+cn: Test"User
+sn: User
+uid: testquoteuser
+userPassword: testpass123

--- a/plugin/auth_ldap/tests/mtr/test_group.ldif
+++ b/plugin/auth_ldap/tests/mtr/test_group.ldif
@@ -1,0 +1,8 @@
+dn: cn=dn_test_group,ou=people,dc=planetexpress,dc=com
+objectClass: groupOfNames
+cn: dn_test_group
+member: cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com
+member: cn=Test\"User,ou=people,dc=planetexpress,dc=com
+member: cn=Test(User),ou=people,dc=planetexpress,dc=com
+member: cn=Test*User,ou=people,dc=planetexpress,dc=com
+member: cn=Test\5cUser,ou=people,dc=planetexpress,dc=com

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -4080,14 +4080,17 @@ int acl_authenticate(THD *thd, enum_server_command command) {
                                 std::string(acl_user->host.get_host()));
         if (g_external_roles.find(u) != g_external_roles.end())
           g_external_roles[u].clear();
-        for (const auto &role : external_roles) {
-          ACL_USER *acl_role = find_acl_user("", role.c_str(), false);
-          if (acl_role != nullptr && acl_role->user != nullptr) {
-            grant_role(acl_role, acl_user, false);
-            const name_and_host_t r(std::string(acl_role->user), "");
-            g_external_roles[u].push_back(r);
+        ACL_USER *cached_acl_user =
+            find_acl_user(acl_user->host.get_host(), acl_user->user, true);
+        if (cached_acl_user != nullptr)
+          for (const auto &role : external_roles) {
+            ACL_USER *acl_role = find_acl_user("", role.c_str(), false);
+            if (acl_role != nullptr && acl_role->user != nullptr) {
+              grant_role(acl_role, cached_acl_user, false);
+              const name_and_host_t r(std::string(acl_role->user), "");
+              g_external_roles[u].push_back(r);
+            }
           }
-        }
       }
       /* Assign default role */
       {
@@ -4290,7 +4293,7 @@ int acl_authenticate(THD *thd, enum_server_command command) {
   ret = 0;
 end:
   if (mpvio.restrictions) mpvio.restrictions->~Restrictions();
-    /* Ready to handle queries */
+  /* Ready to handle queries */
 #ifdef HAVE_PSI_THREAD_INTERFACE
   LEX_CSTRING main_sctx_user = thd->m_main_security_ctx.user();
   LEX_CSTRING main_sctx_host_or_ip = thd->m_main_security_ctx.host_or_ip();


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9704

User-supplied values (user_name, user_dn) substituted into LDAP search
filters via {UA} and {UD} were not properly escaped. Only double-quote
received a partial treatment; parentheses, asterisk, and backslash were
passed through verbatim, producing malformed filters that silently broke
group lookups for users whose DN contained those characters.

Add ldap_filter_escape() which applies the mandatory RFC 4515 §3 \XX
hex encoding for LPAREN (\28), RPAREN (\29), ASTERISK (\2a), and
ESC (\5c). Apply it to all three substitution sites: search_dn() for
user_name, and search_groups() for both {UA} (user_name) and {UD}
(user_dn).

Fix heap-use-after-free when granting external roles during login.
acl_authenticate() was calling grant_role() with the acl_user pointer
from mpvio, which is a copy allocated on the connection's mem_root and
freed when the command ends. grant_role() stores ACL_USER by value in
the role graph, retaining the raw user/host char* pointers. Subsequent
DROP USER walks that graph and dereferences those freed pointers, causing
corrupted reads and Warning 1366 on the role_edges table columns.

Fix: look up the durable ACL cache entry via find_acl_user() and pass
that to grant_role() instead of the mem_root copy. This ensures the
role graph holds pointers that remain valid for the lifetime of the
ACL cache.

MTR test exercises DN containing a double-quote, parentheses, an
asterisk, and a backslash — all expected to authenticate and receive
their group role via the dn_test_group groupOfNames entry.