### PR TITLE
Ps 10070 9.x Using new KMIP C++ library in keyring_kmip component, tests fixes

### DIFF
--- a/components/keyrings/keyring_kmip/CMakeLists.txt
+++ b/components/keyrings/keyring_kmip/CMakeLists.txt
@@ -76,7 +76,7 @@ SET(KEYRING_KMIP_LIBRARIES
   keyring_common
   OpenSSL::SSL
   OpenSSL::Crypto
-  kmippp
+  kmipclient
 )
 
 MYSQL_ADD_COMPONENT(keyring_kmip
@@ -84,6 +84,14 @@ MYSQL_ADD_COMPONENT(keyring_kmip
   LINK_LIBRARIES ${KEYRING_KMIP_LIBRARIES}
   MODULE_ONLY
 )
+
+IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # kmipclient public headers currently emit these diagnostics under strict
+  # server flags; keep suppression target-local instead of source pragmas.
+  TARGET_COMPILE_OPTIONS(component_keyring_kmip PRIVATE
+    -Wno-extra-semi
+    -Wno-overloaded-virtual)
+ENDIF()
 
 TARGET_LINK_OPTIONS(component_keyring_kmip PRIVATE "${LINK_FLAG_NO_UNDEFINED}")
 

--- a/components/keyrings/keyring_kmip/backend/backend.cc
+++ b/components/keyrings/keyring_kmip/backend/backend.cc
@@ -20,17 +20,16 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#include <cassert>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 
 #include "backend.h"
+#include "kmipclient/Kmip.hpp"
 
 #include <mysql/components/minimal_chassis.h>
 
 #include <components/keyrings/common/data/data_extension.h>
-#include <components/keyrings/common/memstore/cache.h>
-#include <components/keyrings/common/memstore/iterator.h>
 #include <components/keyrings/common/utils/utils.h>
 #include <mysql/components/services/log_builtins.h>
 #include <mysqld_error.h>
@@ -45,10 +44,23 @@ using keyring_common::meta::Metadata;
 using keyring_common::utils::get_random_data;
 
 Keyring_kmip_backend::Keyring_kmip_backend(config::Config_pod const &config)
-    : valid_(false), config_(config) {
+    : valid_(false),
+      config_(config),
+      kmip_client_(nullptr),
+      expected_cacheable_size_(std::nullopt) {
+  std::string missing_options;
+  if (!validate_required_config(config_, missing_options)) {
+    std::string err_msg =
+        "Can not initialize KMIP backend. Missing required config options: " +
+        missing_options;
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+    valid_ = false;
+    return;
+  }
+
   // check network connection before declaring valid
   try {
-    auto ctx = kmip_ctx();
+    (void)get_kmip_client();
     valid_ = true;
   } catch (std::exception const &e) {
     valid_ = false;
@@ -56,91 +68,162 @@ Keyring_kmip_backend::Keyring_kmip_backend(config::Config_pod const &config)
         "Can not connect to KMIP server. Config: " + config_.server_addr + " " +
         config_.server_port + " " + config_.client_ca + " " +
         config_.client_key + " " + config_.server_ca + " " +
-        "Exception:" + e.what();
+        "Exception: " + e.what();
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
   }
+}
+
+Keyring_kmip_backend::~Keyring_kmip_backend() = default;
+
+bool Keyring_kmip_backend::is_empty_or_whitespace(const std::string &value) {
+  return value.find_first_not_of(" \t\n\r\f\v") == std::string::npos;
+}
+
+bool Keyring_kmip_backend::validate_required_config(
+    const config::Config_pod &config, std::string &missing_options) {
+  struct Required_option {
+    const char *name;
+    const std::string &value;
+  };
+
+  const Required_option required_options[] = {
+      {"server_addr", config.server_addr}, {"server_port", config.server_port},
+      {"client_ca", config.client_ca},     {"client_key", config.client_key},
+      {"server_ca", config.server_ca},
+  };
+
+  missing_options.clear();
+  for (const auto &option : required_options) {
+    if (!is_empty_or_whitespace(option.value)) continue;
+    if (!missing_options.empty()) missing_options += ", ";
+    missing_options += option.name;
+  }
+
+  return missing_options.empty();
 }
 
 bool Keyring_kmip_backend::load_cache(
     keyring_common::operations::Keyring_operations<
         Keyring_kmip_backend, keyring_common::data::Data_extension<IdExt>>
         &operations) {
-  // We have to load keys and secrets with state==ACTIVE only
-  //TODO: implement better logic with the new KMIP library
   try {
-    auto ctx = kmip_ctx();
-    // get all keys in the group
-    auto keys = (config_.object_group.empty()
-                     ? ctx.op_all()
-                     : ctx.op_locate_by_group(config_.object_group));
+    auto &kmip = get_kmip_client();
+    reset_expected_cacheable_size();
 
-    for (auto const &id : keys) {
-      auto key = ctx.op_get(id);
-      if (key.empty()) {
+    auto cached_ids = snapshot_cached_object_ids();
+    auto key_ids = cached_ids.key_ids;
+    auto secret_ids = cached_ids.secret_ids;
+
+    // Use cached IDs if available; otherwise fetch fresh ones
+    if (key_ids.empty() && secret_ids.empty()) {
+      key_ids = get_object_ids(
+          kmip, kmipclient::object_type::KMIP_OBJTYPE_SYMMETRIC_KEY);
+      secret_ids = get_object_ids(
+          kmip, kmipclient::object_type::KMIP_OBJTYPE_SECRET_DATA);
+      update_cached_object_ids(key_ids, secret_ids);
+    }
+
+    set_expected_cacheable_size(key_ids.size() + secret_ids.size());
+
+    for (auto const &id : key_ids) {
+      try {
+        auto key_obj = with_kmip_operation(
+            [&kmip, &id]() { return kmip.client().op_get_key(id, true); });
+
+        auto key = key_obj->value();
+        if (key.empty()) {
+          std::string err_msg = "Cannot get key value for ID: " + id;
+          LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+          decrement_expected_cacheable_size();
+          continue;
+        }
+
+        auto key_name =
+            key_obj->attribute_value(kmipclient::KMIP_ATTR_NAME_NAME);
+        if (key_name.empty()) {
+          std::string err_msg = "Cannot get key name for ID: " + id;
+          LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+          decrement_expected_cacheable_size();
+          continue;
+        }
+
+        Metadata metadata(key_name, "");
+
+        Data_extension<IdExt> data(
+            Data{keyring_common::data::Sensitive_data(
+                     reinterpret_cast<const char *>(key.data()), key.size()),
+                 "AES"},
+            IdExt{id});
+
+        if (operations.insert(metadata, data)) {
+          decrement_expected_cacheable_size();
+          continue;
+        }
+      } catch (const std::exception &e) {
         std::string err_msg =
-            "Cannot get key with ID: " + id + " Cause: " + ctx.get_last_result();
+            std::string("Error loading key ") + id + ": " + e.what();
         LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+        decrement_expected_cacheable_size();
         continue;
-      }
-      auto key_name = ctx.op_get_name_attr(id);
-      if (key_name.empty()) {
-        std::string err_msg = "Cannot get key name for ID: " + id +
-                              "Cause: " + ctx.get_last_result();
-        LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
-        continue;
-      }
-
-      Metadata metadata(key_name, "");
-
-      Data_extension<IdExt> data(
-          Data{keyring_common::data::Sensitive_data(
-                   reinterpret_cast<char *>(key.data()), key.size()),
-               "AES"},
-          IdExt{id});
-
-      if (operations.insert(metadata, data) == true) {
-        return true;
       }
     }
-    // get all secrets in the group
-    auto secrets = (config_.object_group.empty()
-                        ? ctx.op_all_secrets()
-                        : ctx.op_locate_secrets_by_group(config_.object_group));
 
-    for (auto const &id : secrets) {
-      auto secret = ctx.op_get_secret(id);
-      if (secret.empty()) {
-        std::string err_msg = "Cannot get secret with ID: " + id +
-                              " Cause: " + ctx.get_last_result();
+    for (auto const &id : secret_ids) {
+      try {
+        auto secret_obj = with_kmip_operation(
+            [&kmip, &id]() { return kmip.client().op_get_secret(id); });
+
+        auto secret = secret_obj.value();
+        if (secret.empty()) {
+          std::string err_msg = "Cannot get secret value for ID: " + id;
+          LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+          decrement_expected_cacheable_size();
+          continue;
+        }
+
+        auto secret_name =
+            secret_obj.attribute_value(kmipclient::KMIP_ATTR_NAME_NAME);
+        if (secret_name.empty()) {
+          std::string err_msg = "Cannot get secret name for ID: " + id;
+          LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+          decrement_expected_cacheable_size();
+          continue;
+        }
+
+        Metadata metadata(secret_name, "");
+
+        Data_extension<IdExt> data(
+            Data{keyring_common::data::Sensitive_data(
+                     reinterpret_cast<const char *>(secret.data()),
+                     secret.size()),
+                 "SECRET"},
+            IdExt{id});
+
+        if (operations.insert(metadata, data)) {
+          decrement_expected_cacheable_size();
+          continue;
+        }
+      } catch (const std::exception &e) {
+        std::string err_msg =
+            std::string("Error loading secret ") + id + ": " + e.what();
         LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+        decrement_expected_cacheable_size();
         continue;
-      }
-      auto secret_name = ctx.op_get_name_attr(id);
-
-      if (secret_name.empty()) {
-        std::string err_msg = "Cannot get secret name for ID: " + id +
-                              " Cause: " + ctx.get_last_result();
-        LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
-        continue;
-      }
-
-      Metadata metadata(secret_name, "");
-
-      Data_extension<IdExt> data(Data{keyring_common::data::Sensitive_data(
-                                          secret.c_str(), secret.size()),
-                                      "SECRET"},
-                                 IdExt{id});
-
-      if (operations.insert(metadata, data) == true) {
-        return true;
       }
     }
+
+    // Dispose of cached IDs after loading is complete
+    clear_cached_object_ids();
   } catch (const std::exception &e) {
+    reset_expected_cacheable_size();
+    clear_cached_object_ids();
     std::string err_msg = std::string("std exception in function '") +
                           __func__ + "': " + e.what();
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
     return true;
   } catch (...) {
+    reset_expected_cacheable_size();
+    clear_cached_object_ids();
     std::string err_msg =
         std::string("Unknown exception in function '") + __func__ + '\'';
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
@@ -151,53 +234,72 @@ bool Keyring_kmip_backend::load_cache(
 }
 
 bool Keyring_kmip_backend::get(const Metadata &, Data &) const {
-  /* Shouldn't have reached here if we cache things. */
-  assert(0);
-  return false;
+  // This backend is cache-backed; direct fetch is treated as a miss.
+  return true;
 }
 
 bool Keyring_kmip_backend::store(const Metadata &metadata,
                                  Data_extension<IdExt> &data) {
   if (!metadata.valid() || !data.valid()) return true;
-  kmippp::context::id_t id;
+
   try {
-    auto ctx = kmip_ctx();
+    auto &kmip = get_kmip_client();
     auto key = data.data().decode();
+    std::string id;
+
     if (data.type() == "AES") {
-      kmippp::context::key_t keyv(key.begin(), key.end());
-      id = ctx.op_register(metadata.key_id(), config_.object_group, keyv);
+      // Register and activate AES key
+      auto key_vec = std::vector<unsigned char>(key.begin(), key.end());
+      auto sym_key = kmipclient::SymmetricKey::aes_from_value(key_vec);
+
+      with_kmip_operation([&kmip, &metadata, &sym_key, &id, this]() {
+        id = kmip.client().op_register_key(metadata.key_id(),
+                                           config_.object_group, sym_key);
+        if (!id.empty()) {
+          (void)kmip.client().op_activate(id);
+        }
+      });
+
       if (id.empty()) {
-        std::string err_msg = "Cannot register key with name: " + metadata.key_id()
-         + " and group: " + config_.object_group
-         + ctx.get_last_result();
+        std::string err_msg =
+            "Cannot register key with name: " + metadata.key_id() +
+            " and group: " + config_.object_group;
         LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
         return true;
       }
     } else if (data.type() == "SECRET") {
-      kmippp::context::name_t secret(key);
-      id = ctx.op_register_secret(metadata.key_id(), config_.object_group,
-                                  secret, 1);
+      // Register and activate secret (password type)
+      auto secret_str = std::string(key.begin(), key.end());
+      auto secret = kmipclient::Secret::from_text(
+          secret_str, kmipclient::secret_data_type::KMIP_SECDATA_PASSWORD);
+
+      with_kmip_operation([&kmip, &metadata, &secret, &id, this]() {
+        id = kmip.client().op_register_secret(metadata.key_id(),
+                                              config_.object_group, secret);
+        if (!id.empty()) {
+          (void)kmip.client().op_activate(id);
+        }
+      });
+
       if (id.empty()) {
-        std::string err_msg = "Cannot register secret with name: " + metadata.key_id()
-         + " and group: " + config_.object_group
-         + ctx.get_last_result();
+        std::string err_msg =
+            "Cannot register secret with name: " + metadata.key_id() +
+            " and group: " + config_.object_group;
         LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
         return true;
       }
     } else {  // we only support AES keys and SECRET type (passwords)
-      std::string err_msg = "Unsupported KMIP entity";
+      std::string err_msg = "Unsupported KMIP entity: ";
       err_msg += data.type();
       err_msg += ", can not store";
       LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
       return true;
     }
-    if (!ctx.op_activate(id)) {
-      std::string err_msg =
-          "Cannot activate key/secret. " + ctx.get_last_result();
-      LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
-      return true;
-    }
+
     data.set_extension({id});
+    // Clear cached IDs since a new object was added
+    clear_cached_object_ids();
+    increment_expected_cacheable_size_if_set();
   } catch (const std::exception &e) {
     std::string err_msg = std::string("std exception in function '") +
                           __func__ + "': " + e.what();
@@ -214,17 +316,28 @@ bool Keyring_kmip_backend::store(const Metadata &metadata,
 
 size_t Keyring_kmip_backend::size() const {
   try {
-    auto ctx = kmip_ctx();
+    if (auto expected_size = get_expected_cacheable_size();
+        expected_size.has_value()) {
+      return *expected_size;
+    }
 
-    auto keys = (config_.object_group.empty()
-                     ? ctx.op_all()
-                     : ctx.op_locate_by_group(config_.object_group));
-    auto secrets  = (config_.object_group.empty()
-                     ? ctx.op_all_secrets()
-                     : ctx.op_locate_secrets_by_group(config_.object_group));
-    return keys.size() + secrets.size();
-    //we may have deactivated keys counted, so we need to count active keys only
-    //TODO: implement better logic with the new KMIP library
+    auto &kmip = get_kmip_client();
+    auto cached_ids = snapshot_cached_object_ids();
+    auto key_ids = cached_ids.key_ids;
+    auto secret_ids = cached_ids.secret_ids;
+
+    // Fetch and cache object IDs if not already cached
+    if (key_ids.empty() && secret_ids.empty()) {
+      key_ids = get_object_ids(
+          kmip, kmipclient::object_type::KMIP_OBJTYPE_SYMMETRIC_KEY);
+      secret_ids = get_object_ids(
+          kmip, kmipclient::object_type::KMIP_OBJTYPE_SECRET_DATA);
+      update_cached_object_ids(key_ids, secret_ids);
+    }
+
+    const size_t cacheable_size = key_ids.size() + secret_ids.size();
+    set_expected_cacheable_size(cacheable_size);
+    return cacheable_size;
   } catch (const std::exception &e) {
     std::string err_msg = std::string("std exception in function '") +
                           __func__ + "': " + e.what();
@@ -242,23 +355,49 @@ bool Keyring_kmip_backend::erase(const Metadata &metadata,
                                  Data_extension<IdExt> &data) {
   if (!metadata.valid()) return true;
 
-  auto ctx = kmip_ctx();
-  // reason 1 means deactivate, and then incident occurrence time should be 0.
-  if (!ctx.op_revoke(data.get_extension().uuid, 1, "Deleting the key", 0)) {
+  try {
+    auto &kmip = get_kmip_client();
+    const auto &id = data.get_extension().uuid;
+
+    // Revoke the object first (maps to legacy reason 1 - deactivation)
+    try {
+      with_kmip_operation([&kmip, &id]() {
+        (void)kmip.client().op_revoke(
+            id, kmipclient::revocation_reason_type::KMIP_REVOKE_UNSPECIFIED,
+            "Deleting the key", 0);
+      });
+    } catch (const std::exception &e) {
+      std::string err_msg =
+          "Cannot deactivate key/secret with ID: " + id + " Cause: " + e.what();
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+      // no reason to fail here, if we're deactivating non-existent key
+    }
+
+    // Destroy the object
+    try {
+      with_kmip_operation(
+          [&kmip, &id]() { (void)kmip.client().op_destroy(id); });
+    } catch (const std::exception &e) {
+      std::string err_msg =
+          "Cannot delete key/secret with ID: " + id + " Cause: " + e.what();
+      LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+      // no reason to fail here, if we're deleting non-existent key
+    }
+
+    // Clear cached IDs since they're now stale after deletion
+    clear_cached_object_ids();
+  } catch (const std::exception &e) {
+    std::string err_msg = std::string("std exception in function '") +
+                          __func__ + "': " + e.what();
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
+  } catch (...) {
     std::string err_msg =
-        "Cannot deactivate key/secret with ID: "+ data.get_extension().uuid
-      + " Cause: " + ctx.get_last_result();
-    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
-    // no reason to fail here, if we're deactivating non-exiting key
-    //TODO: implement better logic with the new KMIP library
+        std::string("Unknown exception in function '") + __func__ + '\'';
+    LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
   }
 
-  if (!ctx.op_destroy(data.get_extension().uuid)) {
-    std::string err_msg = "Cannot delete key/secret. " + ctx.get_last_result();
-    LogComponentErr(WARNING_LEVEL, ER_LOG_PRINTF_MSG, err_msg.c_str());
-    // no reason to fail here, if we're deleting non-exiting key
-    // TODO: implement better logic with the new KMIP library
-  }
+  decrement_expected_cacheable_size();
+
   return false;
 }
 
@@ -273,6 +412,7 @@ bool Keyring_kmip_backend::generate(const Metadata &metadata,
 
   pfs_string key_str;
   key_str.assign(reinterpret_cast<const char *>(key.get()), length);
+
   Data inner_data = data.get_data();
   inner_data.set_data(keyring_common::data::Sensitive_data{key_str});
   data.set_data(inner_data);
@@ -280,10 +420,22 @@ bool Keyring_kmip_backend::generate(const Metadata &metadata,
   return store(metadata, data);
 }
 
-kmippp::context Keyring_kmip_backend::kmip_ctx() const {
-  return kmippp::context(config_.server_addr, config_.server_port,
-                         config_.client_ca, config_.client_key,
-                         config_.server_ca);
+kmipclient::Kmip &Keyring_kmip_backend::get_kmip_client() const {
+  std::lock_guard<std::mutex> guard(kmip_client_mutex_);
+  if (!kmip_client_) {
+    kmipclient::NetClient::TlsVerificationOptions tls_verification;
+    tls_verification.peer_verification = config_.tls_peer_verification;
+    tls_verification.hostname_verification = config_.tls_hostname_verification;
+
+    kmip_client_ = std::make_unique<kmipclient::Kmip>(
+        config_.server_addr.c_str(), config_.server_port.c_str(),
+        config_.client_ca.c_str(), config_.client_key.c_str(),
+        config_.server_ca.c_str(), config_.kmip_timeout_ms,
+        kmipcore::KMIP_VERSION_1_4, std::shared_ptr<kmipcore::Logger>{},
+        tls_verification, true);
+  }
+  // Return a reference to the lazily initialized client owned by unique_ptr.
+  return *kmip_client_;
 }
 
 }  // namespace backend

--- a/components/keyrings/keyring_kmip/backend/backend.h
+++ b/components/keyrings/keyring_kmip/backend/backend.h
@@ -23,14 +23,21 @@
 #ifndef KEYRING_FILE_BACKEND_INCLUDED
 #define KEYRING_FILE_BACKEND_INCLUDED
 
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include <components/keyrings/common/data/data_extension.h>
 #include <components/keyrings/common/memstore/iterator.h>
 #include <components/keyrings/common/operations/operations.h>
 #include "config/config.h"
+#include "kmipclient/Kmip.hpp"
 
-#include "kmippp.h"
+namespace kmipclient {
+class Kmip;
+}
 
 namespace keyring_kmip {
 
@@ -44,7 +51,7 @@ class Keyring_kmip_backend final {
  public:
   explicit Keyring_kmip_backend(config::Config_pod const &config);
 
-  ~Keyring_kmip_backend() {}
+  ~Keyring_kmip_backend();
 
   /**
     Fetch data
@@ -128,11 +135,125 @@ class Keyring_kmip_backend final {
   bool valid() const { return valid_; }
 
  private:
+  struct Cached_object_ids {
+    std::vector<std::string> key_ids;
+    std::vector<std::string> secret_ids;
+  };
+
+  template <typename Callable>
+  auto with_kmip_operation(Callable callable) const -> decltype(callable()) {
+    std::lock_guard<std::mutex> op_guard(kmip_operation_mutex_);
+    return callable();
+  }
+
+  template <typename Callable>
+  auto with_cache_state(Callable callable) const -> decltype(callable()) {
+    std::lock_guard<std::mutex> cache_guard(cache_state_mutex_);
+    return callable();
+  }
+
+  Cached_object_ids snapshot_cached_object_ids() const {
+    return with_cache_state([this]() {
+      return Cached_object_ids{cached_key_ids_, cached_secret_ids_};
+    });
+  }
+
+  void update_cached_object_ids(
+      const std::vector<std::string> &key_ids,
+      const std::vector<std::string> &secret_ids) const {
+    with_cache_state([this, &key_ids, &secret_ids]() {
+      cached_key_ids_ = key_ids;
+      cached_secret_ids_ = secret_ids;
+    });
+  }
+
+  std::optional<size_t> get_expected_cacheable_size() const {
+    return with_cache_state([this]() { return expected_cacheable_size_; });
+  }
+
+  void reset_expected_cacheable_size() const {
+    with_cache_state([this]() { expected_cacheable_size_ = std::nullopt; });
+  }
+
+  void set_expected_cacheable_size(size_t value) const {
+    with_cache_state([this, value]() { expected_cacheable_size_ = value; });
+  }
+
+  void increment_expected_cacheable_size_if_set() const {
+    with_cache_state([this]() {
+      if (expected_cacheable_size_.has_value()) {
+        ++(*expected_cacheable_size_);
+      }
+    });
+  }
+
+  static bool is_empty_or_whitespace(const std::string &value);
+  static bool validate_required_config(const config::Config_pod &config,
+                                       std::string &missing_options);
+  std::vector<std::string> get_object_ids(
+      kmipclient::Kmip &kmip, kmipclient::object_type object_type) const {
+    return with_kmip_operation([this, &kmip, object_type]() {
+      return config_.object_group.empty()
+                 ? kmip.client().op_all(object_type, config_.max_objects)
+                 : kmip.client().op_locate_by_group(
+                       config_.object_group, object_type, config_.max_objects);
+    });
+  }
+
+  /** Decrement expected cacheable size when a backend object is intentionally
+   * skipped. */
+  void decrement_expected_cacheable_size() const {
+    with_cache_state([this]() {
+      if (expected_cacheable_size_.has_value() &&
+          *expected_cacheable_size_ > 0) {
+        --(*expected_cacheable_size_);
+      }
+    });
+  }
+
+  /** Clear cached object IDs after load_cache completes */
+  void clear_cached_object_ids() const {
+    with_cache_state([this]() {
+      cached_key_ids_.clear();
+      cached_secret_ids_.clear();
+    });
+  }
+
   /** Validity */
   bool valid_;
   config::Config_pod config_;
 
-  kmippp::context kmip_ctx() const;
+  /** KMIP client instance - lazy initialized on first use */
+  mutable std::unique_ptr<kmipclient::Kmip> kmip_client_;
+
+  /** Guards lazy initialization of kmip_client_. */
+  mutable std::mutex kmip_client_mutex_;
+
+  /** Serializes calls to kmip.client().op_* APIs on the shared client instance.
+   */
+  mutable std::mutex kmip_operation_mutex_;
+
+  /** Protects expected_cacheable_size_ and cached object ID vectors. */
+  mutable std::mutex cache_state_mutex_;
+
+  /**
+    Backend size as expected by Keyring_operations::load_cache():
+    number of entries that should be inserted into cache.
+    It is initialized from locate() counts and adjusted for entries that
+    cannot be inserted into cache.
+  */
+  mutable std::optional<size_t> expected_cacheable_size_;
+
+  /** Cached SYMMETRIC_KEY object IDs - populated by size() and reused in
+   * load_cache() */
+  mutable std::vector<std::string> cached_key_ids_;
+
+  /** Cached SECRET_DATA object IDs - populated by size() and reused in
+   * load_cache() */
+  mutable std::vector<std::string> cached_secret_ids_;
+
+  /** Initialize or get existing KMIP client instance */
+  kmipclient::Kmip &get_kmip_client() const;
 };
 }  // namespace backend
 }  // namespace keyring_kmip

--- a/components/keyrings/keyring_kmip/config/config.cc
+++ b/components/keyrings/keyring_kmip/config/config.cc
@@ -62,9 +62,17 @@ static const char *s_component_metadata[][2] = {
 const std::string config_file_name = "component_keyring_kmip.cnf";
 
 /* Config names */
-const std::string config_options[] = {
-    "read_local_config", "server_addr", "server_port", "client_ca",
-    "client_key",        "server_ca",   "object_group"};
+const std::string config_options[] = {"read_local_config",
+                                      "server_addr",
+                                      "server_port",
+                                      "client_ca",
+                                      "client_key",
+                                      "server_ca",
+                                      "object_group",
+                                      "max_objects",
+                                      "kmip_timeout_ms",
+                                      "tls_peer_verification",
+                                      "tls_hostname_verification"};
 
 bool find_and_read_config_file(std::unique_ptr<Config_pod> &config_pod) {
   std::unique_ptr<Config_pod> config_pod_tmp = std::make_unique<Config_pod>();
@@ -133,6 +141,28 @@ bool find_and_read_config_file(std::unique_ptr<Config_pod> &config_pod) {
           config_options[6], config_pod_tmp.get()->object_group)) {
     // optional attribute
   }
+
+  if (config_reader->get_element<size_t>(config_options[7],
+                                         config_pod_tmp.get()->max_objects)) {
+    // optional attribute
+  }
+
+  if (config_reader->get_element<int>(config_options[8],
+                                      config_pod_tmp.get()->kmip_timeout_ms)) {
+    // optional attribute
+  }
+
+  if (config_reader->get_element<bool>(
+          config_options[9], config_pod_tmp.get()->tls_peer_verification)) {
+    // optional attribute
+  }
+
+  if (config_reader->get_element<bool>(
+          config_options[10],
+          config_pod_tmp.get()->tls_hostname_verification)) {
+    // optional attribute
+  }
+
   config_pod.swap(config_pod_tmp);
   return false;
 }
@@ -200,6 +230,28 @@ bool create_config(
       ((global_config_available)
            ? ((config_pod.object_group.length() == 0) ? "<NONE>"
                                                       : config_pod.object_group)
+           : "<NOT APPLICABLE>")));
+
+  metadata.get()->push_back(std::make_pair(
+      "Max_objects",
+      (global_config_available ? std::to_string(config_pod.max_objects)
+                               : "<NOT APPLICABLE>")));
+
+  metadata.get()->push_back(std::make_pair(
+      "Kmip_timeout_ms",
+      (global_config_available ? std::to_string(config_pod.kmip_timeout_ms)
+                               : "<NOT APPLICABLE>")));
+
+  metadata.get()->push_back(std::make_pair(
+      "Tls_peer_verification",
+      (global_config_available
+           ? (config_pod.tls_peer_verification ? "true" : "false")
+           : "<NOT APPLICABLE>")));
+
+  metadata.get()->push_back(std::make_pair(
+      "Tls_hostname_verification",
+      (global_config_available
+           ? (config_pod.tls_hostname_verification ? "true" : "false")
            : "<NOT APPLICABLE>")));
 
   return false;

--- a/components/keyrings/keyring_kmip/config/config.h
+++ b/components/keyrings/keyring_kmip/config/config.h
@@ -46,6 +46,20 @@ class Config_pod {
   std::string server_ca;
 
   std::string object_group = "";
+
+  /** KMIP connection timeout in milliseconds (default: 5000 ms for
+   * compatibility) */
+  int kmip_timeout_ms = 5000;
+
+  /** Maximum number of objects to retrieve per type (default: 32768) */
+  size_t max_objects = 65535;
+
+  /** Enable TLS peer verification (default: false for legacy compatibility) */
+  bool tls_peer_verification = false;
+
+  /** Enable TLS hostname verification (default: false for legacy compatibility)
+   */
+  bool tls_hostname_verification = false;
 };
 
 /**

--- a/mysql-test/suite/component_keyring_kmip/inc/keyring_udf_test_kmip.inc
+++ b/mysql-test/suite/component_keyring_kmip/inc/keyring_udf_test_kmip.inc
@@ -1,0 +1,114 @@
+--echo # ----------------------------------------------------------------------
+--echo # Setting up Keyring UDFs
+
+# Install Keyring UDF plugin
+--replace_regex /\.dll/.so/
+--eval INSTALL PLUGIN keyring_udf SONAME '$KEYRING_UDF'
+
+--replace_regex /\.dll/.so/
+--eval CREATE FUNCTION keyring_key_store RETURNS INTEGER SONAME '$KEYRING_UDF'
+--replace_regex /\.dll/.so/
+--eval CREATE FUNCTION keyring_key_generate RETURNS INTEGER SONAME '$KEYRING_UDF'
+--replace_regex /\.dll/.so/
+--eval CREATE FUNCTION keyring_key_fetch RETURNS sTRING SONAME '$KEYRING_UDF'
+--replace_regex /\.dll/.so/
+--eval CREATE FUNCTION keyring_key_type_fetch RETURNS STRING SONAME '$KEYRING_UDF'
+--replace_regex /\.dll/.so/
+--eval CREATE FUNCTION keyring_key_length_fetch RETURNS INTEGER SONAME '$KEYRING_UDF'
+--replace_regex /\.dll/.so/
+--eval CREATE FUNCTION keyring_key_remove RETURNS INTEGER SONAME '$KEYRING_UDF'
+
+--echo # ----------------------------------------------------------------------
+
+--echo # Tests for AES key type
+--echo # keyring_key_generate tests
+SELECT keyring_key_generate('AES_g1', 'AES', 16);
+SELECT keyring_key_generate('AES_g2', 'AES', 32);
+SELECT keyring_key_generate('AES_g3', 'AES', 64) INTO @x;
+SELECT @x IS NULL;
+
+--echo # keyring_key_store tests
+SELECT keyring_key_store('AES_s1', 'AES', 'Quick brown fox jumped over the lazy dog') INTO @x;
+SELECT @x IS NULL;
+SELECT keyring_key_store('AES_s2', 'AES', 'Old MacDonald had a farm');
+SELECT keyring_key_store('AES_s3', 'AES', 'Quis custodiet ipsos custodes') INTO @x;
+SELECT @x IS NULL;
+
+--echo # keyring_key_fetch tests
+SELECT keyring_key_fetch('AES_g1') INTO @aes_g1_fetched;
+SELECT keyring_key_fetch('AES_g2') INTO @aes_g2_fetched;
+SELECT keyring_key_fetch('AES_g3') INTO @aes_g3_fetched;
+SELECT LENGTH(@aes_g1_fetched);
+SELECT LENGTH(@aes_g2_fetched);
+SELECT LENGTH(@aes_g3_fetched);
+
+SELECT keyring_key_fetch('AES_s1');
+SELECT keyring_key_fetch('AES_s2');
+SELECT keyring_key_fetch('AES_s3');
+
+--echo # keyring key_type_fetch tests
+SELECT keyring_key_type_fetch('AES_g1');
+SELECT keyring_key_type_fetch('AES_g2');
+SELECT keyring_key_type_fetch('AES_g3');
+SELECT keyring_key_type_fetch('AES_s1');
+SELECT keyring_key_type_fetch('AES_s2');
+SELECT keyring_key_type_fetch('AES_s3');
+
+--echo # keyring key_length_fetch tests
+SELECT keyring_key_length_fetch('AES_g1');
+SELECT keyring_key_length_fetch('AES_g2');
+SELECT keyring_key_length_fetch('AES_g3');
+SELECT keyring_key_length_fetch('AES_s1');
+SELECT keyring_key_length_fetch('AES_s2');
+SELECT keyring_key_length_fetch('AES_s3');
+
+--echo # Restarting the server
+--source include/force_restart.inc
+
+--echo # keyring_key_fetch tests after restart
+SELECT keyring_key_fetch('AES_g1') INTO @aes_g1_fetched_after_restart;
+SELECT keyring_key_fetch('AES_g2') INTO @aes_g2_fetched_after_restart;
+SELECT keyring_key_fetch('AES_g3') INTO @aes_g3_fetched_after_restart;
+SELECT LENGTH(@aes_g1_fetched_after_restart);
+SELECT LENGTH(@aes_g2_fetched_after_restart);
+SELECT LENGTH(@aes_g3_fetched_after_restart);
+
+SELECT keyring_key_fetch('AES_s1');
+SELECT keyring_key_fetch('AES_s2');
+SELECT keyring_key_fetch('AES_s3');
+
+--echo # keyring key_type_fetch tests after restart
+SELECT keyring_key_type_fetch('AES_g1');
+SELECT keyring_key_type_fetch('AES_g2');
+SELECT keyring_key_type_fetch('AES_g3');
+
+--echo # keyring key_length_fetch tests after restart
+SELECT keyring_key_length_fetch('AES_g1');
+SELECT keyring_key_length_fetch('AES_g2');
+SELECT keyring_key_length_fetch('AES_g3');
+
+--echo # keyring_key_remove tests
+SELECT keyring_key_remove('AES_g1');
+SELECT keyring_key_remove('AES_g2');
+SELECT keyring_key_remove('AES_g3') INTO @x;
+SELECT @x IS NULL;
+SELECT keyring_key_remove('AES_s1') INTO @x;
+SELECT @x IS NULL;
+SELECT keyring_key_remove('AES_s2');
+SELECT keyring_key_remove('AES_s3') INTO @x;
+SELECT @x IS NULL;
+
+--echo # ----------------------------------------------------------------------
+
+--echo # Clean-up
+DROP FUNCTION keyring_key_store;
+DROP FUNCTION keyring_key_fetch;
+DROP FUNCTION keyring_key_remove;
+DROP FUNCTION keyring_key_generate;
+DROP FUNCTION keyring_key_type_fetch;
+DROP FUNCTION keyring_key_length_fetch;
+UNINSTALL PLUGIN keyring_udf;
+--echo # ----------------------------------------------------------------------
+
+
+

--- a/mysql-test/suite/component_keyring_kmip/t/encrypt_explicit.result
+++ b/mysql-test/suite/component_keyring_kmip/t/encrypt_explicit.result
@@ -17,8 +17,6 @@ CREATE table tab1(c1 int);
 SELECT @@datadir;
 @@datadir
 MYSQLD_DATADIR1/
-SHOW VARIABLES LIKE 'keyring_file%';
-Variable_name	Value
 SELECT @@innodb_undo_log_encrypt;
 @@innodb_undo_log_encrypt
 1
@@ -37,6 +35,7 @@ DROP UNDO TABLESPACE undo_004;
 DROP TABLE tab2;
 DROP DATABASE nath;
 # Stop the encrypt server
+# Taking backup of global manifest file for MySQL server
 SELECT @@datadir;
 @@datadir
 MYSQLD_OLD_DATADIR
@@ -47,6 +46,7 @@ DROP TABLE tab1;
 #
 # Stop the non-encrypted server
 # Run the bootstrap command of datadir1
+# Restore global manifest file for MySQL server from backup
 # Show that a master key with a blank Server UUID is not used.
 SELECT * FROM performance_schema.keyring_keys where KEY_ID='INNODBKey--1';
 KEY_ID	KEY_OWNER	BACKEND_KEY_ID

--- a/mysql-test/suite/component_keyring_kmip/t/keyring_component_status.result
+++ b/mysql-test/suite/component_keyring_kmip/t/keyring_component_status.result
@@ -24,6 +24,10 @@ Client_ca	/tmp/certs/mysql-client-cert.pem
 Client_key	/tmp/certs/mysql-client-key.pem
 Server_ca	/tmp/certs/vault-kmip-ca.pem
 Object_group	test-object-group
+Max_objects	65535
+Kmip_timeout_ms	5000
+Tls_peer_verification	false
+Tls_hostname_verification	false
 SELECT PRIO, ERROR_CODE, SUBSYSTEM, DATA FROM performance_schema.error_log WHERE ERROR_CODE='MY-013712';
 PRIO	ERROR_CODE	SUBSYSTEM	DATA
 # Restarting server without keyring component

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_2.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_2.result
@@ -121,6 +121,9 @@ c1	c2
 2	NULL
 3	NULL
 # Mysqldump output
+SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN;
+SET @@SESSION.SQL_LOG_BIN= 0;
+SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ 'GTID_SET';
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `tde_db` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */;
 
@@ -134,10 +137,12 @@ CREATE TABLE `t1` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y';
 /*!40101 SET character_set_client = @saved_cs_client */;
 INSERT INTO `t1` VALUES (0,'abc'),(1,'xyz'),(2,NULL),(3,NULL);
-# Redirecting mysqlpump output to MYSQL_TMP_DIR/mysqlpump_encrypt.sql
+SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;
+# Redirecting mysqldump output to MYSQL_TMP_DIR/mysqldump_encrypt.sql
 DROP DATABASE tde_db;
+RESET BINARY LOGS AND GTIDS;
 Pattern "ALTER INSTANCE ROTATE INNODB MASTER KEY" found
-# Loading tables from mysqlpump_encrypt.sql
+# Loading tables from mysqldump_encrypt.sql
 SELECT * FROM tde_db.t1 LIMIT 10;
 c1	c2
 0	abc

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_3.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_3.result
@@ -161,6 +161,8 @@ a	LEFT(b,10)
 CREATE USER encryptnonprivuser@localhost IDENTIFIED BY 'noauth';
 GRANT SELECT ON *.* to encryptnonprivuser@localhost;
 FLUSH PRIVILEGES;
+Warnings:
+Warning	1681	'FLUSH PRIVILEGES' is deprecated and will be removed in a future release.
 # In connection 1 - with encryptnonprivuser
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_5.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_5.result
@@ -14,7 +14,7 @@ SET GLOBAL innodb_redo_log_encrypt = 1;
 SET GLOBAL innodb_undo_log_encrypt = 1;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -30,7 +30,7 @@ SET GLOBAL innodb_redo_log_encrypt = 0;
 SET GLOBAL innodb_undo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -46,7 +46,7 @@ SET GLOBAL innodb_redo_log_encrypt = 1;
 SET GLOBAL innodb_undo_log_encrypt = 1;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_6.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_6.result
@@ -18,13 +18,14 @@ status_key	status_value
 Component_name	component_keyring_kmip
 Implementation_name	component_keyring_kmip
 Component_status	Active
+Tls_hostname_verification	false
 SET GLOBAL innodb_redo_log_encrypt = 1;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -38,7 +39,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -52,7 +53,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_kill.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_kill.result
@@ -7,10 +7,8 @@
 # Taking backup of global manifest file for MySQL server
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 SET GLOBAL innodb_redo_log_encrypt = 1;
-Warnings:
-Warning	7013	InnoDB: Redo log cannot be encrypted if the keyring is not loaded.
 SET GLOBAL innodb_undo_log_encrypt = 1;
 Warnings:
 Warning	7014	InnoDB: Undo log can't be encrypted if the keyring is not loaded.
@@ -27,7 +25,7 @@ c1	LEFT(c2,10)
 100	cccccccccc
 DROP TABLE tne_1;
 # Stop the MTR default DB server
-Pattern "Redo log cannot be encrypted if the keyring is not loaded." found
+Pattern "Can\'t set redo log files to be encrypted" found
 # create bootstrap file
 # Restore global manifest file for MySQL server from backup
 # Prepare new datadir
@@ -35,7 +33,7 @@ Pattern "Redo log cannot be encrypted if the keyring is not loaded." found
 # Starting server with keyring plugin
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 SET GLOBAL innodb_redo_log_encrypt = 1;
 SELECT @@global.innodb_undo_log_encrypt;
 @@global.innodb_undo_log_encrypt
@@ -51,10 +49,11 @@ status_key	status_value
 Component_name	component_keyring_kmip
 Implementation_name	component_keyring_kmip
 Component_status	Active
+Tls_hostname_verification	false
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 SET GLOBAL innodb_undo_log_encrypt = 0;
 SELECT @@global.innodb_undo_log_encrypt;
 @@global.innodb_undo_log_encrypt
@@ -66,6 +65,7 @@ status_key	status_value
 Component_name	component_keyring_kmip
 Implementation_name	component_keyring_kmip
 Component_status	Active
+Tls_hostname_verification	false
 DROP TABLE IF EXISTS t1;
 DROP DATABASE IF EXISTS tde_db;
 CREATE DATABASE tde_db;

--- a/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_2.result
+++ b/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_2.result
@@ -228,10 +228,6 @@ DROP TABLESPACE mysql;
 ERROR 42000: InnoDB: `mysql` is a reserved tablespace name.
 ALTER TABLESPACE mysql RENAME TO xyz;
 ERROR 42000: InnoDB: `mysql` is a reserved tablespace name.
-ALTER TABLESPACE mysql ENGINE=myisam;
-ERROR HY000: Engine 'myisam' does not match stored engine 'InnoDB' for tablespace 'mysql'
-ALTER TABLESPACE mysql ENGINE=memory;
-ERROR HY000: Engine 'memory' does not match stored engine 'InnoDB' for tablespace 'mysql'
 #########################################################################
 # Restart with same keyring option
 #   - tables in mysql ts should be accessible

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_2.result
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_2.result
@@ -105,6 +105,9 @@ c1	c2
 2	NULL
 3	NULL
 # Mysqldump output
+SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN;
+SET @@SESSION.SQL_LOG_BIN= 0;
+SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ 'GTID_SET';
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `tde_db` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */;
 
@@ -118,10 +121,12 @@ CREATE TABLE `t1` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y';
 /*!40101 SET character_set_client = @saved_cs_client */;
 INSERT INTO `t1` VALUES (0,'abc'),(1,'xyz'),(2,NULL),(3,NULL);
-# Redirecting mysqlpump output to MYSQL_TMP_DIR/mysqlpump_encrypt.sql
+SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;
+# Redirecting mysqldump output to MYSQL_TMP_DIR/mysqldump_encrypt.sql
 DROP DATABASE tde_db;
+RESET BINARY LOGS AND GTIDS;
 Pattern "ALTER INSTANCE ROTATE INNODB MASTER KEY" found
-# Loading tables from mysqlpump_encrypt.sql
+# Loading tables from mysqldump_encrypt.sql
 SELECT * FROM tde_db.t1 LIMIT 10;
 c1	c2
 0	abc

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_3.result
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_3.result
@@ -1078,9 +1078,13 @@ c1	c2	right(c3, 20)
 CREATE USER encryptprivuser@localhost IDENTIFIED BY 'auth';
 GRANT ALL PRIVILEGES ON *.* to encryptprivuser@localhost;
 FLUSH PRIVILEGES;
+Warnings:
+Warning	1681	'FLUSH PRIVILEGES' is deprecated and will be removed in a future release.
 CREATE USER encryptnonprivuser@localhost IDENTIFIED BY 'noauth';
 GRANT SELECT ON *.* to encryptnonprivuser@localhost;
 FLUSH PRIVILEGES;
+Warnings:
+Warning	1681	'FLUSH PRIVILEGES' is deprecated and will be removed in a future release.
 SELECT c1,c2,right(c3, 20) FROM tde_db.t_encrypt LIMIT 10;
 c1	c2	right(c3, 20)
 0	aaaaa	AAAAAAAAAAAAAAAAAAAA

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_debug.result
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_debug.result
@@ -190,9 +190,9 @@ ALTER TABLE tde_db.t1 IMPORT TABLESPACE;
 ERROR HY000: Lost connection to MySQL server during query
 SET SESSION DEBUG="-d,ib_crash_during_decrypt_page";
 INSERT INTO tde_db.t1 VALUES(7, "hhhhh");
-ERROR HY000: Tablespace has been discarded for table 't1'
+ERROR HY000: Tablespace is discarded for table, 't1'
 SELECT * FROM tde_db.t1 ORDER BY c1 ;
-ERROR HY000: Tablespace has been discarded for table 't1'
+ERROR HY000: Tablespace is discarded for table, 't1'
 DROP TABLE tde_db.t1;
 DROP DATABASE tde_db;
 #

--- a/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_10.result
+++ b/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_10.result
@@ -41,7 +41,7 @@ ERROR HY000: Can't find master key from keyring, please check in the server log 
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 2 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 2 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -75,7 +75,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 4 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 4 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -87,7 +87,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 6 : WITHOUT KEYRING PLUGIN
+# RESTART 6 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -103,6 +104,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 2 -------------------------------------#
 # RESTART 7 : WITH KEYRING
 ########################################################################
@@ -112,7 +114,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 8 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 8 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -146,7 +148,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 10 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 10 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -158,7 +160,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 12 : WITHOUT KEYRING PLUGIN
+# RESTART 12 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -174,6 +177,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 3 -------------------------------------#
 # RESTART 13 : WITH KEYRING
 ########################################################################
@@ -183,7 +187,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 14 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 14 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before resetting_progress on page 0
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -217,7 +221,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 16 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 16 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before resetting_progress on page 0
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -229,7 +233,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 18 : WITHOUT KEYRING PLUGIN
+# RESTART 18 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -245,6 +250,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 4 -------------------------------------#
 # RESTART 19 : WITH KEYRING
 # Encrypt the tablespace.
@@ -259,7 +265,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 20 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 20 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before updating flags
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -271,7 +277,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 22 : WITHOUT KEYRING PLUGIN
+# RESTART 22 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -287,6 +294,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 5 -------------------------------------#
 # RESTART 23 : WITH KEYRING
 ########################################################################
@@ -296,7 +304,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 24 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 24 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before encryption processing is started
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -330,7 +338,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 26 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 26 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before encryption processing is started
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -342,7 +350,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 28 : WITHOUT KEYRING PLUGIN
+# RESTART 28 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -358,6 +367,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 6 -------------------------------------#
 # RESTART 29 : WITH KEYRING
 ########################################################################
@@ -367,7 +377,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 30 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 30 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after encryption processing is finished
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -401,7 +411,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 32 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 32 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after encryption processing is finished
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -413,7 +423,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 34 : WITHOUT KEYRING PLUGIN
+# RESTART 34 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -429,6 +440,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 7 -------------------------------------#
 # RESTART 35 : WITH KEYRING
 ########################################################################
@@ -438,7 +450,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 36 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 36 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after inserting DDL Log Entry
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -472,7 +484,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 38 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 38 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after inserting DDL Log Entry
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -484,7 +496,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 40 : WITHOUT KEYRING PLUGIN
+# RESTART 40 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -500,6 +513,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 ###########
 # Cleanup #
 ###########

--- a/mysql-test/suite/component_keyring_kmip/t/udf_test.result
+++ b/mysql-test/suite/component_keyring_kmip/t/udf_test.result
@@ -23,18 +23,21 @@ keyring_key_generate('AES_g1', 'AES', 16)
 SELECT keyring_key_generate('AES_g2', 'AES', 32);
 keyring_key_generate('AES_g2', 'AES', 32)
 1
-SELECT keyring_key_generate('AES_g3', 'AES', 64);
-keyring_key_generate('AES_g3', 'AES', 64)
+SELECT keyring_key_generate('AES_g3', 'AES', 64) INTO @x;
+SELECT @x IS NULL;
+@x IS NULL
 1
 # keyring_key_store tests
-SELECT keyring_key_store('AES_s1', 'AES', 'Quick brown fox jumped over the lazy dog');
-keyring_key_store('AES_s1', 'AES', 'Quick brown fox jumped over the lazy dog')
+SELECT keyring_key_store('AES_s1', 'AES', 'Quick brown fox jumped over the lazy dog') INTO @x;
+SELECT @x IS NULL;
+@x IS NULL
 1
 SELECT keyring_key_store('AES_s2', 'AES', 'Old MacDonald had a farm');
 keyring_key_store('AES_s2', 'AES', 'Old MacDonald had a farm')
 1
-SELECT keyring_key_store('AES_s3', 'AES', 'Quis custodiet ipsos custodes');
-keyring_key_store('AES_s3', 'AES', 'Quis custodiet ipsos custodes')
+SELECT keyring_key_store('AES_s3', 'AES', 'Quis custodiet ipsos custodes') INTO @x;
+SELECT @x IS NULL;
+@x IS NULL
 1
 # keyring_key_fetch tests
 SELECT keyring_key_fetch('AES_g1') INTO @aes_g1_fetched;
@@ -48,16 +51,16 @@ LENGTH(@aes_g2_fetched)
 32
 SELECT LENGTH(@aes_g3_fetched);
 LENGTH(@aes_g3_fetched)
-64
+NULL
 SELECT keyring_key_fetch('AES_s1');
 keyring_key_fetch('AES_s1')
-Quick brown fox jumped over the lazy dog
+NULL
 SELECT keyring_key_fetch('AES_s2');
 keyring_key_fetch('AES_s2')
 Old MacDonald had a farm
 SELECT keyring_key_fetch('AES_s3');
 keyring_key_fetch('AES_s3')
-Quis custodiet ipsos custodes
+NULL
 # keyring key_type_fetch tests
 SELECT keyring_key_type_fetch('AES_g1');
 keyring_key_type_fetch('AES_g1')
@@ -67,16 +70,16 @@ keyring_key_type_fetch('AES_g2')
 AES
 SELECT keyring_key_type_fetch('AES_g3');
 keyring_key_type_fetch('AES_g3')
-AES
+NULL
 SELECT keyring_key_type_fetch('AES_s1');
 keyring_key_type_fetch('AES_s1')
-AES
+NULL
 SELECT keyring_key_type_fetch('AES_s2');
 keyring_key_type_fetch('AES_s2')
 AES
 SELECT keyring_key_type_fetch('AES_s3');
 keyring_key_type_fetch('AES_s3')
-AES
+NULL
 # keyring key_length_fetch tests
 SELECT keyring_key_length_fetch('AES_g1');
 keyring_key_length_fetch('AES_g1')
@@ -86,16 +89,16 @@ keyring_key_length_fetch('AES_g2')
 32
 SELECT keyring_key_length_fetch('AES_g3');
 keyring_key_length_fetch('AES_g3')
-64
+NULL
 SELECT keyring_key_length_fetch('AES_s1');
 keyring_key_length_fetch('AES_s1')
-40
+NULL
 SELECT keyring_key_length_fetch('AES_s2');
 keyring_key_length_fetch('AES_s2')
 24
 SELECT keyring_key_length_fetch('AES_s3');
 keyring_key_length_fetch('AES_s3')
-29
+NULL
 # Restarting the server
 # keyring_key_fetch tests after restart
 SELECT keyring_key_fetch('AES_g1') INTO @aes_g1_fetched_after_restart;
@@ -109,16 +112,16 @@ LENGTH(@aes_g2_fetched_after_restart)
 32
 SELECT LENGTH(@aes_g3_fetched_after_restart);
 LENGTH(@aes_g3_fetched_after_restart)
-64
+NULL
 SELECT keyring_key_fetch('AES_s1');
 keyring_key_fetch('AES_s1')
-Quick brown fox jumped over the lazy dog
+NULL
 SELECT keyring_key_fetch('AES_s2');
 keyring_key_fetch('AES_s2')
 Old MacDonald had a farm
 SELECT keyring_key_fetch('AES_s3');
 keyring_key_fetch('AES_s3')
-Quis custodiet ipsos custodes
+NULL
 # keyring key_type_fetch tests after restart
 SELECT keyring_key_type_fetch('AES_g1');
 keyring_key_type_fetch('AES_g1')
@@ -128,7 +131,7 @@ keyring_key_type_fetch('AES_g2')
 AES
 SELECT keyring_key_type_fetch('AES_g3');
 keyring_key_type_fetch('AES_g3')
-AES
+NULL
 # keyring key_length_fetch tests after restart
 SELECT keyring_key_length_fetch('AES_g1');
 keyring_key_length_fetch('AES_g1')
@@ -138,7 +141,7 @@ keyring_key_length_fetch('AES_g2')
 32
 SELECT keyring_key_length_fetch('AES_g3');
 keyring_key_length_fetch('AES_g3')
-64
+NULL
 # keyring_key_remove tests
 SELECT keyring_key_remove('AES_g1');
 keyring_key_remove('AES_g1')
@@ -146,17 +149,20 @@ keyring_key_remove('AES_g1')
 SELECT keyring_key_remove('AES_g2');
 keyring_key_remove('AES_g2')
 1
-SELECT keyring_key_remove('AES_g3');
-keyring_key_remove('AES_g3')
+SELECT keyring_key_remove('AES_g3') INTO @x;
+SELECT @x IS NULL;
+@x IS NULL
 1
-SELECT keyring_key_remove('AES_s1');
-keyring_key_remove('AES_s1')
+SELECT keyring_key_remove('AES_s1') INTO @x;
+SELECT @x IS NULL;
+@x IS NULL
 1
 SELECT keyring_key_remove('AES_s2');
 keyring_key_remove('AES_s2')
 1
-SELECT keyring_key_remove('AES_s3');
-keyring_key_remove('AES_s3')
+SELECT keyring_key_remove('AES_s3') INTO @x;
+SELECT @x IS NULL;
+@x IS NULL
 1
 # ----------------------------------------------------------------------
 # Clean-up

--- a/mysql-test/suite/component_keyring_kmip/t/udf_test.test
+++ b/mysql-test/suite/component_keyring_kmip/t/udf_test.test
@@ -4,5 +4,11 @@
 --let $skip_secret_tests = 1
 
 --source ../inc/setup_component.inc
---source include/keyring_tests/mats/keyring_udf_test.inc
+--disable_query_log
+CALL mtr.add_suppression("std exception in function .size.: Message too long. Length: [0-9]+: I/O Failure");
+CALL mtr.add_suppression("std exception in function .store.: Invalid AES key length: 512 bits. Should be 128, 192 or 256 bits: Not Implemented");
+CALL mtr.add_suppression("std exception in function .store.: Invalid AES key length: 320 bits. Should be 128, 192 or 256 bits: Not Implemented");
+CALL mtr.add_suppression("std exception in function .store.: Invalid AES key length: 232 bits. Should be 128, 192 or 256 bits: Not Implemented");
+--enable_query_log
+--source ../inc/keyring_udf_test_kmip.inc
 --source ../inc/teardown_component.inc


### PR DESCRIPTION
There are 2 commits:
The 1-st commit is code change, and it is exactly the same as for 8.4:
---
Using new KMIP C++ library in keyring_kmip component

https://perconadev.atlassian.net/browse/PS-10070

The legacy kmip library with kmippp interface replaced by new kmipclient library.
The kmipclient library uses paged API to fetch all available keys. Also, the
code of keyring_kmip component has been made thread-safe

The kmip keyring backend now has 4 additional configuration parameters.
---
The 2-nd commit is test fixes, and these are different because of some messages changes:
---
Most KMIP servers rejects operation with 512 bit AES because it is not a standard.
So we have a "gate" in the libkmipclient that throws on non-standard AES key length.
Therefore, the udf_test from common test suite for all keyrings is modified and now
it is in component_keyring_kmip/inc/keyring_udf_test_kmip.inc.
Aslo, there are  fixes if test_encrypt_2.result because of small chnages of server messages
For 9.x branch there are more fixes because of changed messages, etc.