### PR TITLE
PS-10576 [8.0] Percona telemetry — safe non-default sysvars, global status

### DIFF
--- a/components/percona_telemetry/data_provider.cc
+++ b/components/percona_telemetry/data_provider.cc
@@ -14,14 +14,24 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
-#include <mysqld_error.h>
+#include <algorithm>
 #include <sstream>
 
 #include "data_provider.h"
 #include "logger.h"
+#include "telemetry_status_allowlist.h"
+#include "telemetry_sysvars_allowlist.h"
 
 namespace {
 inline const char *b2s(bool val) { return val ? "1" : "0"; }
+
+/* Reject values that look like paths (defense in depth: the allow list is
+   already curated, but we double-check at collection time in case a value
+   shape changes upstream). */
+inline bool is_value_safe_for_export(const std::string &value) {
+  return std::all_of(value.begin(), value.end(),
+                     [](unsigned char ch) { return ch != '/' && ch != '\\'; });
+}
 
 /*
   percona.telemetry user is created when server starts with telemetry
@@ -62,6 +72,11 @@ const char *size = "size";
 // server configuration variables
 const char *server_config_info = "server_config_info";
 const char *thread_handling = "thread_handling";
+const char *nondefault_allowlisted_sysvars = "nondefault_allowlisted_sysvars";
+const char *variable_source = "variable_source";
+const char *variable_value = "variable_value";
+const char *server_status_info = "server_status_info";
+const char *allowlisted_global_status = "allowlisted_global_status";
 }  // namespace JSONKey
 }  // namespace
 
@@ -602,8 +617,117 @@ bool DataProvider::collect_server_config(rapidjson::Document *document) {
                                  thread_handling, allocator);
   }
 
+  /*
+    Non-default globals: provenance from performance_schema.variables_info,
+    restricted to allowlisted names via SQL IN (...) (see
+    telemetry_sysvars_allowlist.h) and value shape via
+    is_value_safe_for_export() above.
+  */
+  if (!kSysvarsAllowlistCsv.empty()) {
+    std::ostringstream oss;
+    oss << "SELECT vi.VARIABLE_NAME, gv.VARIABLE_VALUE, vi.VARIABLE_SOURCE "
+           "FROM performance_schema.variables_info vi "
+           "INNER JOIN performance_schema.global_variables gv "
+           "USING (VARIABLE_NAME) "
+           "WHERE vi.VARIABLE_SOURCE <> 'COMPILED' "
+           "AND vi.VARIABLE_NAME IN ("
+        << kSysvarsAllowlistCsv << ')';
+
+    QueryResult rows;
+    if (!do_query(oss.str(), &rows, nullptr, true)) {
+      rapidjson::Value sysvars_array(rapidjson::Type::kArrayType);
+      for (const Row &row : rows) {
+        if (row.size() < 3) {
+          continue;
+        }
+        const std::string &vname = row[0];
+        const std::string &vval = row[1];
+        const std::string &vsrc = row[2];
+        if (!is_value_safe_for_export(vval)) {
+          continue;
+        }
+        rapidjson::Value one_status(rapidjson::Type::kObjectType);
+        rapidjson::Value name_json;
+        name_json.SetString(vname.c_str(),
+                            static_cast<rapidjson::SizeType>(vname.length()),
+                            allocator);
+        one_status.AddMember(rapidjson::StringRef(JSONKey::name), name_json,
+                             allocator);
+        rapidjson::Value val_json;
+        val_json.SetString(vval.c_str(),
+                           static_cast<rapidjson::SizeType>(vval.length()),
+                           allocator);
+        one_status.AddMember(rapidjson::StringRef(JSONKey::variable_value),
+                             val_json, allocator);
+        rapidjson::Value src_json;
+        src_json.SetString(vsrc.c_str(),
+                           static_cast<rapidjson::SizeType>(vsrc.length()),
+                           allocator);
+        one_status.AddMember(rapidjson::StringRef(JSONKey::variable_source),
+                             src_json, allocator);
+        sysvars_array.PushBack(one_status, allocator);
+      }
+
+      if (!sysvars_array.Empty()) {
+        server_config_json.AddMember(
+            rapidjson::StringRef(JSONKey::nondefault_allowlisted_sysvars),
+            sysvars_array, allocator);
+      }
+    }
+  }
+
   document->AddMember(rapidjson::StringRef(JSONKey::server_config_info),
                       server_config_json, allocator);
+
+  return false;
+}
+
+bool DataProvider::collect_server_status(rapidjson::Document *document) {
+  if (!kStatusAllowlistCsv.empty()) {
+    std::ostringstream oss;
+    oss << "SELECT VARIABLE_NAME, VARIABLE_VALUE FROM "
+           "performance_schema.global_status WHERE VARIABLE_NAME IN ("
+        << kStatusAllowlistCsv << ')';
+
+    QueryResult rows;
+    if (!do_query(oss.str(), &rows, nullptr, true)) {
+      rapidjson::Document::AllocatorType &allocator = document->GetAllocator();
+      rapidjson::Value status_array(rapidjson::Type::kArrayType);
+      for (const Row &row : rows) {
+        if (row.size() < 2) {
+          continue;
+        }
+        const std::string &vname = row[0];
+        const std::string &vval = row[1];
+        if (!is_value_safe_for_export(vval)) {
+          continue;
+        }
+        rapidjson::Value one_status(rapidjson::Type::kObjectType);
+        rapidjson::Value name_json;
+        name_json.SetString(vname.c_str(),
+                            static_cast<rapidjson::SizeType>(vname.length()),
+                            allocator);
+        one_status.AddMember(rapidjson::StringRef(JSONKey::name), name_json,
+                             allocator);
+        rapidjson::Value val_json;
+        val_json.SetString(vval.c_str(),
+                           static_cast<rapidjson::SizeType>(vval.length()),
+                           allocator);
+        one_status.AddMember(rapidjson::StringRef(JSONKey::variable_value),
+                             val_json, allocator);
+        status_array.PushBack(one_status, allocator);
+      }
+
+      if (!status_array.Empty()) {
+        rapidjson::Value server_status_json(rapidjson::Type::kObjectType);
+        server_status_json.AddMember(
+            rapidjson::StringRef(JSONKey::allowlisted_global_status),
+            status_array, allocator);
+        document->AddMember(rapidjson::StringRef(JSONKey::server_status_info),
+                            server_status_json, allocator);
+      }
+    }
+  }
 
   return false;
 }
@@ -634,6 +758,7 @@ bool DataProvider::collect_metrics(rapidjson::Document *document) {
   res |= collect_group_replication_info(document);
   res |= collect_async_replication_info(document);
   res |= collect_server_config(document);
+  res |= collect_server_status(document);
 
   /* The requirement is to have db_replication_id key at the top of JSON
   structure. But it may originate from the different places. The above

--- a/components/percona_telemetry/data_provider.h
+++ b/components/percona_telemetry/data_provider.h
@@ -88,6 +88,7 @@ class DataProvider {
   bool collect_group_replication_info(rapidjson::Document *document);
   bool collect_async_replication_info(rapidjson::Document *document);
   bool collect_server_config(rapidjson::Document *document);
+  bool collect_server_status(rapidjson::Document *document);
   bool collect_db_replication_id(rapidjson::Document *document);
   bool collect_metrics(rapidjson::Document *document);
 

--- a/components/percona_telemetry/telemetry_status_allowlist.h
+++ b/components/percona_telemetry/telemetry_status_allowlist.h
@@ -1,0 +1,120 @@
+/* Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef TELEMETRY_STATUS_ALLOWLIST_H
+#define TELEMETRY_STATUS_ALLOWLIST_H
+
+#include <string_view>
+
+/*
+  Allow list for performance_schema.global_status names collected by the
+  telemetry component. The names below are quoted, comma-joined and ready
+  to drop into SQL `IN (...)` (without surrounding parentheses). Adjacent
+  string literals concatenate at translation time, so this is one
+  contiguous read-only blob in `.rodata`; no allocation, no runtime
+  construction.
+
+  Maintenance:
+    * keep entries lexicographically sorted;
+    * every line ends with a trailing comma except the last;
+    * when adding/removing the last entry, fix up the comma on its neighbor.
+
+  Counters and numeric aggregates only; no SSL strings, paths, hostnames,
+  or InnoDB human-readable status strings. Values are still filtered
+  against `/` and `\` characters at collection time.
+*/
+inline constexpr std::string_view kStatusAllowlistCsv =
+    "'Aborted_clients',"
+    "'Aborted_connects',"
+    "'Acl_cache_items_count',"
+    "'Binlog_cache_disk_use',"
+    "'Binlog_cache_use',"
+    "'Binlog_stmt_cache_disk_use',"
+    "'Binlog_stmt_cache_use',"
+    "'Bytes_received',"
+    "'Bytes_sent',"
+    "'Com_delete',"
+    "'Com_insert',"
+    "'Com_select',"
+    "'Com_update',"
+    "'Connection_errors_internal',"
+    "'Connection_errors_max_connections',"
+    "'Connection_errors_peer_address',"
+    "'Connections',"
+    "'Created_tmp_disk_tables',"
+    "'Created_tmp_tables',"
+    "'Handler_commit',"
+    "'Handler_delete',"
+    "'Handler_read_first',"
+    "'Handler_read_key',"
+    "'Handler_read_next',"
+    "'Handler_read_prev',"
+    "'Handler_read_rnd',"
+    "'Handler_read_rnd_next',"
+    "'Handler_update',"
+    "'Handler_write',"
+    "'Innodb_buffer_pool_read_requests',"
+    "'Innodb_buffer_pool_reads',"
+    "'Innodb_data_read',"
+    "'Innodb_data_reads',"
+    "'Innodb_data_writes',"
+    "'Innodb_data_written',"
+    "'Innodb_dblwr_pages_written',"
+    "'Innodb_dblwr_writes',"
+    "'Innodb_log_waits',"
+    "'Innodb_log_write_requests',"
+    "'Innodb_log_writes',"
+    "'Innodb_os_log_written',"
+    "'Innodb_pages_created',"
+    "'Innodb_pages_read',"
+    "'Innodb_pages_written',"
+    "'Innodb_redo_log_read_only',"
+    "'Innodb_row_lock_time',"
+    "'Innodb_row_lock_time_avg',"
+    "'Innodb_row_lock_time_max',"
+    "'Innodb_row_lock_waits',"
+    "'Innodb_rows_deleted',"
+    "'Innodb_rows_inserted',"
+    "'Innodb_rows_read',"
+    "'Innodb_rows_updated',"
+    "'Libcoredumper_enabled',"
+    "'Max_used_connections',"
+    "'Open_files',"
+    "'Open_table_definitions',"
+    "'Open_tables',"
+    "'Prepared_stmt_count',"
+    "'Queries',"
+    "'Questions',"
+    "'Select_full_join',"
+    "'Select_full_range_join',"
+    "'Select_range',"
+    "'Select_range_check',"
+    "'Select_scan',"
+    "'Slow_queries',"
+    "'Sort_merge_passes',"
+    "'Sort_range',"
+    "'Sort_rows',"
+    "'Sort_scan',"
+    "'Table_locks_immediate',"
+    "'Table_locks_waited',"
+    "'Threadpool_idle_threads',"
+    "'Threadpool_threads',"
+    "'Threads_cached',"
+    "'Threads_connected',"
+    "'Threads_created',"
+    "'Threads_running'";
+
+#endif /* TELEMETRY_STATUS_ALLOWLIST_H */

--- a/components/percona_telemetry/telemetry_sysvars_allowlist.h
+++ b/components/percona_telemetry/telemetry_sysvars_allowlist.h
@@ -1,0 +1,190 @@
+/* Copyright (c) 2024 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef TELEMETRY_SYSVARS_ALLOWLIST_H
+#define TELEMETRY_SYSVARS_ALLOWLIST_H
+
+#include <string_view>
+
+/*
+  Allow list for global system variables collected by the telemetry
+  component. The names below are quoted, comma-joined and ready to drop
+  into SQL `IN (...)` (without surrounding parentheses). Adjacent string
+  literals concatenate at translation time, so this is one contiguous
+  read-only blob in `.rodata`; no allocation, no runtime construction.
+
+  Maintenance:
+    * keep entries lexicographically sorted;
+    * every line ends with a trailing comma except the last;
+    * when adding/removing the last entry, fix up the comma on its neighbor.
+
+  Policy: names whose values are usually numeric, enum, or ON/OFF only.
+  Paths, host lists, SSL file names, etc. are excluded; values are still
+  filtered against `/` and `\` characters at collection time.
+
+  Scope: common MySQL tuning, Percona-specific tuning, clone plugin, RocksDB
+  SE (when installed), semi-sync replication, binlog retention/compression.
+*/
+inline constexpr std::string_view kSysvarsAllowlistCsv =
+    "'binlog_checksum',"
+    "'binlog_expire_logs_auto_purge',"
+    "'binlog_expire_logs_seconds',"
+    "'binlog_format',"
+    "'binlog_order_commits',"
+    "'binlog_row_image',"
+    "'binlog_space_limit',"
+    "'binlog_transaction_compression',"
+    "'binlog_transaction_compression_level_zstd',"
+    "'binlog_transaction_dependency_history_size',"
+    "'binlog_transaction_dependency_tracking',"
+    "'clone_autotune_concurrency',"
+    "'clone_block_ddl',"
+    "'clone_buffer_size',"
+    "'clone_compression_algorithm',"
+    "'clone_ddl_timeout',"
+    "'clone_delay_after_data_drop',"
+    "'clone_donor_timeout_after_network_failure',"
+    "'clone_enable_compression',"
+    "'clone_max_concurrency',"
+    "'clone_max_data_bandwidth',"
+    "'clone_max_network_bandwidth',"
+    "'clone_zstd_compression_level',"
+    "'default_authentication_plugin',"
+    "'disconnect_on_expired_password',"
+    "'div_precision_increment',"
+    "'enforce_gtid_consistency',"
+    "'expand_fast_index_creation',"
+    "'explicit_defaults_for_timestamp',"
+    "'general_log',"
+    "'group_replication_consistency',"
+    "'group_replication_exit_state_action',"
+    "'group_replication_flow_control_mode',"
+    "'group_replication_single_primary_mode',"
+    "'gtid_mode',"
+    "'host_cache_size',"
+    "'innodb_adaptive_flushing',"
+    "'innodb_adaptive_hash_index',"
+    "'innodb_buffer_pool_instances',"
+    "'innodb_buffer_pool_size',"
+    "'innodb_change_buffering',"
+    "'innodb_checksum_algorithm',"
+    "'innodb_ddl_threads',"
+    "'innodb_deadlock_detect',"
+    "'innodb_dedicated_server',"
+    "'innodb_doublewrite',"
+    "'innodb_file_per_table',"
+    "'innodb_fill_factor',"
+    "'innodb_flush_log_at_trx_commit',"
+    "'innodb_flush_method',"
+    "'innodb_flush_neighbors',"
+    "'innodb_ft_cache_size',"
+    "'innodb_io_capacity',"
+    "'innodb_io_capacity_max',"
+    "'innodb_log_buffer_size',"
+    "'innodb_lru_scan_depth',"
+    "'innodb_max_dirty_pages_pct',"
+    "'innodb_max_dirty_pages_pct_lwm',"
+    "'innodb_old_blocks_pct',"
+    "'innodb_old_blocks_time',"
+    "'innodb_open_files',"
+    "'innodb_page_cleaners',"
+    "'innodb_parallel_read_threads',"
+    "'innodb_purge_threads',"
+    "'innodb_read_ahead_threshold',"
+    "'innodb_read_io_threads',"
+    "'innodb_redo_log_capacity',"
+    "'innodb_spin_wait_delay',"
+    "'innodb_stats_persistent',"
+    "'innodb_strict_mode',"
+    "'innodb_sync_spin_loops',"
+    "'innodb_thread_concurrency',"
+    "'innodb_write_io_threads',"
+    "'join_buffer_size',"
+    "'lock_wait_timeout',"
+    "'log_bin',"
+    "'log_error_verbosity',"
+    "'log_replica_updates',"
+    "'long_query_time',"
+    "'master_info_repository',"
+    "'max_allowed_packet',"
+    "'max_connections',"
+    "'max_heap_table_size',"
+    "'max_join_size',"
+    "'max_prepared_stmt_count',"
+    "'max_slowlog_files',"
+    "'max_slowlog_size',"
+    "'metadata_locks_cache_size',"
+    "'net_read_timeout',"
+    "'net_write_timeout',"
+    "'open_files_limit',"
+    "'optimizer_switch',"
+    "'performance_schema',"
+    "'read_buffer_size',"
+    "'read_only',"
+    "'read_rnd_buffer_size',"
+    "'relay_log_recovery',"
+    "'replica_compressed_protocol',"
+    "'replica_parallel_type',"
+    "'replica_parallel_workers',"
+    "'replica_preserve_commit_order',"
+    "'replica_type_conversions',"
+    "'rocksdb_block_cache_size',"
+    "'rocksdb_block_size',"
+    "'rocksdb_bytes_per_sync',"
+    "'rocksdb_compaction_readahead_size',"
+    "'rocksdb_db_write_buffer_size',"
+    "'rocksdb_enable_bulk_load_api',"
+    "'rocksdb_flush_log_at_trx_commit',"
+    "'rocksdb_max_background_compactions',"
+    "'rocksdb_max_background_flushes',"
+    "'rocksdb_max_background_jobs',"
+    "'rocksdb_max_open_files',"
+    "'rocksdb_max_subcompactions',"
+    "'rocksdb_use_io_uring',"
+    "'rocksdb_write_policy',"
+    "'rpl_semi_sync_master_enabled',"
+    "'rpl_semi_sync_replica_enabled',"
+    "'rpl_semi_sync_slave_enabled',"
+    "'rpl_semi_sync_source_enabled',"
+    "'skip_name_resolve',"
+    "'slow_query_log',"
+    "'slow_query_log_always_write_time',"
+    "'sort_buffer_size',"
+    "'sql_mode',"
+    "'sql_require_primary_key',"
+    "'super_read_only',"
+    "'sync_binlog',"
+    "'sync_source_info',"
+    "'table_definition_cache',"
+    "'table_open_cache',"
+    "'table_open_cache_instances',"
+    "'terminology_use_previous',"
+    "'thread_cache_size',"
+    "'thread_handling',"
+    "'thread_pool_high_prio_mode',"
+    "'thread_pool_high_prio_tickets',"
+    "'thread_pool_idle_timeout',"
+    "'thread_pool_max_threads',"
+    "'thread_pool_min_threads',"
+    "'thread_pool_oversubscribe',"
+    "'thread_pool_size',"
+    "'thread_pool_stall_limit',"
+    "'tmp_table_size',"
+    "'transaction_write_set_extraction',"
+    "'userstat',"
+    "'wait_timeout'";
+
+#endif /* TELEMETRY_SYSVARS_ALLOWLIST_H */

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10274,6 +10274,19 @@ static int show_telemetry_traces_support(THD * /*unused*/, SHOW_VAR *var,
   return 0;
 }
 
+/** ON iff libcoredumper is linked in and --coredumper is in effect. */
+static int show_libcoredumper_enabled(THD * /*unused*/, SHOW_VAR *var,
+                                      char *buf) {
+  var->type = SHOW_BOOL;
+  var->value = buf;
+#if HAVE_LIBCOREDUMPER
+  *(pointer_cast<bool *>(buf)) = opt_libcoredumper;
+#else
+  *(pointer_cast<bool *>(buf)) = false;
+#endif
+  return 0;
+}
+
 static int show_deprecated_use_i_s_processlist_count(THD *, SHOW_VAR *var,
                                                      char *buf) {
   var->type = SHOW_LONG;
@@ -10442,6 +10455,8 @@ SHOW_VAR status_vars[] = {
     {"Last_query_partial_plans",
      (char *)offsetof(System_status_var, last_query_partial_plans),
      SHOW_LONGLONG_STATUS, SHOW_SCOPE_SESSION},
+    {"Libcoredumper_enabled", (char *)&show_libcoredumper_enabled, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
     {"Locked_connects", (char *)&locked_account_connection_count, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
     {"Max_execution_time_exceeded",

--- a/unittest/gunit/components/percona_telemetry/CMakeLists.txt
+++ b/unittest/gunit/components/percona_telemetry/CMakeLists.txt
@@ -25,6 +25,10 @@ INCLUDE_DIRECTORIES(SYSTEM
   ${BOOST_INCLUDE_DIR}
 )
 
+# Match component build: RAPIDJSON_NO_SIZETYPEDEFINE needs my_rapidjson_size_t.h
+# before any rapidjson header (see data_provider.h).
+SET(PERCONA_TELEMETRY_COMPONENT_LIBS extra::rapidjson)
+
 SET(PERCONA_TELEMETRY_COMPONENT_SRC
   ${CMAKE_SOURCE_DIR}/components/percona_telemetry/data_provider.cc
 )
@@ -39,7 +43,8 @@ SET(TESTS
   )
 
 FOREACH(test ${TESTS})
-  MYSQL_ADD_EXECUTABLE(${test}-t ${PERCONA_TELEMETRY_COMPONENT_SRC} ${LOCAL_MOCK_SRC} ${test}-t.cc ADD_TEST ${test} LINK_LIBRARIES ${PERCONA_TELEMETRY_COMPONENT_LIBS})
-  TARGET_LINK_LIBRARIES(${test}-t mysys gunit_small)
+  MYSQL_ADD_EXECUTABLE(${test}-t ${PERCONA_TELEMETRY_COMPONENT_SRC} ${LOCAL_MOCK_SRC} ${test}-t.cc ADD_TEST ${test})
+  TARGET_INCLUDE_DIRECTORIES(${test}-t PRIVATE ${CMAKE_SOURCE_DIR}/include)
+  TARGET_LINK_LIBRARIES(${test}-t ${PERCONA_TELEMETRY_COMPONENT_LIBS} mysys gunit_small)
 ENDFOREACH()
 

--- a/unittest/gunit/components/percona_telemetry/data_provider-t.cc
+++ b/unittest/gunit/components/percona_telemetry/data_provider-t.cc
@@ -1,10 +1,26 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+#include <string_view>
+
 #define private public
 #include "components/percona_telemetry/data_provider.h"
 #include "components/percona_telemetry/logger.h"
+#include "components/percona_telemetry/telemetry_status_allowlist.h"
+#include "components/percona_telemetry/telemetry_sysvars_allowlist.h"
 #undef private
+
+namespace {
+bool csv_contains_quoted_name(std::string_view csv, std::string_view name) {
+  std::string needle;
+  needle.reserve(name.size() + 2);
+  needle += '\'';
+  needle.append(name);
+  needle += '\'';
+  return csv.find(needle) != std::string_view::npos;
+}
+}  // namespace
 
 using ::testing::_;
 using ::testing::A;
@@ -13,6 +29,7 @@ using ::testing::Eq;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::SetArgPointee;
+using ::testing::Truly;
 using ::testing::WithArg;
 
 SERVICE_TYPE_NO_CONST(mysql_command_factory) command_factory;
@@ -434,6 +451,108 @@ TEST_F(DataProviderTest, collect_async_replication_info_test) {
   EXPECT_TRUE(ri_iter->value.HasMember("is_replica"));
   iter = ri_iter->value.FindMember("is_replica");
   EXPECT_STREQ(iter->value.GetString(), "1");
+}
+
+TEST_F(DataProviderTest, AllowlistCsvContents) {
+  EXPECT_TRUE(
+      csv_contains_quoted_name(kSysvarsAllowlistCsv, "max_connections"));
+  EXPECT_FALSE(csv_contains_quoted_name(kSysvarsAllowlistCsv, "datadir"));
+  EXPECT_TRUE(csv_contains_quoted_name(kStatusAllowlistCsv, "Threads_running"));
+  EXPECT_TRUE(
+      csv_contains_quoted_name(kStatusAllowlistCsv, "Libcoredumper_enabled"));
+}
+
+TEST_F(DataProviderTest, CollectServerConfigNondefaultSysvars) {
+  MockDataProvider dataProvider;
+  testing::InSequence seq;
+  EXPECT_CALL(dataProvider,
+              do_query(Eq(std::string("SELECT @@thread_handling")),
+                       A<QueryResult *>(), _, _))
+      .WillOnce(DoAll(WithArg<1>(Invoke([](QueryResult *qr) {
+                        qr->clear();
+                        qr->push_back(Row{"one-thread-per-connection"});
+                      })),
+                      Return(false)));
+  EXPECT_CALL(
+      dataProvider,
+      do_query(Truly([](const std::string &q) {
+                 return q.find("performance_schema.variables_info") !=
+                            std::string::npos &&
+                        q.find("global_variables") != std::string::npos &&
+                        q.find("VARIABLE_NAME IN (") != std::string::npos &&
+                        q.find("'max_connections'") != std::string::npos;
+               }),
+               A<QueryResult *>(), _, true))
+      .WillOnce(DoAll(WithArg<1>(Invoke([](QueryResult *qr) {
+                        qr->clear();
+                        /* not allowlisted, allowlisted, allowlisted but
+                         * path-like value */
+                        qr->push_back(Row{"datadir", "/data/mysql", "GLOBAL"});
+                        qr->push_back(Row{"max_connections", "123", "GLOBAL"});
+                        qr->push_back(
+                            Row{"thread_handling", "foo/bar", "PERSISTED"});
+                      })),
+                      Return(false)));
+  rapidjson::Document document(rapidjson::Type::kObjectType);
+  EXPECT_FALSE(dataProvider.collect_server_config(&document));
+  ASSERT_TRUE(document.HasMember("server_config_info"));
+  const rapidjson::Value &sc = document.FindMember("server_config_info")->value;
+  EXPECT_TRUE(sc.HasMember("thread_handling"));
+  ASSERT_TRUE(sc.HasMember("nondefault_allowlisted_sysvars"));
+  const rapidjson::Value &arr =
+      sc.FindMember("nondefault_allowlisted_sysvars")->value;
+  ASSERT_TRUE(arr.IsArray());
+  ASSERT_EQ(arr.Size(), 1U);
+  EXPECT_STREQ(arr[0]["name"].GetString(), "max_connections");
+  EXPECT_STREQ(arr[0]["variable_value"].GetString(), "123");
+  EXPECT_STREQ(arr[0]["variable_source"].GetString(), "GLOBAL");
+  EXPECT_FALSE(sc.HasMember("libcoredumper_enabled"));
+}
+
+TEST_F(DataProviderTest, CollectServerStatusAllowlisted) {
+  MockDataProvider dataProvider;
+  EXPECT_CALL(
+      dataProvider,
+      do_query(Truly([](const std::string &q) {
+                 return q.find("performance_schema.global_status") !=
+                            std::string::npos &&
+                        q.find("Threads_running") != std::string::npos &&
+                        q.find("Libcoredumper_enabled") != std::string::npos;
+               }),
+               A<QueryResult *>(), _, true))
+      .WillOnce(DoAll(WithArg<1>(Invoke([](QueryResult *qr) {
+                        qr->clear();
+                        qr->push_back(Row{"Threads_running", "7"});
+                        qr->push_back(Row{"Libcoredumper_enabled", "OFF"});
+                        /* Allowlisted name but path-like value: must be
+                         * dropped. */
+                        qr->push_back(Row{"Slow_queries", "/var/lib"});
+                      })),
+                      Return(false)));
+
+  rapidjson::Document document(rapidjson::Type::kObjectType);
+  EXPECT_FALSE(dataProvider.collect_server_status(&document));
+  ASSERT_TRUE(document.HasMember("server_status_info"));
+  const rapidjson::Value &ss = document.FindMember("server_status_info")->value;
+  ASSERT_TRUE(ss.HasMember("allowlisted_global_status"));
+  const rapidjson::Value &st =
+      ss.FindMember("allowlisted_global_status")->value;
+  ASSERT_TRUE(st.IsArray());
+  ASSERT_EQ(st.Size(), 2U);
+  bool saw_threads = false;
+  bool saw_core = false;
+  for (unsigned i = 0; i < st.Size(); ++i) {
+    if (!strcmp(st[i]["name"].GetString(), "Threads_running")) {
+      EXPECT_STREQ(st[i]["variable_value"].GetString(), "7");
+      saw_threads = true;
+    }
+    if (!strcmp(st[i]["name"].GetString(), "Libcoredumper_enabled")) {
+      EXPECT_STREQ(st[i]["variable_value"].GetString(), "OFF");
+      saw_core = true;
+    }
+  }
+  EXPECT_TRUE(saw_threads);
+  EXPECT_TRUE(saw_core);
 }
 
 }  // namespace data_provider_unittests


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10576

Extend the percona_telemetry component so periodic reports include how the server is configured and exercise

Configuration (server_config_info)
Report non-default global system variables whose
provenance is not COMPILED, using performance_schema.variables_info joined to global_variables. Only explicitly allowlisted names are collected; values that look like paths (containing / or \) are dropped.

Global status (server_status_info)
Add a separate JSON subtree for allowlisted
performance_schema.global_status rows (name + value), again with path-like value filtering. This keeps counters and usage signals (including Threads_running and Libcoredumper_enabled) out of the config blob.

Server: libcoredumper introspection
Expose a read-only global status Libcoredumper_enabled (ON when built with libcoredumper and the feature is enabled, otherwise OFF).