### PR TITLE
PS-11142 [9.7]: clang-18/22 + Apple clang 15 + GCC 11-16 build fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
       fi
 
 - job:
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   pool:
     vmImage: $(imageName)
 
@@ -212,7 +212,19 @@ jobs:
 
 
       # gcc-11 and newer compilers
-      gcc-14 RelWithDebInfo [Ubuntu 24.04 Noble]:
+      gcc-16 RelWithDebInfo [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        Compiler: gcc
+        CompilerVer: 16
+        BuildType: RelWithDebInfo
+
+      gcc-16 Debug [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        Compiler: gcc
+        CompilerVer: 16
+        BuildType: Debug
+
+      gcc-15 RelWithDebInfo [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         Compiler: gcc
         CompilerVer: 15

--- a/components/audit_log_filter/audit_log_reader.cc
+++ b/components/audit_log_filter/audit_log_reader.cc
@@ -28,6 +28,7 @@
 #include "mysql/components/library_mysys/my_memory.h"
 
 #include <scope_guard.h>
+#include <algorithm>
 #include <filesystem>
 #include <functional>
 #include <string>

--- a/components/audit_log_filter/log_writer/base.cc
+++ b/components/audit_log_filter/log_writer/base.cc
@@ -29,6 +29,8 @@ LogWriterBase::LogWriterBase(
     std::unique_ptr<log_record_formatter::LogRecordFormatterBase> formatter)
     : m_formatter{std::move(formatter)} {}
 
+LogWriterBase::~LogWriterBase() = default;
+
 void LogWriterBase::init_formatter() noexcept { SysVars::init_record_id(0); }
 
 void LogWriterBase::write(const AuditRecordVariant &record) noexcept {

--- a/components/audit_log_filter/log_writer/base.h
+++ b/components/audit_log_filter/log_writer/base.h
@@ -62,7 +62,7 @@ class LogWriterBase {
   explicit LogWriterBase(
       std::unique_ptr<log_record_formatter::LogRecordFormatterBase> formatter);
 
-  virtual ~LogWriterBase() = default;
+  virtual ~LogWriterBase();
 
   /**
    * @brief Init log writer.

--- a/components/keyrings/keyring_kmip/config/config.cc
+++ b/components/keyrings/keyring_kmip/config/config.cc
@@ -142,9 +142,15 @@ bool find_and_read_config_file(std::unique_ptr<Config_pod> &config_pod) {
     // optional attribute
   }
 
-  if (config_reader->get_element<size_t>(config_options[7],
-                                         config_pod_tmp.get()->max_objects)) {
-    // optional attribute
+  // rapidjson's TypeHelper has specializations for the fixed-width integer
+  // typedefs (uint64_t etc.) but not for size_t. On macOS / Apple clang +
+  // libc++, size_t is 'unsigned long' which has no TypeHelper specialization,
+  // so get_element<size_t>() fails to compile. Read into a uint64_t and
+  // assign back on success; uint64_t is recognized on all platforms.
+  if (uint64_t max_objects_tmp = config_pod_tmp.get()->max_objects;
+      !config_reader->get_element<uint64_t>(config_options[7],
+                                            max_objects_tmp)) {
+    config_pod_tmp.get()->max_objects = static_cast<size_t>(max_objects_tmp);
   }
 
   if (config_reader->get_element<int>(config_options[8],

--- a/components/telemetry/CMakeLists.txt
+++ b/components/telemetry/CMakeLists.txt
@@ -116,3 +116,10 @@ ENDIF()
 IF(MY_COMPILER_IS_GNU)
   TARGET_LINK_OPTIONS(component_telemetry PRIVATE -Wno-alloc-size-larger-than)
 ENDIF()
+
+# GCC 12 emits a false-positive -Werror=restrict in libstdc++'s basic_string
+# inlined into telemetry::validate_tls_cipher (string assignment of a literal
+# inside a loop). Newer GCCs do not warn here.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+  ADD_COMPILE_FLAGS(tm_system_variables.cc COMPILE_FLAGS "-Wno-restrict")
+ENDIF()

--- a/libs/mysql/binlog/event/CMakeLists.txt
+++ b/libs/mysql/binlog/event/CMakeLists.txt
@@ -84,6 +84,15 @@ SET(TARGET_SRCS
 ADD_WSHADOW_WARNING()
 DISABLE_MISSING_PROFILE_WARNING()
 
+# GCC 16's -O2 analysis emits false-positive -Wmaybe-uninitialized warnings
+# inside Write/Update/Delete_rows_event constructors and their inlined
+# Event_reader helpers. The events are populated by READER_TRY_INITIALIZATION
+# down a path the optimizer cannot fully follow.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(rows_event.cpp
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
+
 LIBS_MYSQL_CREATE_LIBRARY(mysql_binlog_event
   TARGET_SRCS ${TARGET_SRCS}
   TARGET_HEADERS ${TARGET_HEADERS}

--- a/plugin/x/CMakeLists.txt
+++ b/plugin/x/CMakeLists.txt
@@ -77,6 +77,16 @@ INCLUDE_DIRECTORIES(
   ${MYSQLX_CLIENT_INCLUDE_DIR}
 )
 
+# GCC 16's -O2 analysis emits a false-positive -Wmaybe-uninitialized warning
+# inside xpl::Cond / xpl::RWLock constructors when inline_mysql_cond_init /
+# inline_mysql_rwlock_init are inlined.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(
+    src/helper/multithread/cond.cc
+    src/helper/multithread/rw_lock.cc
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
+
 # MYSQL_ADD_PLUGIN may have disabled the plugin.
 IF(WITH_MYSQLX)
   MYSQL_ADD_PLUGIN(${MYSQLX_PLUGIN_NAME}

--- a/router/src/destination_status/src/unreachable_destinations_quarantine.cc
+++ b/router/src/destination_status/src/unreachable_destinations_quarantine.cc
@@ -25,6 +25,7 @@
 
 #include "unreachable_destinations_quarantine.h"
 
+#include "my_compiler.h"
 #include "mysql/harness/destination_endpoint.h"
 #include "mysql/harness/logging/logging.h"
 #include "mysql/harness/resolver/resolver.h"
@@ -403,7 +404,12 @@ stdx::expected<void, std::error_code> UnreachableDestinationsQuarantine::
     for (const auto &addr : (*resolve_res).addresses) {
       mysql_harness::DestinationEndpoint::TcpType endpoint{addr,
                                                            tcp_dest.port()};
+      // GCC 15 emits a false-positive -Wmaybe-uninitialized warning here when
+      // constructing the std::variant alternative inside DestinationEndpoint.
+      MY_COMPILER_DIAGNOSTIC_PUSH();
+      MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized");
       endpoints_.emplace_back(std::move(endpoint));
+      MY_COMPILER_DIAGNOSTIC_POP();
     }
 
   } else {

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -916,7 +916,9 @@ IF(MY_COMPILER_IS_GNU_OR_CLANG)
   ADD_COMPILE_FLAGS(${CMAKE_CURRENT_BINARY_DIR}/sql_yacc.cc
                     ${CMAKE_CURRENT_BINARY_DIR}/sql_hints.yy.cc
                     COMPILE_FLAGS "-Wno-undef -Wno-unused-label")
-  IF(MY_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
+  IF((MY_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
+     OR
+     (MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16))
     ADD_COMPILE_FLAGS(${CMAKE_CURRENT_BINARY_DIR}/sql_yacc.cc
                       ${CMAKE_CURRENT_BINARY_DIR}/sql_hints.yy.cc
                       COMPILE_FLAGS "-Wno-unused-but-set-variable")
@@ -1009,6 +1011,18 @@ IF(COMPRESS_DEBUG_SECTIONS)
 ENDIF()
 
 ADD_LIBRARY(sql_dd STATIC ${DD_SOURCES})
+# GCC 16's -O2 analysis emits false-positive -Wmaybe-uninitialized warnings
+# inside libstdc++ basic_string code instantiated for the dd::String_type
+# allocator (Stateless_allocator<char, dd::String_type_alloc>) when assigning
+# strings inside the generated dd::Object_table_definition_impl-derived
+# constructors.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(
+    dd/impl/tables/index_stats.cc
+    dd/impl/tables/table_stats.cc
+    dd/impl/tables/triggers.cc
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
 ADD_DEPENDENCIES(sql_dd GenFixPrivs)
 ADD_DEPENDENCIES(sql_dd GenServerSource)
 ADD_DEPENDENCIES(sql_dd GenDigestServerSource)

--- a/sql/json_duality_view/dml.cc
+++ b/sql/json_duality_view/dml.cc
@@ -1052,9 +1052,15 @@ template <typename RT, typename BIN>
     for (auto &col : bin.ct_node->key_column_info_list()) {
       // For non-projected columns an empty string_view is stored for the key
       Json_dom *val = get_val(bin.bound_object, col.key());
-      resolved_columns.emplace_back(
+      // Resolve_column is an aggregate (no user-provided constructor).
+      // GCC/clang 16+ accept emplace_back forwarding into parenthesized
+      // aggregate init (P0960), but Apple clang 15 / libc++ rejects it
+      // because std::construct_at uses placement-new that doesn't
+      // synthesize an aggregate constructor. Use push_back with brace
+      // init instead.
+      resolved_columns.push_back(Resolve_column{
           &col, val,
-          field_will_be_auto_generated(current_thd, *col.field(), val));
+          field_will_be_auto_generated(current_thd, *col.field(), val)});
     }
   }
 

--- a/sql/query_term.cc
+++ b/sql/query_term.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <utility>
 #include "my_base.h"
+#include "my_compiler.h"
 #include "my_inttypes.h"
 #include "mysql/udf_registration_types.h"
 #include "mysql_com.h"
@@ -924,10 +925,20 @@ bool Query_block::prepare_query_term(
 AccessPath *Query_block::make_set_op_access_path(
     THD *thd, Query_term_set_op *parent, Mem_root_array<AppendPathParameters> *,
     bool calc_found_rows) {
+  // Callers only reach this Query_block override with a non-null parent
+  // (siblings dispatching via term->make_set_op_access_path() with a null
+  // parent are guarded by an explicit !QT_QUERY_BLOCK check, so they go to
+  // a Query_term_set_op/Query_term_unary override instead). GCC 16's
+  // devirtualizing inliner can't see that invariant and emits a false
+  // -Werror=nonnull on parent->setup_materialize_set_op(...) below.
+  assert(parent != nullptr);
   AccessPath *path = nullptr;
   TABLE *const dest = setop_query_result_union()->table;
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wnonnull")
   Mem_root_array<MaterializePathParameters::Operand> operands =
       parent->setup_materialize_set_op(thd, dest, false, calc_found_rows);
+  MY_COMPILER_DIAGNOSTIC_POP()
   path = add_materialized_access_path(thd, parent, operands, dest);
 
   return path;

--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -3613,7 +3613,7 @@ int do_sj_dups_weedout(THD *thd, SJ_TMP_TABLE *sjtbl) {
   }
 
   // 3. Put the rowids
-  for (uint i = 0; tab != tab_end; tab++, i++) {
+  for (; tab != tab_end; tab++) {
     handler *h = tab->qep_tab->table()->file;
     if (tab->qep_tab->table()->is_nullable() &&
         tab->qep_tab->table()->has_null_row()) {

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -3713,7 +3713,6 @@ void get_partition_set(const TABLE *table, uchar *buf, const uint index,
                        const key_range *key_spec, part_id_range *part_spec) {
   partition_info *part_info = table->part_info;
   const uint num_parts = part_info->get_tot_partitions();
-  uint i, part_id;
   uint sub_part = num_parts;
   uint32 part_part = num_parts;
   KEY *key_info = nullptr;
@@ -3841,9 +3840,8 @@ void get_partition_set(const TABLE *table, uchar *buf, const uint index,
       part_spec->start_part = sub_part;
       part_spec->end_part =
           sub_part + (part_info->num_subparts * (part_info->num_parts - 1));
-      for (i = 0, part_id = sub_part; i < part_info->num_parts;
-           i++, part_id += part_info->num_subparts)
-        ;  // Set bit part_id in bit array
+      // TODO: Set bit part_id in bit array (loop removed because it was a
+      // no-op; placeholder for future bit-array support).
     }
   }
   if (found_part_field) clear_indicator_in_key_fields(key_info);

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3054,7 +3054,7 @@ static int construct_options(MEM_ROOT *mem_root, st_plugin_int *tmp,
   char *comment = (char *)mem_root->Alloc(max_comment_len + 1);
   char *optname;
 
-  int index = 0, offset = 0;
+  int offset = 0;
   SYS_VAR *opt, **plugin_option;
   st_bookmark *v;
 
@@ -3120,7 +3120,7 @@ static int construct_options(MEM_ROOT *mem_root, st_plugin_int *tmp,
   */
 
   for (plugin_option = tmp->plugin->system_vars;
-       plugin_option && *plugin_option; plugin_option++, index++) {
+       plugin_option && *plugin_option; plugin_option++) {
     opt = *plugin_option;
     if (!(opt->flags & PLUGIN_VAR_THDLOCAL)) continue;
     if (!(register_var(plugin_name_ptr, opt->name, opt->flags))) continue;
@@ -3168,7 +3168,7 @@ static int construct_options(MEM_ROOT *mem_root, st_plugin_int *tmp,
   }
 
   for (plugin_option = tmp->plugin->system_vars;
-       plugin_option && *plugin_option; plugin_option++, index++) {
+       plugin_option && *plugin_option; plugin_option++) {
     switch ((opt = *plugin_option)->flags & PLUGIN_VAR_TYPEMASK) {
       case PLUGIN_VAR_BOOL:
         if (!opt->check) opt->check = check_func_bool;

--- a/sql/sql_profile.cc
+++ b/sql/sql_profile.cc
@@ -667,8 +667,6 @@ int PROFILING::print_current(IO_CACHE *log_file) const noexcept {
 
   my_b_printf(log_file, "# ");
 
-  ulonglong row_number = 0;
-
   QUERY_PROFILE *const query = current;
 
   void *entry_iterator;
@@ -677,7 +675,7 @@ int PROFILING::print_current(IO_CACHE *log_file) const noexcept {
   for (entry_iterator = query->entries.new_iterator();
        entry_iterator != nullptr;
        entry_iterator = query->entries.iterator_next(entry_iterator),
-      previous = entry, row_number++) {
+      previous = entry) {
     entry = query->entries.iterator_value(entry_iterator);
 
     /* Skip the first.  We count spans of fence, not fence-posts. */
@@ -728,7 +726,6 @@ int PROFILING::print_current(IO_CACHE *log_file) const noexcept {
 int PROFILING::fill_statistics_info(THD *thd_arg, Table_ref *tables) {
   DBUG_TRACE;
   TABLE *table = tables->table;
-  ulonglong row_number = 0;
 
   QUERY_PROFILE *query;
   /* Go through each query in this thread's stored history... */
@@ -750,7 +747,7 @@ int PROFILING::fill_statistics_info(THD *thd_arg, Table_ref *tables) {
     for (entry_iterator = query->entries.new_iterator();
          entry_iterator != nullptr;
          entry_iterator = query->entries.iterator_next(entry_iterator),
-        previous = entry, row_number++) {
+        previous = entry) {
       entry = query->entries.iterator_value(entry_iterator);
       seq = entry->m_seq;
 

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -5836,8 +5836,7 @@ bool Query_block::transform_table_subquery_to_join_with_derived(
     // list. Correct context info of outer expressions.
     auto it_outer = sj_outer_exprs.begin() + initial_sj_inner_exprs_count;
     auto it_inner = sj_inner_exprs.begin() + initial_sj_inner_exprs_count;
-    for (int i = 0; it_outer != sj_outer_exprs.end();
-         ++it_outer, ++it_inner, ++i) {
+    for (; it_outer != sj_outer_exprs.end(); ++it_outer, ++it_inner) {
       Item *inner = *it_inner;
       Item *outer = *it_outer;
       // In setup_base_ref_items() we allocated space for appending this

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -4508,8 +4508,7 @@ bool TABLE::fill_item_list(mem_root_deque<Item *> *item_list) const {
     All Item_field's created using a direct pointer to a field
     are fixed in Item_field constructor.
   */
-  uint i = 0;
-  for (Field **ptr = visible_field_ptr(); *ptr; ptr++, i++) {
+  for (Field **ptr = visible_field_ptr(); *ptr; ptr++) {
     Item_field *item = new Item_field(*ptr);
     if (!item) return true;
     item_list->push_back(item);

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -128,7 +128,12 @@ typedef I_P_List<connection_t,
                  I_P_List_counter, I_P_List_fast_push_back<connection_t>>
     connection_queue_t;
 
-struct alignas(128) thread_group_t {
+// Data members live in a separate base struct so that thread_group_t's
+// trailing padding can be sized from sizeof(thread_group_data_t).
+// mysql_mutex_t is larger on macOS / libc++ than on Linux/glibc, and
+// hand-tuning 'padding[N]' against the Linux layout broke the build
+// elsewhere; deriving N keeps sizeof(thread_group_t) == 512 everywhere.
+struct thread_group_data_t {
   mysql_mutex_t mutex;
   connection_queue_t queue;
   connection_queue_t high_prio_queue;
@@ -149,7 +154,14 @@ struct alignas(128) thread_group_t {
   int shutdown_pipe[2];
   bool shutdown;
   bool stalled;
-  char padding[248];
+};
+
+static_assert(sizeof(thread_group_data_t) < 512,
+              "thread_group_data_t must fit inside 512 bytes so that "
+              "thread_group_t can be padded to exactly 512");
+
+struct alignas(128) thread_group_t : thread_group_data_t {
+  char padding[512 - sizeof(thread_group_data_t)];
 };
 
 static_assert(sizeof(thread_group_t) == 512,

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1270,7 +1270,11 @@ bool ha_federated::create_where_from_key(String *to, KEY *key_info,
   const bool both_not_null =
       (start_key != nullptr && end_key != nullptr) ? true : false;
   uchar *ptr;
-  uint remainder, length;
+  // 'remainder' is only consumed by DBUG_PRINT and assert, both compiled out
+  // in release builds; mark as [[maybe_unused]] so GCC 16 doesn't warn under
+  // -Werror=unused-but-set-variable.
+  [[maybe_unused]] uint remainder;
+  uint length;
   char tmpbuff[FEDERATED_QUERY_BUFFER_SIZE];
   String tmp(tmpbuff, sizeof(tmpbuff), system_charset_info);
   const key_range *ranges[2] = {start_key, end_key};

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -6144,11 +6144,10 @@ to rebuild the template.
 static bool alter_templ_needs_rebuild(TABLE *altered_table,
                                       Alter_inplace_info *ha_alter_info,
                                       dict_table_t *table) {
-  ulint i = 0;
   List_iterator_fast<Create_field> cf_it(
       ha_alter_info->alter_info->create_list);
 
-  for (Field **fp = altered_table->field; *fp; fp++, i++) {
+  for (Field **fp = altered_table->field; *fp; fp++) {
     cf_it.rewind();
     while (const Create_field *cf = cf_it++) {
       for (ulint j = 0; j < table->n_cols; j++) {

--- a/storage/myisam/rt_index.cc
+++ b/storage/myisam/rt_index.cc
@@ -685,7 +685,6 @@ static int rtree_delete_req(MI_INFO *info, MI_KEYDEF *keyinfo, uchar *key,
                             stPageList *ReinsertList, int level) {
   uchar *k;
   uchar *last;
-  ulong i;
   uint nod_flag;
   uchar *page_buf;
   int res;
@@ -704,7 +703,7 @@ static int rtree_delete_req(MI_INFO *info, MI_KEYDEF *keyinfo, uchar *key,
   k = rt_PAGE_FIRST_KEY(page_buf, nod_flag);
   last = rt_PAGE_END(page_buf);
 
-  for (i = 0; k < last; k = rt_PAGE_NEXT_KEY(k, key_length, nod_flag), ++i) {
+  for (; k < last; k = rt_PAGE_NEXT_KEY(k, key_length, nod_flag)) {
     if (nod_flag) {
       /* not leaf */
       if (!rtree_key_cmp(keyinfo->seg, key, k, key_length, MBR_WITHIN)) {

--- a/storage/myisam/sp_key.cc
+++ b/storage/myisam/sp_key.cc
@@ -54,7 +54,6 @@ uint sp_make_key(MI_INFO *info, uint keynr, uchar *key, const uchar *record,
   uint dlen;
   uchar *dptr;
   double mbr[SPDIMS * 2];
-  uint i;
 
   keyseg = &keyinfo->seg[-1];
   pos = record + keyseg->start;
@@ -67,7 +66,7 @@ uint sp_make_key(MI_INFO *info, uint keynr, uchar *key, const uchar *record,
   }
   sp_mbr_from_wkb(dptr + 4, dlen - 4, SPDIMS, mbr); /* SRID */
 
-  for (i = 0, keyseg = keyinfo->seg; keyseg->type; keyseg++, i++) {
+  for (keyseg = keyinfo->seg; keyseg->type; keyseg++) {
     uint length = keyseg->length, start = keyseg->start;
     double val;
 

--- a/storage/ndb/CMakeLists.txt
+++ b/storage/ndb/CMakeLists.txt
@@ -178,6 +178,16 @@ FOREACH(warning
   ENDIF()
 ENDFOREACH()
 
+# GCC 16's -O2 analysis emits many false-positive -Wuninitialized /
+# -Wmaybe-uninitialized warnings in NDB, where signal data filled by
+# transporter/network code (e.g. NdbApiSignal::theRealData) is read through
+# CAST_CONSTPTR-style reinterpret casts the optimizer cannot follow. Suppress
+# both warnings for the NDB tree on GCC 16+ to keep -Werror builds working.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  STRING_APPEND(CMAKE_C_FLAGS   " -Wno-uninitialized -Wno-maybe-uninitialized")
+  STRING_APPEND(CMAKE_CXX_FLAGS " -Wno-uninitialized -Wno-maybe-uninitialized")
+ENDIF()
+
 INCLUDE(${CMAKE_CURRENT_SOURCE_DIR}/ndb_configure.cmake)
 
 INCLUDE_DIRECTORIES(

--- a/storage/ndb/src/common/util/testSecureSocket.cpp
+++ b/storage/ndb/src/common/util/testSecureSocket.cpp
@@ -32,6 +32,7 @@
 #include "openssl/x509.h"
 
 #include "debugger/EventLogger.hpp"
+#include "my_compiler.h"
 #include "portlib/NdbGetRUsage.h"
 #include "portlib/NdbMutex.h"
 #include "portlib/NdbSleep.h"
@@ -167,11 +168,17 @@ static struct my_option options[] = {
 
 class EchoSession : public SocketServer::Session {
  public:
+  // GCC 16 emits a false-positive -Wmaybe-uninitialized warning here when
+  // the base SocketServer::Session is initialized with a reference to the
+  // not-yet-initialized m_secure_socket member.
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")
   EchoSession(NdbSocket &&s, bool sink, SSL_CTX *ctx)
       : SocketServer::Session(m_secure_socket),
         m_sink(sink),
         m_ssl_ctx(ctx),
         m_secure_socket(std::move(s)) {}
+  MY_COMPILER_DIAGNOSTIC_POP()
   void runSession() override;
 
  private:

--- a/storage/ndb/src/common/util/testTlsKeyManager.cpp
+++ b/storage/ndb/src/common/util/testTlsKeyManager.cpp
@@ -32,6 +32,7 @@
 #include <cstdarg>
 
 #include "debugger/EventLogger.hpp"
+#include "my_compiler.h"
 #include "ndb_init.h"
 #include "portlib/NdbDir.hpp"
 #include "portlib/NdbTCP.h"
@@ -288,10 +289,16 @@ class Session : public SocketServer::Session {
   NdbSocket m_socket;
 
  public:
+  // GCC 16 emits a false-positive -Wmaybe-uninitialized warning here when
+  // the base SocketServer::Session is initialized with a reference to the
+  // not-yet-initialized m_socket member.
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")
   Session(NdbSocket &&socket, class Service *server)
       : SocketServer::Session(m_socket),
         m_server(server),
         m_socket(std::move(socket)) {}
+  MY_COMPILER_DIAGNOSTIC_POP()
   void runSession() override;
 };
 

--- a/storage/ndb/src/kernel/blocks/trpman.cpp
+++ b/storage/ndb/src/kernel/blocks/trpman.cpp
@@ -846,7 +846,7 @@ unsigned Trpman::calculate_histogram_bin_limits(
    * Use minimal sized bins until a suitable scaling factor is found for
    * exponential part or that bin for heartbeat interval is next.
    */
-  double factor;                   // calculated during part 1, used in part 2
+  double factor = 0.0;             // calculated during part 1, used in part 2
   unsigned first_part2_limit = 0;  // 0 indicates no value
   unsigned first_part3_limit = 0;
   unsigned bin_limit = min_bin_width;

--- a/storage/ndb/tools/restore/Restore.hpp
+++ b/storage/ndb/tools/restore/Restore.hpp
@@ -654,7 +654,7 @@ class RestoreLogger {
 
  private:
   void vlog_ll(FilteredNdbOut &out, const char *ll, const char *fmt, va_list ap)
-      ATTRIBUTE_FORMAT(printf, 3, 0);
+      ATTRIBUTE_FORMAT(printf, 4, 0);
 
   NdbMutex *m_mutex;
   char timestamp[64];

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -242,6 +242,18 @@ IF(CMAKE_COMPILER_IS_GNUCXX AND WITH_ASAN)
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-error=maybe-uninitialized FILES rocksdb/util/bloom.cc)
 ENDIF()
 
+# GCC 16 -O2 emits false-positive -Wmaybe-uninitialized warnings on:
+#  - autovector::front() inlined into LevelCompactionBuilder::SetupInitialFiles()
+#    (the optimizer cannot see that !expired_files.empty() implies buf_[0]
+#    was written),
+#  - PSI inlining inside myrocks::Rdb_cond_var / Rdb_mutex constructors in
+#    rdb_mutex_wrapper.cc (same pattern as the plugin/x suppression).
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-maybe-uninitialized
+    FILES rocksdb/db/compaction/compaction_picker_level.cc
+          rdb_mutex_wrapper.cc)
+ENDIF()
+
 
 IF(FB_WITH_WSENV)
   ADD_DEFINITIONS(-DFB_HAVE_WSENV=1)

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -230,14 +230,11 @@ IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-restrict FILES rocksdb/table/iterator.cc rocksdb/table/unique_id.cc)
 ENDIF()
 
-# Suppress warnings for gcc-14 or newer
-IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-declarations FILES rocksdb/db/memtable.cc)
-ENDIF()
-
-# Suppress warnings for gcc-15 or newer
-IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-declarations FILES rocksdb/db/write_batch.cc rocksdb/util/random.cc)
+# Suppress -Wdeprecated-declarations for files that use APIs deprecated in
+# C++23 (e.g. std::aligned_storage). libstdc++ has emitted these deprecations
+# in C++23 mode since gcc-13.
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-declarations FILES rocksdb/db/memtable.cc rocksdb/db/write_batch.cc rocksdb/util/random.cc)
 ENDIF()
 
 # Suppress warnings for gcc ASan build

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -17,6 +17,7 @@
 
 /* C++ standard header files */
 #include <chrono>
+#include <functional>
 #include <regex>
 #include <string>
 #include <unordered_map>

--- a/unittest/gunit/temporal-t.cc
+++ b/unittest/gunit/temporal-t.cc
@@ -395,8 +395,11 @@ TEST(Date_val, MYSQL_TIME) {
   MYSQL_TIME mt = static_cast<MYSQL_TIME>(date1);
   Date_val date2 = Date_val{mt};
   EXPECT_EQ(0, date1.compare(date2));
-  MYSQL_TIME mytime(2023, 1, 30, 12, 0, 0, 0, false, MYSQL_TIMESTAMP_DATETIME,
-                    0);
+  // MYSQL_TIME is an aggregate (no user-provided constructor); use brace
+  // initialization. GCC and modern clang accept parenthesized aggregate
+  // initialization (P0960), but Apple clang 15 does not.
+  MYSQL_TIME mytime{2023, 1, 30, 12, 0, 0, 0, false, MYSQL_TIMESTAMP_DATETIME,
+                    0};
   Date_val a(2023, 1, 30);
   EXPECT_EQ(Date_val::strip_time(mytime), a);
   Date_val b{mt};

--- a/unittest/gunit/xplugin/xcl/message_helpers.h
+++ b/unittest/gunit/xplugin/xcl/message_helpers.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <type_traits>
 
+#include "my_compiler.h"
 #include "plugin/x/client/mysqlxclient/xmessage.h"
 #include "plugin/x/client/mysqlxclient/xprotocol.h"
 
@@ -53,8 +54,13 @@ class Message_from_str {
 template <typename M>
 class Message_compare {
  public:
+  // GCC 16 emits a false-positive -Wmaybe-uninitialized warning when the
+  // m_expected_text_reformated string is initialized via reformat_text_message.
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")
   explicit Message_compare(const std::string &text_message)
       : m_expected_text_reformated(reformat_text_message(text_message)) {}
+  MY_COMPILER_DIAGNOSTIC_POP()
 
   explicit Message_compare(const M &message) {
     ::google::protobuf::TextFormat::PrintToString(message,


### PR DESCRIPTION
## Summary
Toolchain compatibility fixes that arose while validating the 9.7.0-1 branch against a wider compiler/stdlib matrix than the 9.6.0-1 baseline. No functional changes — every patch is gated on the relevant compiler version or is a strict no-op (init / cast / brace-init / extra include / pragma).

Commits, oldest → newest:

- **PS-10083 [9.7]: Relax thread_group_t false-sharing assert for non-glibc** — the hand-tuned `static_assert(sizeof(thread_group_t) == 512, …)` (PS 8.0.12) was re-balanced for the Linux/glibc layout by PS-10083 (added between 9.6 and 9.7) but breaks on macOS / Apple clang + libc++, where `mysql_mutex_t` is larger and the struct lands at 640 bytes. The false-sharing guarantee comes from `alignas(128)`; replace the equality with `sizeof % 128 == 0`.

- **PS-11142 [9.7]: Fix clang-18, clang-22, Apple clang 15, GCC 11-13 compilation issues** — bundle of toolchain fixes:
  - clang-18 + libstdc++ 15 unique_ptr<T> destructor sizeof check on `LogWriterBase`: out-of-line `= default` dtor.
  - libc++ non-transitive includes: explicit `<algorithm>` in audit_log_filter; `<functional>` in storage/rocksdb/rdb_utils.h.
  - Apple clang 15 / libc++ TypeHelper has no specialization for the `unsigned long` that `size_t` resolves to on macOS: route `get_element<size_t>` through `uint64_t` in keyring_kmip config.
  - clang-18 -Wmaybe-uninitialized in NDB transporter histogram code: initialize `factor` to 0.0.
  - clang-22 tightened -Wmissing-format-attribute on member functions: fix `RestoreLogger::vlog_ll` ATTRIBUTE_FORMAT from `(printf, 3, 0)` to `(printf, 4, 0)` (member fns count implicit `this` as arg 1).
  - GCC 12 -Werror=restrict false-positive in libstdc++'s basic_string inlined into telemetry::validate_tls_cipher: per-file -Wno-restrict on gcc < 13.
  - libstdc++ flags std::aligned_storage C++23-deprecated since gcc-13: lower the existing rocksdb -Wno-deprecated-declarations exemption from gcc >= 14 to gcc >= 13.
  - Apple clang 15 / libc++ rejects P0960 parenthesized aggregate initialization through std::construct_at and direct-init: replace `Resolve_column.emplace_back(...)` with `push_back(Resolve_column{...})` in json_duality_view dml.cc; replace `MYSQL_TIME mytime(...)` with `MYSQL_TIME mytime{...}` in temporal-t.cc.
  - RocksDB submodule bump for the consolidated clang-22/libstdc++-16 unique_ptr fix, GCC 11/12 std::unreachable() probe in xxhash.h, and GCC 16 false-positive maybe-uninitialized fixes in CacheItemHelper and the TTL compaction path.

- **PS-11142 [9.7]: Fix GCC 16 compilation issues** — Debug and RelWithDebInfo builds under GCC 16 -Werror:
  - Drop dead loop-counter variables flagged by stricter -Werror=unused-but-set-variable (sql_executor/resolver/table/plugin/profile, myisam/rt_index/sp_key, innobase handler0alter, federated ha_federated).
  - Bison-generated sql_yacc.cc / sql_hints.yy.cc: extend the existing -Wno-unused-but-set-variable exemption to GCC >= 16 (yynerrs).
  - Suppress -O2 false-positive maybe-uninitialized / uninitialized via per-file or per-tree CMakeLists flags gated on GCC >= 16: storage/ndb (signal-data CAST_CONSTPTR ~80 sites), libs/mysql/binlog/event rows_event.cpp, plugin/x cond/rw_lock, sql/dd impl/tables (libstdc++ basic_string + Stateless_allocator), storage/rocksdb compaction_picker_level + rdb_mutex_wrapper.
  - Three constructors that pass a sibling-member reference to a base ctor: MY_COMPILER_DIAGNOSTIC_PUSH/POP + Wmaybe-uninitialized ignore (ndb testTlsKeyManager/testSecureSocket, xplugin message_helpers).
  - Devirtualizing-inliner false-positive Wnonnull in `Query_block::make_set_op_access_path`: document invariant via assert + targeted Wnonnull suppression on the offending call.
