### PR TITLE
PS-10070, PS-10083 [8.4]: fixes for Apple clang

### DIFF
--- a/components/keyrings/keyring_kmip/config/config.cc
+++ b/components/keyrings/keyring_kmip/config/config.cc
@@ -20,6 +20,8 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #define RAPIDJSON_HAS_STDSTRING 1
@@ -142,9 +144,15 @@ bool find_and_read_config_file(std::unique_ptr<Config_pod> &config_pod) {
     // optional attribute
   }
 
-  if (config_reader->get_element<size_t>(config_options[7],
-                                         config_pod_tmp.get()->max_objects)) {
-    // optional attribute
+  // rapidjson's TypeHelper has specializations for the fixed-width integer
+  // typedefs (uint64_t etc.) but not for size_t. On macOS / Apple clang +
+  // libc++, size_t is 'unsigned long' which has no TypeHelper specialization,
+  // so get_element<size_t>() fails to compile. Read into a uint64_t and
+  // assign back on success; uint64_t is recognized on all platforms.
+  if (uint64_t max_objects_tmp = config_pod_tmp.get()->max_objects;
+      !config_reader->get_element<uint64_t>(config_options[7],
+                                            max_objects_tmp)) {
+    config_pod_tmp.get()->max_objects = static_cast<size_t>(max_objects_tmp);
   }
 
   if (config_reader->get_element<int>(config_options[8],

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -152,8 +152,16 @@ struct alignas(128) thread_group_t {
   char padding[248];
 };
 
-static_assert(sizeof(thread_group_t) == 512,
-              "sizeof(thread_group_t) must be 512 to avoid false sharing");
+// thread_group_t is alignas(128); to avoid false sharing the struct must
+// occupy a whole number of 128-byte cache lines. Linux/glibc lays this
+// out at exactly 512 bytes (the original size when 'padding[248]' was
+// hand-tuned), but on macOS / libc++ pthread_mutex_t is larger so the
+// struct grows past 512 (e.g. to 640). Both sizes are still multiples of
+// 128 so the false-sharing guarantee holds; assert that invariant
+// rather than the absolute size.
+static_assert(sizeof(thread_group_t) % 128 == 0,
+              "sizeof(thread_group_t) must be a multiple of 128 to avoid "
+              "false sharing");
 
 static thread_group_t all_groups[MAX_THREAD_GROUPS];
 static uint group_count;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10070

rapidjson's TypeHelper has specializations for the fixed-width integer typedefs (uint64_t etc.) but not for size_t. On macOS / Apple clang + libc++, size_t is 'unsigned long' which has no TypeHelper specialization, so get_element<size_t>() fails to compile. Read into a uint64_t and assign back on success; uint64_t is recognized on all platforms.