### PR TITLE
PS10083 8.4 fix apple build

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -152,8 +152,16 @@ struct alignas(128) thread_group_t {
   char padding[248];
 };
 
-static_assert(sizeof(thread_group_t) == 512,
-              "sizeof(thread_group_t) must be 512 to avoid false sharing");
+// thread_group_t is alignas(128); to avoid false sharing the struct must
+// occupy a whole number of 128-byte cache lines. Linux/glibc lays this
+// out at exactly 512 bytes (the original size when 'padding[248]' was
+// hand-tuned), but on macOS / libc++ pthread_mutex_t is larger so the
+// struct grows past 512 (e.g. to 640). Both sizes are still multiples of
+// 128 so the false-sharing guarantee holds; assert that invariant
+// rather than the absolute size.
+static_assert(sizeof(thread_group_t) % 128 == 0,
+              "sizeof(thread_group_t) must be a multiple of 128 to avoid "
+              "false sharing");
 
 static thread_group_t all_groups[MAX_THREAD_GROUPS];
 static uint group_count;


### PR DESCRIPTION
The static_assert(sizeof(thread_group_t) == 512, ...) in sql/threadpool_unix.cc has existed since PS 8.0.12 and was hand-tuned against the Linux/glibc layout of the embedded mysql_mutex_t and PSI structures. PS-10083 ("Add more statistics for threadpool", merged 2026-03-11 between 9.6.0 and 9.7.0) inserted two LiveStats members into thread_group_t and adjusted the trailing 'char padding[]' from 328 to 248 to keep the Linux total at exactly 512.

LiveStats itself is platform-neutral (5 PODs, 40 bytes), but mysql_mutex_t expands by ~128 bytes on macOS / Apple clang + libc++, so on that platform the struct lands at 640 bytes and breaks the build:

    sql/threadpool_unix.cc:155:1: error: static assertion failed due
        to requirement 'sizeof(thread_group_t) == 512'

The false-sharing guarantee comes from alignas(128); what matters is that the struct occupies a whole number of 128-byte cache lines, not that it is exactly 512 bytes (640 is also a multiple of 128). Replace the equality check with 'sizeof % 128 == 0' so Linux/glibc, libc++ on macOS, and any future libstdc++ layout drift all pass while the no-false-sharing invariant remains enforced.