### PR TITLE
PS-11142 [8.0]: Fix GCC 16 compilation issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
       fi
 
 - job:
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   pool:
     vmImage: $(imageName)
 
@@ -268,6 +268,18 @@ jobs:
 
 
       # gcc-9 and newer compilers
+      gcc-16 RelWithDebInfo [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        Compiler: gcc
+        CompilerVer: 16
+        BuildType: RelWithDebInfo
+
+      gcc-16 Debug [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        Compiler: gcc
+        CompilerVer: 16
+        BuildType: Debug
+
       gcc-15 RelWithDebInfo [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         Compiler: gcc

--- a/libbinlogevents/src/CMakeLists.txt
+++ b/libbinlogevents/src/CMakeLists.txt
@@ -56,6 +56,15 @@ SET(REPLICATION_SOURCES
   uuid.cpp
   )
 
+# GCC 16's -O2 analysis emits false-positive -Wmaybe-uninitialized warnings
+# on the Write/Update/Delete_rows_event and Rows_query_event constructors
+# via inlined binary_log::Event_reader helpers (m_ptr / m_buffer / m_type).
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(
+    rows_event.cpp
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
+
 MY_CHECK_CXX_COMPILER_WARNING("-Wmissing-profile" HAS_MISSING_PROFILE)
 IF(HAS_MISSING_PROFILE)
   ADD_COMPILE_FLAGS(

--- a/libbinlogstandalone/src/CMakeLists.txt
+++ b/libbinlogstandalone/src/CMakeLists.txt
@@ -49,6 +49,17 @@ SET(REPLICATION_SOURCES
   ${CMAKE_SOURCE_DIR}/libbinlogevents/src/uuid.cpp
   )
 
+# GCC 16's -O2 analysis emits false-positive -Wmaybe-uninitialized warnings
+# on the Write/Update/Delete _rows_event constructors via inlined
+# binary_log::Event_reader helpers (m_ptr / m_buffer / m_type). The same
+# suppression is applied to the libbinlogevents target; replicate it here
+# for the standalone build of the same source.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(
+    ${CMAKE_SOURCE_DIR}/libbinlogevents/src/rows_event.cpp
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
+
 # Configure for building static library
 ADD_LIBRARY(binlogstandalone_static STATIC ${REPLICATION_SOURCES})
 

--- a/libmysql/libmysql.cc
+++ b/libmysql/libmysql.cc
@@ -3989,12 +3989,10 @@ int STDCALL mysql_stmt_store_result(MYSQL_STMT *stmt) {
       max_length
     */
     MYSQL_BIND *my_bind, *end;
-    MYSQL_FIELD *field;
     memset(stmt->bind, 0, sizeof(*stmt->bind) * stmt->field_count);
 
-    for (my_bind = stmt->bind, end = my_bind + stmt->field_count,
-        field = stmt->fields;
-         my_bind < end; my_bind++, field++) {
+    for (my_bind = stmt->bind, end = my_bind + stmt->field_count; my_bind < end;
+         my_bind++) {
       my_bind->buffer_type = MYSQL_TYPE_NULL;
       my_bind->buffer_length = 1;
     }

--- a/plugin/audit_log_filter/audit_log_reader.cc
+++ b/plugin/audit_log_filter/audit_log_reader.cc
@@ -25,6 +25,7 @@
 #include <mysql/components/services/mysql_current_thread_reader.h>
 
 #include <scope_guard.h>
+#include <algorithm>
 #include <filesystem>
 #include <functional>
 #include <string>

--- a/plugin/audit_log_filter/log_writer/base.cc
+++ b/plugin/audit_log_filter/log_writer/base.cc
@@ -27,6 +27,8 @@ LogWriterBase::LogWriterBase(
     std::unique_ptr<log_record_formatter::LogRecordFormatterBase> formatter)
     : m_formatter{std::move(formatter)} {}
 
+LogWriterBase::~LogWriterBase() = default;
+
 void LogWriterBase::init_formatter() noexcept { SysVars::init_record_id(0); }
 
 void LogWriterBase::write(const AuditRecordVariant &record) noexcept {

--- a/plugin/audit_log_filter/log_writer/base.h
+++ b/plugin/audit_log_filter/log_writer/base.h
@@ -62,7 +62,7 @@ class LogWriterBase {
   explicit LogWriterBase(
       std::unique_ptr<log_record_formatter::LogRecordFormatterBase> formatter);
 
-  virtual ~LogWriterBase() = default;
+  virtual ~LogWriterBase();
 
   /**
    * @brief Init log writer.

--- a/plugin/x/CMakeLists.txt
+++ b/plugin/x/CMakeLists.txt
@@ -81,6 +81,18 @@ ADD_COMPILE_FLAGS(${XPLUGIN_SRC}
   COMPILE_FLAGS "${MYSQLX_PROTOCOL_FLAGS}"
 )
 
+# GCC 16's -O2 analysis emits a false-positive -Wmaybe-uninitialized
+# warning on PSI inlining inside xpl::Cond / xpl::RWLock constructors,
+# where inline_mysql_cond_init / inline_mysql_rwlock_init forward
+# &that->m_cond (or &that->m_rwlock) before the member is technically
+# initialized by the PSI helper itself.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(
+    src/helper/multithread/cond.cc
+    src/helper/multithread/rw_lock.cc
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
+
 # MYSQL_ADD_PLUGIN may have disabled the plugin.
 IF(WITH_MYSQLX)
   MYSQL_ADD_PLUGIN(${MYSQLX_PLUGIN_NAME}

--- a/router/src/routing/src/dest_round_robin.cc
+++ b/router/src/routing/src/dest_round_robin.cc
@@ -43,7 +43,6 @@ Destinations DestRoundRobin::destinations() {
     // move iterator forward and remember the position as 'last'
     std::advance(cur, start_pos_);
     auto last = cur;
-    size_t n = start_pos_;
 
     // for start_pos == 2:
     //
@@ -57,7 +56,7 @@ Destinations DestRoundRobin::destinations() {
     //
     // dests = [2 3 4]
 
-    for (; cur != end; ++cur, ++n) {
+    for (; cur != end; ++cur) {
       auto const &dest = *cur;
 
       dests.push_back(std::make_unique<Destination>(dest.str(), dest.address(),
@@ -68,7 +67,7 @@ Destinations DestRoundRobin::destinations() {
     //
     // dests = [2 3 4] + [0 1]
     //
-    for (cur = begin, n = 0; cur != last; ++cur, ++n) {
+    for (cur = begin; cur != last; ++cur) {
       auto const &dest = *cur;
 
       dests.push_back(std::make_unique<Destination>(dest.str(), dest.address(),

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -915,7 +915,9 @@ IF(MY_COMPILER_IS_GNU_OR_CLANG)
   ADD_COMPILE_FLAGS(${CMAKE_CURRENT_BINARY_DIR}/sql_yacc.cc
                     ${CMAKE_CURRENT_BINARY_DIR}/sql_hints.yy.cc
                     COMPILE_FLAGS "-Wno-undef -Wno-unused-label")
-  IF(MY_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
+  IF((MY_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
+     OR
+     (MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16))
     ADD_COMPILE_FLAGS(${CMAKE_CURRENT_BINARY_DIR}/sql_yacc.cc
                       ${CMAKE_CURRENT_BINARY_DIR}/sql_hints.yy.cc
                       COMPILE_FLAGS "-Wno-unused-but-set-variable")
@@ -984,6 +986,18 @@ ENDIF()
 EXCLUDE_FROM_MSVC_PGO(sql_gis)
 
 ADD_LIBRARY(sql_dd STATIC ${DD_SOURCES})
+# GCC 16's -O2 analysis emits false-positive -Wmaybe-uninitialized warnings
+# inside libstdc++ basic_string code instantiated for the dd::String_type
+# allocator (Stateless_allocator<char, dd::String_type_alloc>) when assigning
+# strings inside the generated dd::Object_table_definition_impl-derived
+# constructors.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  ADD_COMPILE_FLAGS(
+    dd/impl/tables/index_stats.cc
+    dd/impl/tables/table_stats.cc
+    dd/impl/tables/triggers.cc
+    COMPILE_FLAGS "-Wno-maybe-uninitialized")
+ENDIF()
 ADD_DEPENDENCIES(sql_dd GenFixPrivs)
 ADD_DEPENDENCIES(sql_dd GenServerSource)
 ADD_DEPENDENCIES(sql_dd GenDigestServerSource)

--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -3467,7 +3467,7 @@ int do_sj_dups_weedout(THD *thd, SJ_TMP_TABLE *sjtbl) {
   }
 
   // 3. Put the rowids
-  for (uint i = 0; tab != tab_end; tab++, i++) {
+  for (; tab != tab_end; tab++) {
     handler *h = tab->qep_tab->table()->file;
     if (tab->qep_tab->table()->is_nullable() &&
         tab->qep_tab->table()->has_null_row()) {

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -3686,7 +3686,6 @@ void get_partition_set(const TABLE *table, uchar *buf, const uint index,
                        const key_range *key_spec, part_id_range *part_spec) {
   partition_info *part_info = table->part_info;
   uint num_parts = part_info->get_tot_partitions();
-  uint i, part_id;
   uint sub_part = num_parts;
   uint32 part_part = num_parts;
   KEY *key_info = nullptr;
@@ -3814,9 +3813,8 @@ void get_partition_set(const TABLE *table, uchar *buf, const uint index,
       part_spec->start_part = sub_part;
       part_spec->end_part =
           sub_part + (part_info->num_subparts * (part_info->num_parts - 1));
-      for (i = 0, part_id = sub_part; i < part_info->num_parts;
-           i++, part_id += part_info->num_subparts)
-        ;  // Set bit part_id in bit array
+      // TODO: Set bit part_id in bit array (loop removed because it was a
+      // no-op; placeholder for future bit-array support).
     }
   }
   if (found_part_field) clear_indicator_in_key_fields(key_info);

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3218,7 +3218,7 @@ static int construct_options(MEM_ROOT *mem_root, st_plugin_int *tmp,
   char *comment = (char *)mem_root->Alloc(max_comment_len + 1);
   char *optname;
 
-  int index = 0, offset = 0;
+  int offset = 0;
   SYS_VAR *opt, **plugin_option;
   st_bookmark *v;
 
@@ -3284,7 +3284,7 @@ static int construct_options(MEM_ROOT *mem_root, st_plugin_int *tmp,
   */
 
   for (plugin_option = tmp->plugin->system_vars;
-       plugin_option && *plugin_option; plugin_option++, index++) {
+       plugin_option && *plugin_option; plugin_option++) {
     opt = *plugin_option;
     if (!(opt->flags & PLUGIN_VAR_THDLOCAL)) continue;
     if (!(register_var(plugin_name_ptr, opt->name, opt->flags))) continue;
@@ -3333,7 +3333,7 @@ static int construct_options(MEM_ROOT *mem_root, st_plugin_int *tmp,
   }
 
   for (plugin_option = tmp->plugin->system_vars;
-       plugin_option && *plugin_option; plugin_option++, index++) {
+       plugin_option && *plugin_option; plugin_option++) {
     switch ((opt = *plugin_option)->flags & PLUGIN_VAR_TYPEMASK) {
       case PLUGIN_VAR_BOOL:
         if (!opt->check) opt->check = check_func_bool;

--- a/sql/sql_profile.cc
+++ b/sql/sql_profile.cc
@@ -667,8 +667,6 @@ int PROFILING::print_current(IO_CACHE *log_file) const noexcept {
 
   my_b_printf(log_file, "# ");
 
-  ulonglong row_number = 0;
-
   QUERY_PROFILE *const query = current;
 
   void *entry_iterator;
@@ -677,7 +675,7 @@ int PROFILING::print_current(IO_CACHE *log_file) const noexcept {
   for (entry_iterator = query->entries.new_iterator();
        entry_iterator != nullptr;
        entry_iterator = query->entries.iterator_next(entry_iterator),
-      previous = entry, row_number++) {
+      previous = entry) {
     entry = query->entries.iterator_value(entry_iterator);
 
     /* Skip the first.  We count spans of fence, not fence-posts. */
@@ -728,7 +726,6 @@ int PROFILING::print_current(IO_CACHE *log_file) const noexcept {
 int PROFILING::fill_statistics_info(THD *thd_arg, Table_ref *tables) {
   DBUG_TRACE;
   TABLE *table = tables->table;
-  ulonglong row_number = 0;
 
   QUERY_PROFILE *query;
   /* Go through each query in this thread's stored history... */
@@ -750,7 +747,7 @@ int PROFILING::fill_statistics_info(THD *thd_arg, Table_ref *tables) {
     for (entry_iterator = query->entries.new_iterator();
          entry_iterator != nullptr;
          entry_iterator = query->entries.iterator_next(entry_iterator),
-        previous = entry, row_number++) {
+        previous = entry) {
       entry = query->entries.iterator_value(entry_iterator);
       seq = entry->m_seq;
 

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -5654,8 +5654,7 @@ bool Query_block::transform_table_subquery_to_join_with_derived(
     // list. Correct context info of outer expressions.
     auto it_outer = sj_outer_exprs.begin() + initial_sj_inner_exprs_count;
     auto it_inner = sj_inner_exprs.begin() + initial_sj_inner_exprs_count;
-    for (int i = 0; it_outer != sj_outer_exprs.end();
-         ++it_outer, ++it_inner, ++i) {
+    for (; it_outer != sj_outer_exprs.end(); ++it_outer, ++it_inner) {
       Item *inner = *it_inner;
       Item *outer = *it_outer;
       // In setup_base_ref_items() we allocated space for appending this

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -4449,8 +4449,7 @@ bool TABLE::fill_item_list(mem_root_deque<Item *> *item_list) const {
     All Item_field's created using a direct pointer to a field
     are fixed in Item_field constructor.
   */
-  uint i = 0;
-  for (Field **ptr = visible_field_ptr(); *ptr; ptr++, i++) {
+  for (Field **ptr = visible_field_ptr(); *ptr; ptr++) {
     Item_field *item = new Item_field(*ptr);
     if (!item) return true;
     item_list->push_back(item);

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -126,7 +126,12 @@ typedef I_P_List<connection_t,
                  I_P_List_null_counter, I_P_List_fast_push_back<connection_t>>
     connection_queue_t;
 
-struct alignas(128) thread_group_t {
+// Data members live in a separate base struct so that thread_group_t's
+// trailing padding can be sized from sizeof(thread_group_data_t).
+// mysql_mutex_t is larger on macOS / libc++ than on Linux/glibc, and
+// hand-tuning 'padding[N]' against the Linux layout broke the build
+// elsewhere; deriving N keeps sizeof(thread_group_t) == 512 everywhere.
+struct thread_group_data_t {
   mysql_mutex_t mutex;
   connection_queue_t queue;
   connection_queue_t high_prio_queue;
@@ -145,7 +150,14 @@ struct alignas(128) thread_group_t {
   int shutdown_pipe[2];
   bool shutdown;
   bool stalled;
-  char padding[328];
+};
+
+static_assert(sizeof(thread_group_data_t) < 512,
+              "thread_group_data_t must fit inside 512 bytes so that "
+              "thread_group_t can be padded to exactly 512");
+
+struct alignas(128) thread_group_t : thread_group_data_t {
+  char padding[512 - sizeof(thread_group_data_t)];
 };
 
 static_assert(sizeof(thread_group_t) == 512,

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1267,7 +1267,11 @@ bool ha_federated::create_where_from_key(String *to, KEY *key_info,
   bool both_not_null =
       (start_key != nullptr && end_key != nullptr) ? true : false;
   uchar *ptr;
-  uint remainder, length;
+  // 'remainder' is only consumed by DBUG_PRINT and assert, both compiled out
+  // in release builds; mark as [[maybe_unused]] so GCC 16 doesn't warn under
+  // -Werror=unused-but-set-variable.
+  [[maybe_unused]] uint remainder;
+  uint length;
   char tmpbuff[FEDERATED_QUERY_BUFFER_SIZE];
   String tmp(tmpbuff, sizeof(tmpbuff), system_charset_info);
   const key_range *ranges[2] = {start_key, end_key};

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -6130,11 +6130,10 @@ to rebuild the template.
 static bool alter_templ_needs_rebuild(TABLE *altered_table,
                                       Alter_inplace_info *ha_alter_info,
                                       dict_table_t *table) {
-  ulint i = 0;
   List_iterator_fast<Create_field> cf_it(
       ha_alter_info->alter_info->create_list);
 
-  for (Field **fp = altered_table->field; *fp; fp++, i++) {
+  for (Field **fp = altered_table->field; *fp; fp++) {
     cf_it.rewind();
     while (const Create_field *cf = cf_it++) {
       for (ulint j = 0; j < table->n_cols; j++) {

--- a/storage/myisam/rt_index.cc
+++ b/storage/myisam/rt_index.cc
@@ -685,7 +685,6 @@ static int rtree_delete_req(MI_INFO *info, MI_KEYDEF *keyinfo, uchar *key,
                             stPageList *ReinsertList, int level) {
   uchar *k;
   uchar *last;
-  ulong i;
   uint nod_flag;
   uchar *page_buf;
   int res;
@@ -704,7 +703,7 @@ static int rtree_delete_req(MI_INFO *info, MI_KEYDEF *keyinfo, uchar *key,
   k = rt_PAGE_FIRST_KEY(page_buf, nod_flag);
   last = rt_PAGE_END(page_buf);
 
-  for (i = 0; k < last; k = rt_PAGE_NEXT_KEY(k, key_length, nod_flag), ++i) {
+  for (; k < last; k = rt_PAGE_NEXT_KEY(k, key_length, nod_flag)) {
     if (nod_flag) {
       /* not leaf */
       if (!rtree_key_cmp(keyinfo->seg, key, k, key_length, MBR_WITHIN)) {

--- a/storage/myisam/sp_key.cc
+++ b/storage/myisam/sp_key.cc
@@ -53,7 +53,6 @@ uint sp_make_key(MI_INFO *info, uint keynr, uchar *key, const uchar *record,
   uint dlen;
   uchar *dptr;
   double mbr[SPDIMS * 2];
-  uint i;
 
   keyseg = &keyinfo->seg[-1];
   pos = record + keyseg->start;
@@ -66,7 +65,7 @@ uint sp_make_key(MI_INFO *info, uint keynr, uchar *key, const uchar *record,
   }
   sp_mbr_from_wkb(dptr + 4, dlen - 4, SPDIMS, mbr); /* SRID */
 
-  for (i = 0, keyseg = keyinfo->seg; keyseg->type; keyseg++, i++) {
+  for (keyseg = keyinfo->seg; keyseg->type; keyseg++) {
     uint length = keyseg->length, start = keyseg->start;
     double val;
 

--- a/storage/ndb/CMakeLists.txt
+++ b/storage/ndb/CMakeLists.txt
@@ -266,6 +266,19 @@ ELSE(WITH_NDB_JAVA)
   MESSAGE(STATUS "Excluding Cluster Java components")
 ENDIF(WITH_NDB_JAVA)
 
+# GCC 16's -O2 analysis emits a large number of false-positive
+# -Wmaybe-uninitialized / -Wuninitialized warnings across the NDB tree.
+# Signal data is populated by transporter/network code and read through
+# CAST_CONSTPTR casts the optimizer cannot follow, so it treats many
+# members as possibly-uninitialized inside print/handler routines.
+# Disable both warnings tree-wide for NDB under GCC >= 16.
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+  STRING_APPEND(CMAKE_C_FLAGS
+    " -Wno-maybe-uninitialized -Wno-uninitialized")
+  STRING_APPEND(CMAKE_CXX_FLAGS
+    " -Wno-maybe-uninitialized -Wno-uninitialized")
+ENDIF()
+
 ADD_SUBDIRECTORY(include)
 ADD_SUBDIRECTORY(src)
 

--- a/storage/ndb/src/common/util/testSecureSocket.cpp
+++ b/storage/ndb/src/common/util/testSecureSocket.cpp
@@ -31,6 +31,7 @@
 #include "openssl/x509.h"
 
 #include "debugger/EventLogger.hpp"
+#include "my_compiler.h"
 #include "portlib/NdbGetRUsage.h"
 #include "portlib/NdbMutex.h"
 #include "portlib/NdbSleep.h"
@@ -166,11 +167,17 @@ static struct my_option options[] = {
 
 class EchoSession : public SocketServer::Session {
  public:
+  // GCC 16 emits a false-positive -Wmaybe-uninitialized warning here when
+  // the base SocketServer::Session is initialized with a reference to the
+  // not-yet-initialized m_secure_socket member.
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")
   EchoSession(NdbSocket &&s, bool sink, SSL_CTX *ctx)
       : SocketServer::Session(m_secure_socket),
         m_sink(sink),
         m_ssl_ctx(ctx),
         m_secure_socket(std::move(s)) {}
+  MY_COMPILER_DIAGNOSTIC_POP()
   void runSession() override;
 
  private:

--- a/storage/ndb/src/kernel/blocks/trpman.cpp
+++ b/storage/ndb/src/kernel/blocks/trpman.cpp
@@ -817,7 +817,7 @@ unsigned Trpman::calculate_histogram_bin_limits(
    * Use minimal sized bins until a suitable scaling factor is found for
    * exponential part or that bin for heartbeat interval is next.
    */
-  double factor;                   // calculated during part 1, used in part 2
+  double factor = 0.0;             // calculated during part 1, used in part 2
   unsigned first_part2_limit = 0;  // 0 indicates no value
   unsigned first_part3_limit = 0;
   unsigned bin_limit = min_bin_width;

--- a/storage/ndb/tools/restore/Restore.hpp
+++ b/storage/ndb/tools/restore/Restore.hpp
@@ -654,7 +654,7 @@ class RestoreLogger {
 
  private:
   void vlog_ll(FilteredNdbOut &out, const char *ll, const char *fmt, va_list ap)
-      ATTRIBUTE_FORMAT(printf, 3, 0);
+      ATTRIBUTE_FORMAT(printf, 4, 0);
 
   NdbMutex *m_mutex;
   char timestamp[64];

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -291,6 +291,18 @@ IF(CMAKE_COMPILER_IS_GNUCXX AND WITH_ASAN)
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-error=maybe-uninitialized FILES rocksdb/util/bloom.cc)
 ENDIF()
 
+# GCC 16 -O2 emits false-positive -Wmaybe-uninitialized warnings on:
+#  - autovector::front() inlined into LevelCompactionBuilder::SetupInitialFiles()
+#    (the optimizer cannot see that !expired_files.empty() implies buf_[0]
+#    was written),
+#  - PSI inlining inside myrocks::Rdb_cond_var / Rdb_mutex constructors in
+#    rdb_mutex_wrapper.cc (same pattern as the plugin/x suppression).
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-maybe-uninitialized
+    FILES rocksdb/db/compaction/compaction_picker_level.cc
+          rdb_mutex_wrapper.cc)
+ENDIF()
+
 
 IF(FB_WITH_WSENV)
   ADD_DEFINITIONS(-DFB_HAVE_WSENV=1)

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -17,6 +17,7 @@
 
 /* C++ standard header files */
 #include <chrono>
+#include <functional>
 #include <regex>
 #include <string>
 #include <unordered_map>

--- a/unittest/gunit/xplugin/xcl/message_helpers.h
+++ b/unittest/gunit/xplugin/xcl/message_helpers.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <type_traits>
 
+#include "my_compiler.h"
 #include "plugin/x/client/mysqlxclient/xmessage.h"
 #include "plugin/x/client/mysqlxclient/xprotocol.h"
 
@@ -53,8 +54,13 @@ class Message_from_str {
 template <typename M>
 class Message_compare {
  public:
+  // GCC 16 emits a false-positive -Wmaybe-uninitialized warning when the
+  // m_expected_text_reformated string is initialized via reformat_text_message.
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")
   explicit Message_compare(const std::string &text_message)
       : m_expected_text_reformated(reformat_text_message(text_message)) {}
+  MY_COMPILER_DIAGNOSTIC_POP()
 
   explicit Message_compare(const M &message) {
     ::google::protobuf::TextFormat::PrintToString(message,


### PR DESCRIPTION
Bundle of build fixes across three Jira tickets:

  - **[PS-10083](https://perconadev.atlassian.net/browse/PS-10083)** — Keep `thread_group_t` at 512 bytes  on non-glibc. Recent upstream PS-10083 inserted two `LiveStats` members and re-tuned the trailing `padding[]` for the Linux/glibc layout of `mysql_mutex_t`. macOS/libc++ has a ~128-byte-larger mutex,  so the hand-tuned `static_assert(sizeof(thread_group_t) == 512)` failed there. Split the struct into a  `thread_group_data_t` base + a derived `thread_group_t` whose padding sizes itself from `sizeof(base)`, so the 512-byte invariant holds on every platform without touching field accesses.
  - **[PS-10979](https://perconadev.atlassian.net/browse/PS-10979)** — Build fixes for older/newer toolchains: clang-18 + libstdc++ 15 (unique_ptr incomplete-type for `LogRecordFormatterBase`); Apple  clang 15 / libc++ missing transitive `<algorithm>` / `<functional>`, missing `size_t` rapidjson `TypeHelper`, P0960 aggregate-emplace; clang-22 off-by-one `ATTRIBUTE_FORMAT` on a member function; GCC 12 false-positive `-Werror=restrict` inside libstdc++ basic_string; GCC ≥ 13 `std::aligned_storage` deprecation in RocksDB; and a RocksDB submodule bump for the consolidated clang-22 / GCC 11-12 / GCC 16 fixes.
  - **[PS-11142](https://perconadev.atlassian.net/browse/PS-11142)** — Make Debug and RelWithDebInfo build cleanly under GCC 16 `-Werror`: source-level cleanups for genuine `-Wunused-but-set-variable` failures (`libmysql.cc`, `dest_round_robin.cc`, `sql_executor/resolver/plugin/profile/partition/table.cc`, MyISAM, InnoDB, federated), `MY_COMPILER_DIAGNOSTIC_*` suppression for two false-positive `-Wmaybe-uninitialized` ctors that pass a  sibling member to the base initializer, per-file/per-tree `-Wno-maybe-uninitialized` for known false-positive hotspots (NDB tree-wide, `rows_event.cpp` in both binlog-events build targets, plugin/x cond/rwlock, dd/impl/tables, RocksDB compaction picker / mutex wrapper), and an extension of the existing Bison-generated `-Wno-unused-but-set-variable` exemption to GCC ≥ 16. CI adds gcc-16 Debug + RelWithDebInfo jobs on Ubuntu 24.04 (with timeout bumped to 360 min).

[PS-10083]: https://perconadev.atlassian.net/browse/PS-10083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-10979]: https://perconadev.atlassian.net/browse/PS-10979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11142]: https://perconadev.atlassian.net/browse/PS-11142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ