### PR TITLE
PS-10963 [8.0]: Fix sporadic auth_sec.mysql_native_plugin_deprecated …

### DIFF
--- a/mysql-test/suite/auth_sec/r/mysql_native_plugin_deprecated.result
+++ b/mysql-test/suite/auth_sec/r/mysql_native_plugin_deprecated.result
@@ -1,6 +1,10 @@
 #
 # Bug #35336317: Deprecate mysql_native_password
 #
+# Restart server to avoid test failures in situation when deprecation
+# warning has been already emitted due to mysql_native_password
+# usage by one of earlier tests.
+# restart
 include/assert_grep.inc [There shouldn't be a warning when no user authenticated with native]
 CREATE USER bug35336317@localhost IDENTIFIED WITH 'mysql_native_password';
 include/assert_grep.inc [There should be one warning from CREATE USER]

--- a/mysql-test/suite/auth_sec/t/mysql_native_plugin_deprecated.test
+++ b/mysql-test/suite/auth_sec/t/mysql_native_plugin_deprecated.test
@@ -2,6 +2,11 @@
 --echo # Bug #35336317: Deprecate mysql_native_password
 --echo #
 
+--echo # Restart server to avoid test failures in situation when deprecation
+--echo # warning has been already emitted due to mysql_native_password
+--echo # usage by one of earlier tests.
+--source include/restart_mysqld.inc
+
 --let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_count= 0
 --let $assert_select= 'mysql_native_password' is deprecated


### PR DESCRIPTION
…test failures.

auth_sec.mysql_native_plugin_deprecated test failed when it was scheduled to run after some other test which produced mysql_native_password plugin deprecation message in the error log. In such a case the former test didn't produce the same message as it is expected (as it is supposed to be generated only once after server start-up) and the test failed.

Fixed this issue by restarting server at the start of auth_sec.mysql_native_plugin_deprecated test, to ensure that deprecation message is always produced by it.