### PR TITLE
PS-10963 [8.0]: Fix main.coredump failures on ARM64.

### DIFF
--- a/mysql-test/t/coredump.test
+++ b/mysql-test/t/coredump.test
@@ -1,3 +1,10 @@
+# We don't support coredumper functionality on ARM at the moment.
+let $have_arm64 = `SELECT convert(@@version_compile_machine USING latin1) IN ("aarch64")`;
+if ($have_arm64)
+{
+   skip Test requires: 'not_arm64';
+}
+
 # Valgrind reports false positives coming from coredumper internals
 --source include/not_valgrind.inc
 # ASAN disables core dumps


### PR DESCRIPTION
Disable failing test on ARM64 since libcoredumper is not supported on this platform at the moment.