### PR TITLE
ci(test): validate org secrets for HD-30964 (do not merge)

### DIFF
--- a/.github/workflows/validate-org-secrets.yml
+++ b/.github/workflows/validate-org-secrets.yml
@@ -1,0 +1,56 @@
+# One-off smoke test for HD-30964: validates the org secrets
+# GHA_RUNNER_HCLOUD_TOKEN and GHA_RUNNER_PAT resolve and pass live API checks
+# from inside this repo's workflow context. No infrastructure is created.
+# Delete this file (or the branch hosting it) after the test completes.
+
+name: validate-org-secrets
+
+on:
+  pull_request:
+    branches: [8.0, trunk, 8.4]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify GHA_RUNNER_HCLOUD_TOKEN
+        env:
+          HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+        run: |
+          set -eu
+          [ -n "$HCLOUD_TOKEN" ] || { echo "::error::GHA_RUNNER_HCLOUD_TOKEN missing"; exit 1; }
+          echo "length=${#HCLOUD_TOKEN}"
+          HTTP=$(curl -sS -o /tmp/x -w "%{http_code}" \
+            -H "Authorization: Bearer $HCLOUD_TOKEN" \
+            'https://api.hetzner.cloud/v1/datacenters?per_page=1')
+          [ "$HTTP" = "200" ] || { echo "::error::Hetzner HTTP $HTTP"; cat /tmp/x; exit 1; }
+          echo "Hetzner API: OK"
+
+      - name: Verify GHA_RUNNER_PAT mints a runner registration token
+        env:
+          RUNNER_PAT: ${{ secrets.GHA_RUNNER_PAT }}
+        run: |
+          set -eu
+          [ -n "$RUNNER_PAT" ] || { echo "::error::GHA_RUNNER_PAT missing"; exit 1; }
+          echo "length=${#RUNNER_PAT}"
+          HTTP=$(curl -sS -o /tmp/x -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer $RUNNER_PAT" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/percona/percona-server/actions/runners/registration-token)
+          [ "$HTTP" = "201" ] || { echo "::error::reg-token HTTP $HTTP"; cat /tmp/x; exit 1; }
+          PREFIX=$(jq -r '.token | .[0:8]' /tmp/x)
+          echo "Runner reg token mint: OK (prefix=${PREFIX}...)"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Org secrets validation"
+            echo ""
+            echo "- GHA_RUNNER_HCLOUD_TOKEN: Hetzner API live check passed"
+            echo "- GHA_RUNNER_PAT: runner registration-token mint passed"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Smoke test for HD-30964: confirms `GHA_RUNNER_HCLOUD_TOKEN` + `GHA_RUNNER_PAT` resolve and work from this repo's workflow context. 2 read-only HTTP calls, zero infrastructure. Will close + delete branch as soon as the run completes.

Related: PS-11078.