### PR TITLE
PS-11078: migrate percona-server arm64 builds from Cirrus to GHA on Hetzner

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,309 @@
+# PoC for PS-11078: ephemeral Hetzner cax* runner running the percona-server
+# arm64 build. Build shape PORTED FROM azure-pipelines.yml (per Przemek's ask
+# 2026-05-18: ".cirrus.yml is just a simplified port from Azure"). Deviations
+# from Azure are arm64-specific and called out inline.
+#
+# Target: replace Cirrus arm64 task before Cirrus shuts down 2026-06-01.
+
+name: build-arm64
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [8.0]
+    paths-ignore:
+      # Mirrors azure-pipelines.yml `paths.exclude`
+      - 'doc/**'
+      - 'build-ps/**'
+      - 'man/**'
+      - 'mysql-test/**'
+      - 'packaging/**'
+      - 'policy/**'
+      - 'scripts/**'
+      - 'support-files/**'
+
+concurrency:
+  group: build-arm64-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Mirror Azure variable names so the eventual Azure-to-Hetzner migration
+  # is one-to-one. Names kept identical even where GHA syntax differs.
+  PARENT_BRANCH: '8.0'
+  BUILD_TYPE: Debug
+  BUILD_PARAMS_TYPE: normal
+  COMPILER: gcc
+  COMPILER_VER: ''           # blank => system default (Azure picks gcc-XX explicitly per matrix entry)
+  IMAGE_NAME: ubuntu-24.04   # Azure 'imageName'; pinned for fingerprint stability
+  UBUNTU_CODE_NAME: noble
+  BOOST_VERSION: boost_1_77_0
+  USE_CCACHE: '1'
+  CCACHE_COMPRESS: '1'
+  CCACHE_COMPRESSLEVEL: '9'
+  CCACHE_CPP2: '1'
+  CCACHE_MAXSIZE: 4G
+  # Hetzner-specific (Azure has no equivalent because MS-hosted is fixed)
+  IMAGE: ubuntu-24.04
+  SSH_KEY_ID: '107239874'
+  RUNNER_NAME: ps-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  # TRUSTED. Dynamic capacity probe: cax41 -> cax31 -> cax21 across DCs.
+  pick-target:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      location: ${{ steps.probe.outputs.location }}
+      server_type: ${{ steps.probe.outputs.server_type }}
+    steps:
+      - id: probe
+        env:
+          HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          for type in cax41 cax31 cax21; do
+            for dc in fsn1 hel1 nbg1; do
+              PROBE_NAME="cap-probe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${type}-${dc}"
+              HTTP=$(curl -sS -o /tmp/resp.json -w "%{http_code}" -X POST \
+                -H "Authorization: Bearer $HCLOUD_TOKEN" -H "Content-Type: application/json" \
+                https://api.hetzner.cloud/v1/servers \
+                -d "{\"name\":\"$PROBE_NAME\",\"server_type\":\"$type\",\"image\":\"$IMAGE\",\"location\":\"$dc\",\"start_after_create\":false}")
+              if [ "$HTTP" = "201" ]; then
+                ID=$(jq -r '.server.id // empty' /tmp/resp.json)
+                [ -n "$ID" ] || { echo "::error::201 without server id"; exit 1; }
+                curl -fsS -X DELETE -H "Authorization: Bearer $HCLOUD_TOKEN" \
+                  "https://api.hetzner.cloud/v1/servers/$ID" >/dev/null
+                if [ "$type" != "cax41" ]; then
+                  echo "::warning::cax41 unavailable (PS-11174); falling back to $type in $dc"
+                fi
+                echo "Hetzner target: $type in $dc" >> "$GITHUB_STEP_SUMMARY"
+                { echo "location=$dc"; echo "server_type=$type"; } >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ERR=$(jq -r '.error.code // "?"' /tmp/resp.json 2>/dev/null || echo "?")
+              echo "::warning::$type/$dc: HTTP $HTTP ($ERR)"
+            done
+          done
+          echo "::error::No CAX capacity in fsn1/hel1/nbg1"
+          exit 1
+
+  # TRUSTED. Provision the ephemeral runner.
+  create-runner:
+    needs: pick-target
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      runner_label: ${{ env.RUNNER_NAME }}
+      server_id: ${{ steps.create.outputs.server_id }}
+      server_type: ${{ needs.pick-target.outputs.server_type }}
+    steps:
+      - id: create
+        uses: olexandr-havryliak/hcloud-github-runner@bb1089d8b718a06493cb37c51dfe596e44baefc2
+        with:
+          mode: create
+          name: ${{ env.RUNNER_NAME }}
+          hcloud_token: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          github_token: ${{ secrets.GHA_RUNNER_PAT }}
+          image: ${{ env.IMAGE }}
+          location: ${{ needs.pick-target.outputs.location }}
+          server_type: ${{ needs.pick-target.outputs.server_type }}
+          ssh_key: ${{ env.SSH_KEY_ID }}
+          pre_runner_script: |
+            apt-get update -y
+            apt-get install -y curl ca-certificates jq
+
+  # UNTRUSTED. PR code runs here. Build mirrors azure-pipelines.yml
+  # (PARENT_BRANCH=8.0, BuildType=Debug, BUILD_PARAMS_TYPE=normal, Compiler=gcc)
+  # arm64 deviations are annotated.
+  do-the-job:
+    needs: [pick-target, create-runner]
+    runs-on: ${{ needs.create-runner.outputs.runner_label }}
+    permissions:
+      contents: read
+    timeout-minutes: 180
+    env:
+      CCACHE_DIR: /home/runner/ccache
+      BOOST_DIR: /tmp/boost
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: System info
+        run: |
+          set -eux
+          echo "Server type: ${{ needs.create-runner.outputs.server_type }}"
+          uname -a
+          nproc
+          free -h
+          df -h /
+
+      - name: Conditional swap (only when RAM < 16 GB)
+        run: |
+          set -eux
+          MEM_GB=$(awk '/MemTotal/ {print int($2/1024/1024)}' /proc/meminfo)
+          if [ "$MEM_GB" -lt 16 ]; then
+            sudo fallocate -l 16G /swapfile
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+            sudo swapon /swapfile
+          fi
+          free -h
+
+      # Azure step: `*** Install Build Dependencies`. arm64 picks system gcc
+      # (no version selector + LLVM repo plumbing needed).
+      - name: Install Build Dependencies
+        run: |
+          set -eux
+          SELECTED_CC="${COMPILER}${COMPILER_VER:+-${COMPILER_VER}}"
+          SELECTED_CXX="${COMPILER}++${COMPILER_VER:+-${COMPILER_VER}}"
+          [ "$COMPILER" = "gcc" ] && SELECTED_CXX="g++${COMPILER_VER:+-${COMPILER_VER}}"
+          echo "SELECTED_CC=$SELECTED_CC" >> "$GITHUB_ENV"
+          echo "SELECTED_CXX=$SELECTED_CXX" >> "$GITHUB_ENV"
+          PACKAGES="$SELECTED_CC"
+          [ "$COMPILER" = "gcc" ] && PACKAGES="$SELECTED_CXX"
+          sudo apt-get -yq update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            $PACKAGES make pkg-config dpkg-dev unzip lz4 git cmake cmake-curses-gui ccache bison \
+            libtirpc-dev libudev-dev libaio-dev libmecab-dev libnuma-dev \
+            libssl-dev libreadline-dev libedit-dev libpam-dev \
+            libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev \
+            libsasl2-modules-gssapi-mit \
+            libxml-simple-perl
+          # Azure: SYSTEM_LIBRARIES path (BUILD_PARAMS_TYPE != inverted)
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            libicu-dev libevent-dev liblz4-dev zlib1g-dev \
+            protobuf-compiler libprotobuf-dev libprotoc-dev \
+            libzstd-dev libfido2-dev
+          # arm64-only addition: libeatmydata1 needed for MTR LD_PRELOAD
+          # (Cirrus arm64 task uses it; Azure x86 jobs don't run MTR).
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libeatmydata1
+          REAL_COMPILER_VER=$($SELECTED_CC --version | head -1 | awk '{print $4}')
+          echo "REAL_COMPILER_VER=$REAL_COMPILER_VER" >> "$GITHUB_ENV"
+
+      # Azure ccache key shape: '"ccache" | PARENT_BRANCH | imageName-Compiler-VER-BuildType | BUILD_PARAMS_TYPE | Build.SourceVersion'
+      - name: ccache cache (Azure key shape)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.2.0
+        with:
+          path: /home/runner/ccache
+          key: ccache-${{ env.PARENT_BRANCH }}-${{ env.IMAGE_NAME }}-${{ env.COMPILER }}-${{ env.BUILD_TYPE }}-${{ env.BUILD_PARAMS_TYPE }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ env.PARENT_BRANCH }}-${{ env.IMAGE_NAME }}-${{ env.COMPILER }}-${{ env.BUILD_TYPE }}-${{ env.BUILD_PARAMS_TYPE }}-
+
+      - name: boost cache (Azure key shape)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.2.0
+        with:
+          path: /tmp/boost
+          key: ${{ env.BOOST_VERSION }}
+
+      # Azure: `- checkout: self` with `fetchDepth: 32`.
+      - name: Checkout (fetchDepth 32 mirrors Azure)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
+        with:
+          fetch-depth: 32
+
+      # Azure: `*** Update git submodules` with --depth=256.
+      - name: Update git submodules
+        run: |
+          set -eux
+          git submodule sync
+          git submodule update --init --force --depth=256
+          git submodule
+
+      - name: System and compiler info
+        run: |
+          set -eux
+          $SELECTED_CC -v
+          $SELECTED_CXX -v
+          ccache --version
+          mkdir -p "$CCACHE_DIR" "$BOOST_DIR"
+          ccache -p | grep -E "max_size|cache_dir"
+          ccache --zero-stats
+
+      # Azure: `*** cmake ...` step. Linux/non-inverted branch.
+      - name: cmake (Azure parity, Linux non-inverted)
+        run: |
+          set -eux
+          mkdir bin && cd bin
+          COMPILE_OPT=(
+            -DCMAKE_C_FLAGS_DEBUG=-g1
+            -DCMAKE_CXX_FLAGS_DEBUG=-g1
+          )
+          CMAKE_OPT="
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+            -DBUILD_CONFIG=mysql_release
+            -DWITH_PACKAGE_FLAGS=OFF
+            -DDOWNLOAD_BOOST=1
+            -DWITH_BOOST=$BOOST_DIR
+            -DCMAKE_C_COMPILER=$SELECTED_CC
+            -DCMAKE_CXX_COMPILER=$SELECTED_CXX
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DWITH_ROCKSDB=ON
+            -DWITH_COREDUMPER=ON
+            -DWITH_KEYRING_VAULT=ON
+            -DWITH_KEYRING_VAULT_TEST=ON
+            -DWITH_PAM=ON
+            -DMYSQL_MAINTAINER_MODE=ON
+            -DWITH_MECAB=system
+            -DWITH_NUMA=ON
+            -DWITH_READLINE=system
+            -DWITH_SYSTEM_LIBS=ON
+          "
+          cmake .. $CMAKE_OPT "${COMPILE_OPT[@]}"
+          rm -f "$BOOST_DIR/$BOOST_VERSION.tar.gz"
+          cmake -L .
+
+      # Azure: `*** Compile` uses `make -j2` (MS-hosted has 2 cores).
+      # arm64 deviation: scale to cax* cores, capped at 16 (Cirrus pattern).
+      # Rationale: literal -j2 would waste cax41's 16 cores; arm64 builds
+      # benefit linearly from parallelism, this is THE migration win.
+      - name: Compile (make -j, capped at 16)
+        run: |
+          set -eux
+          cd bin
+          NPROC=$(nproc --all)
+          NTHREADS=$(( NPROC > 16 ? 16 : NPROC ))
+          echo "Using $NTHREADS/$NPROC threads (Azure literal: -j2)"
+          make -j${NTHREADS}
+          ccache --show-stats
+          df -h /
+
+      # arm64-only step (Azure x86 doesn't run MTR; Cirrus arm64 does).
+      # Mirrors Cirrus's arm64 task: --debug-server, --force,
+      # --max-test-fail=0, --retry-failure=0.
+      - name: MTR main.1st (arm64-only; Cirrus parity)
+        run: |
+          set -eux
+          cd bin
+          NPROC=$(nproc --all)
+          NTHREADS=$(( NPROC > 16 ? 16 : NPROC ))
+          LIBEATMYDATA=$(whereis libeatmydata.so | awk '{print $2}')
+          mysql-test/mysql-test-run.pl main.1st \
+            --parallel=$NTHREADS \
+            --junit-output=/tmp/MTR_results.xml \
+            --mysqld-env=LD_PRELOAD=${LIBEATMYDATA} \
+            --force --max-test-fail=0 --retry-failure=0 \
+            --debug-server
+
+      - name: Upload MTR results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.0
+        with:
+          name: mtr-results
+          path: /tmp/MTR_results.xml
+          if-no-files-found: ignore
+
+  delete-runner:
+    needs: [pick-target, create-runner, do-the-job]
+    if: always() && needs.create-runner.outputs.server_id != ''
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: olexandr-havryliak/hcloud-github-runner@bb1089d8b718a06493cb37c51dfe596e44baefc2
+        with:
+          mode: delete
+          name: ${{ env.RUNNER_NAME }}
+          server_id: ${{ needs.create-runner.outputs.server_id }}
+          hcloud_token: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          github_token: ${{ secrets.GHA_RUNNER_PAT }}

--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -1,0 +1,135 @@
+# Hourly sweeper for leaked Hetzner runner VMs and offline GHA runners.
+# Companion to build-arm64.yml; catches orphans from control-plane crashes,
+# cancelled workflows, and probe-step leaks.
+
+name: orphan-sweep
+
+on:
+  schedule:
+    - cron: '23 * * * *'   # hourly, off the top of hour
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run: list what would be deleted, do nothing'
+        type: boolean
+        default: false
+      max_age_hours:
+        description: 'Orphan age threshold (hours); default 2h; lower at your own risk (build-arm64 has timeout-minutes: 180)'
+        type: string
+        default: '6'
+
+permissions: {}
+
+concurrency:
+  group: orphan-sweep
+  cancel-in-progress: false   # let prior sweep finish; serialize with next
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+      RUNNER_PAT: ${{ secrets.GHA_RUNNER_PAT }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      MAX_AGE_HOURS: ${{ inputs.max_age_hours || '6' }}
+    steps:
+      - name: Sweep Hetzner orphans
+        run: |
+          set -euo pipefail
+          : "${HCLOUD_TOKEN:?secret HCLOUD_TOKEN required}"
+          NOW=$(date -u +%s)
+          MAX_AGE_SECONDS=$(( MAX_AGE_HOURS * 3600 ))
+          echo "Threshold: ${MAX_AGE_HOURS}h (${MAX_AGE_SECONDS}s); dry_run=${DRY_RUN}"
+
+          # Page through all servers (max 50/page). Servers we own start with ps-arm64- or cap-probe-.
+          PAGE=1
+          : > /tmp/candidates.tsv
+          while :; do
+            RESP=$(curl -fsS -H "Authorization: Bearer $HCLOUD_TOKEN" \
+              "https://api.hetzner.cloud/v1/servers?per_page=50&page=${PAGE}")
+            echo "$RESP" \
+              | jq -r --arg now "$NOW" --arg age "$MAX_AGE_SECONDS" '
+                  .servers[]
+                  | select(.name | test("^(ps-arm64-|cap-probe-)"))
+                  | select(($now|tonumber) - (.created | fromdateiso8601) > ($age|tonumber))
+                  | [.id, .name, .created] | @tsv' \
+              >> /tmp/candidates.tsv
+            LAST=$(echo "$RESP" | jq -r '.meta.pagination.last_page // 1')
+            [ "$PAGE" -ge "$LAST" ] && break
+            PAGE=$((PAGE+1))
+          done
+
+          TOTAL=$(wc -l < /tmp/candidates.tsv)
+          DELETED=0
+          FAILED=0
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "Candidates (>${MAX_AGE_HOURS}h old, matching prefix):"
+            cat /tmp/candidates.tsv
+            while IFS=$'\t' read -r id name created; do
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "::notice::[dry-run] would delete $name (id=$id, created=$created)"
+              else
+                echo "::warning::Deleting orphan: $name (id=$id, created=$created)"
+                if curl -fsS -X DELETE -H "Authorization: Bearer $HCLOUD_TOKEN" \
+                     "https://api.hetzner.cloud/v1/servers/$id" >/dev/null; then
+                  DELETED=$((DELETED+1))
+                else
+                  echo "::error::Failed to delete server $id"
+                  FAILED=$((FAILED+1))
+                fi
+              fi
+            done < /tmp/candidates.tsv
+          fi
+
+          {
+            echo "### Hetzner sweep"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| candidates | ${TOTAL} |"
+            echo "| deleted | ${DELETED} |"
+            echo "| failed | ${FAILED} |"
+            echo "| threshold | ${MAX_AGE_HOURS}h |"
+            echo "| dry_run | ${DRY_RUN} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sweep offline GHA runners
+        if: env.RUNNER_PAT != ''
+        run: |
+          set -euo pipefail
+          UNREGISTERED=0
+          FAILED=0
+          # offline runners with our naming prefix
+          mapfile -t LINES < <(
+            curl -fsS -H "Authorization: Bearer $RUNNER_PAT" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runners?per_page=100" \
+              | jq -r '.runners[] | select(.status=="offline") | select(.name | test("^ps-arm64-")) | "\(.id)\t\(.name)"'
+          )
+          for line in "${LINES[@]}"; do
+            [ -z "$line" ] && continue
+            id="${line%%$'\t'*}"
+            name="${line#*$'\t'}"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice::[dry-run] would unregister offline runner: $name (id=$id)"
+            else
+              echo "::warning::Unregistering offline runner: $name (id=$id)"
+              if curl -fsS -X DELETE -H "Authorization: Bearer $RUNNER_PAT" \
+                   "https://api.github.com/repos/${{ github.repository }}/actions/runners/$id" >/dev/null; then
+                UNREGISTERED=$((UNREGISTERED+1))
+              else
+                FAILED=$((FAILED+1))
+              fi
+            fi
+          done
+
+          {
+            echo ""
+            echo "### GHA offline runner sweep"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| unregistered | ${UNREGISTERED} |"
+            echo "| failed | ${FAILED} |"
+            echo "| candidates | ${#LINES[@]} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}
     env:
       HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
-      GH_TOKEN: ${{ secrets.GHA_GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GHA_RUNNER_PAT }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
       MAX_AGE_HOURS: ${{ inputs.max_age_hours || '6' }}
     steps:

--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}
     env:
       HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
-      RUNNER_PAT: ${{ secrets.GHA_RUNNER_PAT }}
+      GH_TOKEN: ${{ secrets.GHA_GH_TOKEN }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
       MAX_AGE_HOURS: ${{ inputs.max_age_hours || '6' }}
     steps:
@@ -95,14 +95,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Sweep offline GHA runners
-        if: env.RUNNER_PAT != ''
+        if: env.GH_TOKEN != ''
         run: |
           set -euo pipefail
           UNREGISTERED=0
           FAILED=0
           # offline runners with our naming prefix
           mapfile -t LINES < <(
-            curl -fsS -H "Authorization: Bearer $RUNNER_PAT" \
+            curl -fsS -H "Authorization: Bearer $GH_TOKEN" \
               "https://api.github.com/repos/${{ github.repository }}/actions/runners?per_page=100" \
               | jq -r '.runners[] | select(.status=="offline") | select(.name | test("^ps-arm64-")) | "\(.id)\t\(.name)"'
           )
@@ -114,7 +114,7 @@ jobs:
               echo "::notice::[dry-run] would unregister offline runner: $name (id=$id)"
             else
               echo "::warning::Unregistering offline runner: $name (id=$id)"
-              if curl -fsS -X DELETE -H "Authorization: Bearer $RUNNER_PAT" \
+              if curl -fsS -X DELETE -H "Authorization: Bearer $GH_TOKEN" \
                    "https://api.github.com/repos/${{ github.repository }}/actions/runners/$id" >/dev/null; then
                 UNREGISTERED=$((UNREGISTERED+1))
               else


### PR DESCRIPTION
## Summary

Migrate percona-server's arm64 build coverage from Cirrus CI to GitHub Actions on Hetzner ephemeral runners before Cirrus shuts down 2026-06-01. 
Adds `.github/workflows/build-arm64.yml` (Cirrus-parity build, ported from `azure-pipelines.yml`) and `.github/workflows/orphan-sweep.yml` (hourly leaked-VM cleanup).

## Why

- arm64 is the only platform Cirrus covers for percona-server (Azure covers all x86 variants). Ports `azure-pipelines.yml` (gcc Debug, `BUILD_PARAMS_TYPE=normal`) to GHA, retargeted arm64. Same shape as Azure so the eventual Azure→Hetzner migration is a label swap (per Przemek 2026-05-18).
- Runner: ephemeral Hetzner `cax*` via [olexandr-havryliak/hcloud-github-runner@bb1089d8](https://github.com/olexandr-havryliak/hcloud-github-runner/commit/bb1089d8b718a06493cb37c51dfe596e44baefc2) (PSMDB pattern, SHA-pinned). Capacity probe `cax41 → cax31 → cax21 × DCs` auto-degrades during [PS-11174](https://perconadev.atlassian.net/browse/PS-11174) ARM outage. ccache via `actions/cache@v4` (Azure key shape); boost cached separately.
- Trust split: build job runs PR code with read-only `GITHUB_TOKEN`, no infra secrets. Trusted `create-runner`/`delete-runner` hold org `GHA_RUNNER_*` secrets from [HD-30964](https://percona.atlassian.net/servicedesk/customer/portal/2/HD-30964).
- Validated on `nogueiraanderson/percona-server` fork end-to-end: 4-job pipeline all green, build 2m54s + MTR `main.1st` 36s on `cax21` warm-cache.
- MTR: `main.1st` on PR (Cirrus parity). Cron + matrix `[8.0, trunk, 8.4] × [Debug, RelWithDebInfo]` (`binlog_nogtid` for RelWithDebInfo) in follow-up PR.
- Out of scope: fork-PR coverage (`inikep/percona-server`), `.cirrus.yml` deletion (deferred pending parallel-run-window answer from Przemek).

## Tickets

- [PS-11078](https://perconadev.atlassian.net/browse/PS-11078) (this), [PS-11174](https://perconadev.atlassian.net/browse/PS-11174), [HD-30964](https://percona.atlassian.net/servicedesk/customer/portal/2/HD-30964)


[PS-11174]: https://perconadev.atlassian.net/browse/PS-11174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HD-30964]: https://percona.atlassian.net/browse/HD-30964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ