### PR TITLE
PS-11161 [8.0]: mem_root_deque performance optimizations (part 2).

### DIFF
--- a/sql/parse_tree_node_base.cc
+++ b/sql/parse_tree_node_base.cc
@@ -30,7 +30,7 @@ Parse_context::Parse_context(THD *thd_arg, Query_block *sl_arg)
     : thd(thd_arg),
       mem_root(thd->mem_root),
       select(sl_arg),
-      m_stack(thd->mem_root) {
+      m_stack(Mem_root_allocator<QueryLevel>(thd->mem_root)) {
   m_stack.push_back(QueryLevel(thd->mem_root, SC_TOP));
 }
 
@@ -40,7 +40,7 @@ Parse_context::Parse_context(THD *thd_arg, Query_block *sl_arg)
   query_term.h .
 */
 bool Parse_context::finalize_query_expression() {
-  QueryLevel ql = m_stack.back();
+  QueryLevel ql = std::move(m_stack.back());
   m_stack.pop_back();
   assert(ql.m_elts.size() == 1);
   Query_term *top = ql.m_elts.back();
@@ -53,8 +53,8 @@ bool Parse_context::finalize_query_expression() {
 bool Parse_context::is_top_level_union_all(Surrounding_context op) {
   if (op == SC_EXCEPT_ALL || op == SC_INTERSECT_ALL) return false;
   assert(op == SC_UNION_ALL);
-  for (size_t i = m_stack.size(); i > 0; i--) {
-    switch (m_stack[i - 1].m_type) {
+  for (auto i = m_stack.crbegin(); i != m_stack.crend(); ++i) {
+    switch (i->m_type) {
       case SC_UNION_DISTINCT:
       case SC_INTERSECT_DISTINCT:
       case SC_INTERSECT_ALL:
@@ -65,7 +65,7 @@ bool Parse_context::is_top_level_union_all(Surrounding_context op) {
       case SC_QUERY_EXPRESSION:
         // Ordering above this level in the context stack (syntactically
         // outside) precludes streaming of UNION ALL.
-        if (m_stack[i - 1].m_has_order) return false;
+        if (i->m_has_order) return false;
         [[fallthrough]];
       default:;
     }

--- a/sql/parse_tree_node_base.h
+++ b/sql/parse_tree_node_base.h
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <cstdarg>
 #include <cstdlib>
+#include <list>
 #include <new>
 #include <queue>
 
@@ -37,6 +38,7 @@
 #include "mem_root_deque.h"
 #include "my_inttypes.h"  // TODO: replace with cstdint
 #include "sql/check_stack.h"
+#include "sql/mem_root_allocator.h"
 #include "sql/parse_location.h"
 #include "sql/sql_const.h"
 
@@ -110,19 +112,22 @@ enum Surrounding_context {
 
 struct QueryLevel {
   Surrounding_context m_type;
-  mem_root_deque<Query_term *> m_elts;
+  std::list<Query_term *, Mem_root_allocator<Query_term *>> m_elts;
   bool m_has_order{false};
   QueryLevel(MEM_ROOT *mem_root, Surrounding_context sc, bool has_order = false)
-      : m_type(sc), m_elts(mem_root), m_has_order(has_order) {}
+      : m_type(sc),
+        m_elts(Mem_root_allocator<Query_term *>(mem_root)),
+        m_has_order(has_order) {}
 };
 /**
   Environment data for the contextualization phase
 */
 struct Parse_context {
-  THD *const thd;                      ///< Current thread handler
-  MEM_ROOT *mem_root;                  ///< Current MEM_ROOT
-  Query_block *select;                 ///< Current Query_block object
-  mem_root_deque<QueryLevel> m_stack;  ///< Aids query term tree construction
+  THD *const thd;       ///< Current thread handler
+  MEM_ROOT *mem_root;   ///< Current MEM_ROOT
+  Query_block *select;  ///< Current Query_block object
+  std::list<QueryLevel, Mem_root_allocator<QueryLevel>>
+      m_stack;  ///< Aids query term tree construction
   /// Call upon parse completion.
   /// @returns true on error, else false
   bool finalize_query_expression();

--- a/sql/parse_tree_nodes.cc
+++ b/sql/parse_tree_nodes.cc
@@ -1224,7 +1224,6 @@ bool PT_query_specification::contextualize(Parse_context *pc) {
   if (contextualize_safe(pc, opt_window_clause)) return true;
   pc->select->parsing_place = CTX_NONE;
 
-  QueryLevel ql = pc->m_stack.back();
   pc->m_stack.pop_back();
   pc->m_stack.back().m_elts.push_back(pc->select);
   return (opt_hints != nullptr ? opt_hints->contextualize(pc) : false);
@@ -1244,7 +1243,6 @@ bool PT_table_value_constructor::contextualize(Parse_context *pc) {
     pc->select->fields.push_back(item);
   }
 
-  QueryLevel ql = pc->m_stack.back();
   pc->m_stack.pop_back();
   pc->m_stack.back().m_elts.push_back(pc->select);
 
@@ -1709,7 +1707,7 @@ bool PT_set_operation::contextualize_setop(Parse_context *pc,
     pc->thd->lex->pop_context();
   }
 
-  QueryLevel ql = pc->m_stack.back();
+  QueryLevel ql = std::move(pc->m_stack.back());
   pc->m_stack.pop_back();
 
   Query_term_set_op *setop = nullptr;
@@ -4110,7 +4108,7 @@ bool PT_query_expression::contextualize(Parse_context *pc) {
   if (Parse_tree_node::contextualize(pc) || m_body->contextualize(pc))
     return true;
 
-  QueryLevel ql = pc->m_stack.back();
+  QueryLevel ql = std::move(pc->m_stack.back());
   Query_term *expr = ql.m_elts.back();
   pc->m_stack.pop_back();
 
@@ -4151,7 +4149,7 @@ bool PT_query_expression::contextualize(Parse_context *pc) {
         expr = new (pc->mem_root) Query_term_unary(pc->mem_root, expr);
         if (expr == nullptr) return true;
       }
-      QueryLevel upper = pc->m_stack.back();
+      QueryLevel upper = std::move(pc->m_stack.back());
       pc->m_stack.pop_back();
       ql.m_elts.pop_back();
       if (upper.m_type == SC_UNION_DISTINCT || upper.m_type == SC_UNION_ALL ||
@@ -4160,7 +4158,7 @@ bool PT_query_expression::contextualize(Parse_context *pc) {
           upper.m_type == SC_INTERSECT_ALL)
         ql = upper;
       ql.m_elts.push_back(expr);
-      pc->m_stack.push_back(ql);
+      pc->m_stack.push_back(std::move(ql));
     } break;
     case QT_QUERY_BLOCK: {
       if (contextualize_order_and_limit(pc)) return true;
@@ -4168,7 +4166,7 @@ bool PT_query_expression::contextualize(Parse_context *pc) {
         expr = new (pc->mem_root) Query_term_unary(pc->mem_root, expr);
         if (expr == nullptr) return true;
       }
-      QueryLevel upper = pc->m_stack.back();
+      QueryLevel upper = std::move(pc->m_stack.back());
       pc->m_stack.pop_back();
       ql.m_elts.pop_back();
       if (upper.m_type == SC_UNION_DISTINCT || upper.m_type == SC_UNION_ALL ||
@@ -4177,7 +4175,7 @@ bool PT_query_expression::contextualize(Parse_context *pc) {
           upper.m_type == SC_INTERSECT_ALL)
         ql = upper;
       ql.m_elts.push_back(expr);
-      pc->m_stack.push_back(ql);
+      pc->m_stack.push_back(std::move(ql));
     } break;
     case QT_UNION:
     case QT_EXCEPT:


### PR DESCRIPTION
Avoid usage of mem_root_deque for stack of QueryLevel objects and its members QueryLevel::m_elts. Both these containers are likely to contain a few elements in common cases (for simple queries there will be only one element in them), so using mem_root_deque which preallocates space for 16 elements (which means around 1.5Kb for QueryLevel stack on 64-bit system) is likely to waste memory while creating additional pressure on the main memory root.

Replace unnecessary copying of QueryLevel objects by using move semantics where possible.