### PR TITLE
PS-11161 [9.7]: mem_root_deque performance optimizations (part 2).

### DIFF
--- a/sql/parse_tree_node_base.cc
+++ b/sql/parse_tree_node_base.cc
@@ -37,7 +37,7 @@ Parse_context::Parse_context(THD *thd_arg, Query_block *sl_arg,
       thd(thd_arg),
       mem_root(thd->mem_root),
       select(sl_arg),
-      m_stack(thd->mem_root) {
+      m_stack(Mem_root_allocator<QueryLevel>(thd->mem_root)) {
   m_stack.push_back(QueryLevel(thd->mem_root, SC_TOP));
 }
 
@@ -47,7 +47,7 @@ Parse_context::Parse_context(THD *thd_arg, Query_block *sl_arg,
   query_term.h .
 */
 bool Parse_context::finalize_query_expression() {
-  QueryLevel ql = m_stack.back();
+  QueryLevel ql = std::move(m_stack.back());
   m_stack.pop_back();
   assert(ql.m_elts.size() == 1);
   Query_term *top = ql.m_elts.back();
@@ -64,8 +64,8 @@ bool Parse_context::finalize_query_expression() {
 bool Parse_context::is_top_level_union_all(Surrounding_context op) {
   if (op == SC_EXCEPT_ALL || op == SC_INTERSECT_ALL) return false;
   assert(op == SC_UNION_ALL);
-  for (size_t i = m_stack.size(); i > 0; i--) {
-    switch (m_stack[i - 1].m_type) {
+  for (auto i = m_stack.crbegin(); i != m_stack.crend(); ++i) {
+    switch (i->m_type) {
       case SC_UNION_DISTINCT:
       case SC_INTERSECT_DISTINCT:
       case SC_INTERSECT_ALL:
@@ -76,7 +76,7 @@ bool Parse_context::is_top_level_union_all(Surrounding_context op) {
       case SC_QUERY_EXPRESSION:
         // Ordering above this level in the context stack (syntactically
         // outside) precludes streaming of UNION ALL.
-        if (m_stack[i - 1].m_has_order) return false;
+        if (i->m_has_order) return false;
         [[fallthrough]];
       default:;
     }

--- a/sql/parse_tree_node_base.h
+++ b/sql/parse_tree_node_base.h
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <cstdarg>
 #include <cstdlib>
+#include <list>
 #include <new>
 #include <queue>
 #include <typeinfo>
@@ -39,6 +40,7 @@
 #include "my_inttypes.h"  // TODO: replace with cstdint
 #include "sql-common/json_dom.h"
 #include "sql/check_stack.h"
+#include "sql/mem_root_allocator.h"
 #include "sql/parse_location.h"
 #include "sql/sql_const.h"
 #include "sql/sql_list.h"
@@ -114,10 +116,12 @@ enum Surrounding_context {
 
 struct QueryLevel {
   Surrounding_context m_type;
-  mem_root_deque<Query_term *> m_elts;
+  std::list<Query_term *, Mem_root_allocator<Query_term *>> m_elts;
   bool m_has_order{false};
   QueryLevel(MEM_ROOT *mem_root, Surrounding_context sc, bool has_order = false)
-      : m_type(sc), m_elts(mem_root), m_has_order(has_order) {}
+      : m_type(sc),
+        m_elts(Mem_root_allocator<Query_term *>(mem_root)),
+        m_has_order(has_order) {}
 };
 
 class Json_object;
@@ -420,10 +424,11 @@ struct Parse_context_base {
   Environment data for the contextualization phase
 */
 struct Parse_context : public Parse_context_base {
-  THD *const thd;                      ///< Current thread handler
-  MEM_ROOT *mem_root;                  ///< Current MEM_ROOT
-  Query_block *select;                 ///< Current Query_block object
-  mem_root_deque<QueryLevel> m_stack;  ///< Aids query term tree construction
+  THD *const thd;       ///< Current thread handler
+  MEM_ROOT *mem_root;   ///< Current MEM_ROOT
+  Query_block *select;  ///< Current Query_block object
+  std::list<QueryLevel, Mem_root_allocator<QueryLevel>>
+      m_stack;  ///< Aids query term tree construction
   /// Call upon parse completion.
   /// @returns true on error, else false
   bool finalize_query_expression();

--- a/sql/parse_tree_nodes.cc
+++ b/sql/parse_tree_nodes.cc
@@ -1605,7 +1605,6 @@ bool PT_query_specification::do_contextualize(Parse_context *pc) {
 
   pc->select->parsing_place = CTX_NONE;
 
-  QueryLevel ql = pc->m_stack.back();
   pc->m_stack.pop_back();
   pc->m_stack.back().m_elts.push_back(pc->select);
   return (opt_hints != nullptr ? opt_hints->contextualize(pc) : false);
@@ -1634,7 +1633,6 @@ bool PT_table_value_constructor::do_contextualize(Parse_context *pc) {
     pc->select->fields.push_back(item);
   }
 
-  QueryLevel ql = pc->m_stack.back();
   pc->m_stack.pop_back();
   pc->m_stack.back().m_elts.push_back(pc->select);
 
@@ -2115,7 +2113,7 @@ bool PT_set_operation::contextualize_setop(Parse_context *pc,
     pc->thd->lex->pop_context();
   }
 
-  QueryLevel ql = pc->m_stack.back();
+  QueryLevel ql = std::move(pc->m_stack.back());
   pc->m_stack.pop_back();
 
   Query_term_set_op *setop = nullptr;
@@ -4928,7 +4926,7 @@ bool PT_query_expression::do_contextualize(Parse_context *pc) {
   if (Parse_tree_node::do_contextualize(pc) || m_body->contextualize(pc))
     return true;
 
-  QueryLevel ql = pc->m_stack.back();
+  QueryLevel ql = std::move(pc->m_stack.back());
   Query_term *expr = ql.m_elts.back();
   pc->m_stack.pop_back();
 
@@ -4969,7 +4967,7 @@ bool PT_query_expression::do_contextualize(Parse_context *pc) {
         expr = new (pc->mem_root) Query_term_unary(pc->mem_root, expr);
         if (expr == nullptr) return true;
       }
-      QueryLevel upper = pc->m_stack.back();
+      QueryLevel upper = std::move(pc->m_stack.back());
       pc->m_stack.pop_back();
       ql.m_elts.pop_back();
       if (upper.m_type == SC_UNION_DISTINCT || upper.m_type == SC_UNION_ALL ||
@@ -4978,7 +4976,7 @@ bool PT_query_expression::do_contextualize(Parse_context *pc) {
           upper.m_type == SC_INTERSECT_ALL)
         ql = upper;
       ql.m_elts.push_back(expr);
-      pc->m_stack.push_back(ql);
+      pc->m_stack.push_back(std::move(ql));
     } break;
     case QT_QUERY_BLOCK: {
       if (contextualize_order_and_limit(pc)) return true;
@@ -4986,7 +4984,7 @@ bool PT_query_expression::do_contextualize(Parse_context *pc) {
         expr = new (pc->mem_root) Query_term_unary(pc->mem_root, expr);
         if (expr == nullptr) return true;
       }
-      QueryLevel upper = pc->m_stack.back();
+      QueryLevel upper = std::move(pc->m_stack.back());
       pc->m_stack.pop_back();
       ql.m_elts.pop_back();
       if (upper.m_type == SC_UNION_DISTINCT || upper.m_type == SC_UNION_ALL ||
@@ -4995,7 +4993,7 @@ bool PT_query_expression::do_contextualize(Parse_context *pc) {
           upper.m_type == SC_INTERSECT_ALL)
         ql = upper;
       ql.m_elts.push_back(expr);
-      pc->m_stack.push_back(ql);
+      pc->m_stack.push_back(std::move(ql));
     } break;
     case QT_UNION:
     case QT_EXCEPT:


### PR DESCRIPTION
Avoid usage of mem_root_deque for stack of QueryLevel objects and its members QueryLevel::m_elts. Both these containers are likely to contain a few elements in common cases (for simple queries there will be only one element in them), so using mem_root_deque which preallocates space for 16 elements (which means around 1.5Kb for QueryLevel stack on 64-bit system) is likely to waste memory while creating additional pressure on the main memory root.

Replace unnecessary copying of QueryLevel objects by using move semantics where possible.