### PR TITLE
PS-10963 [8.0]: Disable audit_log_filter.udf_audit_log_read_validate_…

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -14,6 +14,9 @@
 # audit_log
 audit_log.audit_log_prune_seconds_var_cnf @windows : BUG#32245509 Test lets mysqltest crash only on windows.
 
+# audit_log_filter
+audit_log_filter.udf_audit_log_read_validate_output : BUG#0000 Test with known issues for problematic feature. Both are fixed in 8.4
+
 # audit_null
 audit_null.audit_plugin_bugs : BUG#28080637 Test fails consistently
 


### PR DESCRIPTION
…output test.

This test failed in Jenkins or locally when run after some other tests (for example udf_audit_log_read_bookmark).

We decided to disable it, since the fix for this issue seems to be non-trivial, and since both the test and functionality it covers are known to have problems which were properly fixed only in 8.4.