### PR TITLE
PS-11078: nightly arm64 RelWithDebInfo + binlog_nogtid (centralised on 8.0)

### DIFF
--- a/.github/workflows/build-arm64-nightly.yml
+++ b/.github/workflows/build-arm64-nightly.yml
@@ -1,0 +1,336 @@
+# PS-11078: nightly RelWithDebInfo arm64 build on Hetzner cax*. Replaces the
+# Cirrus nightly task `(arm64) gcc RelWithDebInfo [Noble]` on 8.0, trunk, 8.4
+# before Cirrus shuts down 2026-06-01.
+#
+# Centralised on 8.0 (default branch) because GHA `schedule:` triggers only
+# fire from the default branch. Three cron entries dispatch to ref=8.0, trunk,
+# or 8.4 via the `pickbranch` job. Build shape mirrors azure-pipelines.yml on
+# the target branch; cmake/apt deltas (Boost cache, KEYRING_VAULT vs
+# COMPONENT_KEYRING_VAULT, READLINE vs EDITLINE, ZenFS, CURL) are gated on
+# `$BRANCH` inside the build step.
+#
+# MTR: `--suite=binlog_nogtid` per Przemek's 2026-05-18 ask.
+
+name: build-arm64-nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'   # trunk
+    - cron: '0 1 * * *'   # 8.0
+    - cron: '0 2 * * *'   # 8.4
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build'
+        type: choice
+        options:
+          - '8.0'
+          - trunk
+          - '8.4'
+        default: '8.0'
+
+concurrency:
+  group: build-arm64-nightly-${{ inputs.branch || github.event.schedule || github.ref }}
+  cancel-in-progress: false   # never cancel a paid Hetzner build mid-run
+
+permissions:
+  contents: read
+
+env:
+  BUILD_TYPE: RelWithDebInfo
+  BUILD_PARAMS_TYPE: normal
+  COMPILER: gcc
+  COMPILER_VER: ''
+  IMAGE_NAME: ubuntu-24.04
+  UBUNTU_CODE_NAME: noble
+  BOOST_VERSION: boost_1_77_0
+  USE_CCACHE: '1'
+  CCACHE_COMPRESS: '1'
+  CCACHE_COMPRESSLEVEL: '9'
+  CCACHE_CPP2: '1'
+  CCACHE_MAXSIZE: 8G   # RelWithDebInfo bigger than Debug
+  IMAGE: ubuntu-24.04
+  SSH_KEY_ID: '107239874'
+  RUNNER_NAME: ps-arm64-nightly-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  # TRUSTED. Decide which branch this run targets.
+  pickbranch:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      branch: ${{ steps.pick.outputs.branch }}
+    steps:
+      - id: pick
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            BRANCH="${{ inputs.branch }}"
+          else
+            case "${{ github.event.schedule }}" in
+              '0 0 * * *') BRANCH=trunk ;;
+              '0 1 * * *') BRANCH='8.0' ;;
+              '0 2 * * *') BRANCH='8.4' ;;
+              *) echo "::error::Unrecognised schedule: ${{ github.event.schedule }}"; exit 1 ;;
+            esac
+          fi
+          echo "Nightly RelWithDebInfo target: $BRANCH" >> "$GITHUB_STEP_SUMMARY"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+  # TRUSTED. Dynamic capacity probe: cax41 -> cax31 -> cax21 across DCs.
+  pick-target:
+    needs: pickbranch
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      location: ${{ steps.probe.outputs.location }}
+      server_type: ${{ steps.probe.outputs.server_type }}
+    steps:
+      - id: probe
+        env:
+          HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          for type in cax41 cax31 cax21; do
+            for dc in fsn1 hel1 nbg1; do
+              PROBE_NAME="cap-probe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${type}-${dc}"
+              HTTP=$(curl -sS -o /tmp/resp.json -w "%{http_code}" -X POST \
+                -H "Authorization: Bearer $HCLOUD_TOKEN" -H "Content-Type: application/json" \
+                https://api.hetzner.cloud/v1/servers \
+                -d "{\"name\":\"$PROBE_NAME\",\"server_type\":\"$type\",\"image\":\"$IMAGE\",\"location\":\"$dc\",\"start_after_create\":false}")
+              if [ "$HTTP" = "201" ]; then
+                ID=$(jq -r '.server.id // empty' /tmp/resp.json)
+                [ -n "$ID" ] || { echo "::error::201 without server id"; exit 1; }
+                curl -fsS -X DELETE -H "Authorization: Bearer $HCLOUD_TOKEN" \
+                  "https://api.hetzner.cloud/v1/servers/$ID" >/dev/null
+                if [ "$type" != "cax41" ]; then
+                  echo "::warning::cax41 unavailable (PS-11174); falling back to $type in $dc"
+                fi
+                echo "Hetzner target: $type in $dc" >> "$GITHUB_STEP_SUMMARY"
+                { echo "location=$dc"; echo "server_type=$type"; } >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ERR=$(jq -r '.error.code // "?"' /tmp/resp.json 2>/dev/null || echo "?")
+              echo "::warning::$type/$dc: HTTP $HTTP ($ERR)"
+            done
+          done
+          echo "::error::No CAX capacity in fsn1/hel1/nbg1"
+          exit 1
+
+  # TRUSTED. Provision the ephemeral runner.
+  create-runner:
+    needs: [pickbranch, pick-target]
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      runner_label: ${{ env.RUNNER_NAME }}
+      server_id: ${{ steps.create.outputs.server_id }}
+      server_type: ${{ needs.pick-target.outputs.server_type }}
+    steps:
+      - id: create
+        uses: olexandr-havryliak/hcloud-github-runner@bb1089d8b718a06493cb37c51dfe596e44baefc2
+        with:
+          mode: create
+          name: ${{ env.RUNNER_NAME }}
+          hcloud_token: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          github_token: ${{ secrets.GHA_RUNNER_PAT }}
+          image: ${{ env.IMAGE }}
+          location: ${{ needs.pick-target.outputs.location }}
+          server_type: ${{ needs.pick-target.outputs.server_type }}
+          ssh_key: ${{ env.SSH_KEY_ID }}
+          pre_runner_script: |
+            apt-get update -y
+            apt-get install -y curl ca-certificates jq
+
+  # UNTRUSTED. Target-branch code runs here.
+  do-the-job:
+    needs: [pickbranch, pick-target, create-runner]
+    runs-on: ${{ needs.create-runner.outputs.runner_label }}
+    permissions:
+      contents: read
+    timeout-minutes: 240
+    env:
+      BRANCH: ${{ needs.pickbranch.outputs.branch }}
+      PARENT_BRANCH: ${{ needs.pickbranch.outputs.branch }}
+      CCACHE_DIR: /home/runner/ccache
+      BOOST_DIR: /tmp/boost
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: System info
+        run: |
+          set -eux
+          echo "Server type: ${{ needs.create-runner.outputs.server_type }}"
+          echo "Target branch: $BRANCH"
+          uname -a
+          nproc
+          free -h
+          df -h /
+
+      - name: Conditional swap (only when RAM < 16 GB)
+        run: |
+          set -eux
+          MEM_GB=$(awk '/MemTotal/ {print int($2/1024/1024)}' /proc/meminfo)
+          if [ "$MEM_GB" -lt 16 ]; then
+            sudo fallocate -l 16G /swapfile
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+            sudo swapon /swapfile
+          fi
+          free -h
+
+      - name: Install Build Dependencies
+        run: |
+          set -eux
+          SELECTED_CC="${COMPILER}${COMPILER_VER:+-${COMPILER_VER}}"
+          SELECTED_CXX="${COMPILER}++${COMPILER_VER:+-${COMPILER_VER}}"
+          [ "$COMPILER" = "gcc" ] && SELECTED_CXX="g++${COMPILER_VER:+-${COMPILER_VER}}"
+          echo "SELECTED_CC=$SELECTED_CC" >> "$GITHUB_ENV"
+          echo "SELECTED_CXX=$SELECTED_CXX" >> "$GITHUB_ENV"
+          PACKAGES="$SELECTED_CC"
+          [ "$COMPILER" = "gcc" ] && PACKAGES="$SELECTED_CXX"
+          # 8.0 uses libreadline; trunk/8.4 use libedit only.
+          APT_EXTRA=""
+          [ "$BRANCH" = "8.0" ] && APT_EXTRA="libreadline-dev"
+          sudo apt-get -yq update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            $PACKAGES make pkg-config dpkg-dev unzip lz4 git cmake cmake-curses-gui ccache bison \
+            libtirpc-dev libudev-dev libaio-dev libmecab-dev libnuma-dev \
+            libssl-dev libedit-dev libpam-dev \
+            libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev \
+            libsasl2-modules-gssapi-mit \
+            libxml-simple-perl $APT_EXTRA
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            libicu-dev libevent-dev liblz4-dev zlib1g-dev \
+            protobuf-compiler libprotobuf-dev libprotoc-dev \
+            libzstd-dev libfido2-dev
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libeatmydata1
+          REAL_COMPILER_VER=$($SELECTED_CC --version | head -1 | awk '{print $4}')
+          echo "REAL_COMPILER_VER=$REAL_COMPILER_VER" >> "$GITHUB_ENV"
+
+      - name: ccache cache (Azure key shape; branch-scoped)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.2.0
+        with:
+          path: /home/runner/ccache
+          key: ccache-${{ env.BRANCH }}-${{ env.IMAGE_NAME }}-${{ env.COMPILER }}-${{ env.BUILD_TYPE }}-${{ env.BUILD_PARAMS_TYPE }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ env.BRANCH }}-${{ env.IMAGE_NAME }}-${{ env.COMPILER }}-${{ env.BUILD_TYPE }}-${{ env.BUILD_PARAMS_TYPE }}-
+
+      - name: boost cache (8.0 only)
+        if: env.BRANCH == '8.0'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.2.0
+        with:
+          path: /tmp/boost
+          key: ${{ env.BOOST_VERSION }}
+
+      - name: Checkout target branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
+        with:
+          ref: ${{ env.BRANCH }}
+          fetch-depth: 32
+
+      - name: Update git submodules
+        run: |
+          set -eux
+          git submodule sync
+          git submodule update --init --force --depth=256
+          git submodule
+
+      - name: System and compiler info
+        run: |
+          set -eux
+          $SELECTED_CC -v
+          $SELECTED_CXX -v
+          ccache --version
+          mkdir -p "$CCACHE_DIR" "$BOOST_DIR"
+          ccache -p | grep -E "max_size|cache_dir"
+          ccache --zero-stats
+
+      - name: cmake (branch-aware; Azure parity per branch)
+        run: |
+          set -eux
+          mkdir bin && cd bin
+          COMPILE_OPT=()
+          if [ "$BRANCH" = "8.0" ]; then
+            # 8.0: Boost cache + WITH_KEYRING_VAULT(_TEST) + WITH_READLINE=system
+            VARIANT_OPT="
+              -DDOWNLOAD_BOOST=1
+              -DWITH_BOOST=$BOOST_DIR
+              -DWITH_KEYRING_VAULT=ON
+              -DWITH_KEYRING_VAULT_TEST=ON
+              -DWITH_READLINE=system
+            "
+          else
+            # trunk / 8.4: system Boost, WITH_COMPONENT_KEYRING_VAULT, WITH_EDITLINE=system, WITH_CURL=bundled
+            VARIANT_OPT="
+              -DWITH_COMPONENT_KEYRING_VAULT=ON
+              -DWITH_EDITLINE=system
+              -DWITH_CURL=bundled
+            "
+          fi
+          CMAKE_OPT="
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+            -DBUILD_CONFIG=mysql_release
+            -DWITH_PACKAGE_FLAGS=OFF
+            -DCMAKE_C_COMPILER=$SELECTED_CC
+            -DCMAKE_CXX_COMPILER=$SELECTED_CXX
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DWITH_ROCKSDB=ON
+            -DWITH_COREDUMPER=ON
+            -DWITH_PAM=ON
+            -DMYSQL_MAINTAINER_MODE=ON
+            -DWITH_MECAB=system
+            -DWITH_NUMA=ON
+            -DWITH_SYSTEM_LIBS=ON
+            $VARIANT_OPT
+          "
+          cmake .. $CMAKE_OPT "${COMPILE_OPT[@]}"
+          [ "$BRANCH" = "8.0" ] && rm -f "$BOOST_DIR/$BOOST_VERSION.tar.gz" || true
+          cmake -L .
+
+      - name: Compile (make -j, capped at 16)
+        run: |
+          set -eux
+          cd bin
+          NPROC=$(nproc --all)
+          NTHREADS=$(( NPROC > 16 ? 16 : NPROC ))
+          echo "Using $NTHREADS/$NPROC threads"
+          make -j${NTHREADS}
+          ccache --show-stats
+          df -h /
+
+      - name: MTR binlog_nogtid (Cirrus RelWithDebInfo parity)
+        run: |
+          set -eux
+          cd bin
+          NPROC=$(nproc --all)
+          NTHREADS=$(( NPROC > 16 ? 16 : NPROC ))
+          LIBEATMYDATA=$(whereis libeatmydata.so | awk '{print $2}')
+          mysql-test/mysql-test-run.pl \
+            --suite=binlog_nogtid \
+            --parallel=$NTHREADS \
+            --junit-output=/tmp/MTR_results.xml \
+            --mysqld-env=LD_PRELOAD=${LIBEATMYDATA} \
+            --force --max-test-fail=0 --retry-failure=0
+
+      - name: Upload MTR results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.0
+        with:
+          name: mtr-binlog_nogtid-${{ env.BRANCH }}
+          path: /tmp/MTR_results.xml
+          if-no-files-found: ignore
+
+  delete-runner:
+    needs: [pickbranch, pick-target, create-runner, do-the-job]
+    if: always() && needs.create-runner.outputs.server_id != ''
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: olexandr-havryliak/hcloud-github-runner@bb1089d8b718a06493cb37c51dfe596e44baefc2
+        with:
+          mode: delete
+          name: ${{ env.RUNNER_NAME }}
+          server_id: ${{ needs.create-runner.outputs.server_id }}
+          hcloud_token: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          github_token: ${{ secrets.GHA_RUNNER_PAT }}


### PR DESCRIPTION
**Feature**
- Replaces the Cirrus `(arm64) gcc RelWithDebInfo [Noble]` nightly task on 8.0, trunk, and 8.4 before Cirrus shuts down 2026-06-01.

**Why**
- Second of two arm64 Cirrus tasks (per-PR Debug already ported in [PR 5961](https://github.com/percona/percona-server/pull/5961)).
- Centralised on 8.0 because GHA `schedule:` triggers only fire from the default branch. Three cron entries dispatch to `ref=8.0`, `trunk`, `8.4` via a `pickbranch` job; build-step gates Boost cache, `KEYRING_VAULT` vs `COMPONENT_KEYRING_VAULT`, `READLINE` vs `EDITLINE`, `WITH_CURL` per target.
- MTR suite is `binlog_nogtid` per Przemek 2026-05-18.

**Tickets**
- [PS-11078](https://perconadev.atlassian.net/browse/PS-11078) (this slice)
- Companion: [PR 5961](https://github.com/percona/percona-server/pull/5961) (8.0 per-PR Debug, merged)

[PS-11078]: https://perconadev.atlassian.net/browse/PS-11078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ