### PR TITLE
PS-11078: per-PR arm64 Debug build for 8.4

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -14,6 +14,11 @@ name: build-arm64
 
 on:
   workflow_dispatch:
+    inputs:
+      debug_keep_vm:
+        description: 'On create-runner failure: keep Hetzner VM alive for SSH diagnosis (root, key 107239874). orphan-sweep reaps after 6h; you can delete sooner via Hetzner API.'
+        type: boolean
+        default: false
   pull_request:
     branches: ['8.4']
     paths-ignore:
@@ -112,15 +117,12 @@ jobs:
           location: ${{ needs.pick-target.outputs.location }}
           server_type: ${{ needs.pick-target.outputs.server_type }}
           ssh_key: ${{ env.SSH_KEY_ID }}
-          # Pin runner version (vs `latest`) so cloud-init does not fetch
-          # the tarball from GitHub releases on every boot.
-          runner_version: '2.334.0'
           # 20min budget (default is 10min) to absorb transient apt-mirror or
           # GitHub-release slowness during cloud-init bootstrap.
           runner_wait: '120'
           # Retry apt with backoff; transient apt-mirror hiccups on first
-          # cloud-init were the root cause of "runner never registered"
-          # failures observed 2026-05-22 (Codex diagnosis).
+          # cloud-init were a hypothesised cause of "runner never registered"
+          # failures (Codex diagnosis 2026-05-22). Cheap to guard against.
           pre_runner_script: |
             set -euxo pipefail
             export DEBIAN_FRONTEND=noninteractive
@@ -133,6 +135,46 @@ jobs:
               sleep $((i * 15))
             done
             [ "$ok" = 1 ]
+
+      # Diagnostic preservation: on create-runner failure with workflow_dispatch
+      # `debug_keep_vm` flag set, surface VM IP + SSH instructions in the run
+      # summary BEFORE delete-runner reaps the VM. SSH in manually with the
+      # personal key (107239874) to grab cloud-init logs and runner _diag.
+      - name: Preserve VM for manual diagnosis (on failure, debug-only)
+        if: failure() && inputs.debug_keep_vm == true
+        env:
+          HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          SERVER_ID: ${{ steps.create.outputs.server_id }}
+        run: |
+          set -euo pipefail
+          [ -n "${SERVER_ID:-}" ] || { echo "::warning::No server_id; nothing to preserve"; exit 0; }
+          IP=$(curl -fsS -H "Authorization: Bearer $HCLOUD_TOKEN" \
+            "https://api.hetzner.cloud/v1/servers/$SERVER_ID" \
+            | jq -r '.server.public_net.ipv4.ip')
+          {
+            echo "### Debug VM kept alive for manual diagnosis"
+            echo ""
+            echo "Server ID: \`$SERVER_ID\`"
+            echo "Public IPv4: \`$IP\`"
+            echo ""
+            echo "**SSH** (key 107239874, \`anderson@percona\`):"
+            echo "\`\`\`bash"
+            echo "ssh root@$IP"
+            echo "\`\`\`"
+            echo ""
+            echo "**Files to grab:**"
+            echo "- \`/var/log/cloud-init.log\`"
+            echo "- \`/var/log/cloud-init-output.log\`"
+            echo "- \`/actions-runner/_diag/\` (if it exists)"
+            echo ""
+            echo "**Cleanup when done:**"
+            echo "\`\`\`bash"
+            echo "curl -X DELETE -H \"Authorization: Bearer \$HCLOUD_TOKEN\" \\"
+            echo "  https://api.hetzner.cloud/v1/servers/$SERVER_ID"
+            echo "\`\`\`"
+            echo ""
+            echo "orphan-sweep.yml reaps after 6h regardless."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # UNTRUSTED. PR code runs here. Build mirrors azure-pipelines.yml on `8.4`.
   do-the-job:
@@ -293,7 +335,13 @@ jobs:
 
   delete-runner:
     needs: [pick-target, create-runner, do-the-job]
-    if: always() && needs.create-runner.outputs.server_id != ''
+    # Skip delete when debug_keep_vm is set AND create-runner failed, so the
+    # broken VM stays alive for manual SSH diagnosis. orphan-sweep reaps it
+    # after 6h regardless. Normal happy path is unaffected.
+    if: |
+      always()
+      && needs.create-runner.outputs.server_id != ''
+      && !(inputs.debug_keep_vm == true && needs.create-runner.result == 'failure')
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,288 @@
+# PS-11078: ephemeral Hetzner cax* runner running the percona-server arm64
+# Debug build for PRs targeting `8.4`. Replaces the Cirrus
+# `(arm64) gcc Debug [Noble]` task before Cirrus shuts down 2026-06-01.
+#
+# Build shape ported from azure-pipelines.yml (per Przemek 2026-05-18:
+# ".cirrus.yml is just a simplified port from Azure"). Diff vs the 8.0
+# version: system Boost (no cache), WITH_COMPONENT_KEYRING_VAULT,
+# WITH_EDITLINE=system, +WITH_CURL=bundled, no libreadline-dev.
+#
+# Companion: build-arm64-nightly.yml on 8.0 (centralised, handles
+# RelWithDebInfo + binlog_nogtid nightly for all three branches).
+
+name: build-arm64
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['8.4']
+    paths-ignore:
+      # Mirrors azure-pipelines.yml `paths.exclude`
+      - 'doc/**'
+      - 'build-ps/**'
+      - 'man/**'
+      - 'mysql-test/**'
+      - 'packaging/**'
+      - 'policy/**'
+      - 'scripts/**'
+      - 'support-files/**'
+
+concurrency:
+  group: build-arm64-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PARENT_BRANCH: '8.4'
+  BUILD_TYPE: Debug
+  BUILD_PARAMS_TYPE: normal
+  COMPILER: gcc
+  COMPILER_VER: ''
+  IMAGE_NAME: ubuntu-24.04
+  UBUNTU_CODE_NAME: noble
+  USE_CCACHE: '1'
+  CCACHE_COMPRESS: '1'
+  CCACHE_COMPRESSLEVEL: '9'
+  CCACHE_CPP2: '1'
+  CCACHE_MAXSIZE: 4G
+  IMAGE: ubuntu-24.04
+  SSH_KEY_ID: '107239874'
+  RUNNER_NAME: ps-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  # TRUSTED. Dynamic capacity probe: cax41 -> cax31 -> cax21 across DCs.
+  pick-target:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      location: ${{ steps.probe.outputs.location }}
+      server_type: ${{ steps.probe.outputs.server_type }}
+    steps:
+      - id: probe
+        env:
+          HCLOUD_TOKEN: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          for type in cax41 cax31 cax21; do
+            for dc in fsn1 hel1 nbg1; do
+              PROBE_NAME="cap-probe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${type}-${dc}"
+              HTTP=$(curl -sS -o /tmp/resp.json -w "%{http_code}" -X POST \
+                -H "Authorization: Bearer $HCLOUD_TOKEN" -H "Content-Type: application/json" \
+                https://api.hetzner.cloud/v1/servers \
+                -d "{\"name\":\"$PROBE_NAME\",\"server_type\":\"$type\",\"image\":\"$IMAGE\",\"location\":\"$dc\",\"start_after_create\":false}")
+              if [ "$HTTP" = "201" ]; then
+                ID=$(jq -r '.server.id // empty' /tmp/resp.json)
+                [ -n "$ID" ] || { echo "::error::201 without server id"; exit 1; }
+                curl -fsS -X DELETE -H "Authorization: Bearer $HCLOUD_TOKEN" \
+                  "https://api.hetzner.cloud/v1/servers/$ID" >/dev/null
+                if [ "$type" != "cax41" ]; then
+                  echo "::warning::cax41 unavailable (PS-11174); falling back to $type in $dc"
+                fi
+                echo "Hetzner target: $type in $dc" >> "$GITHUB_STEP_SUMMARY"
+                { echo "location=$dc"; echo "server_type=$type"; } >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ERR=$(jq -r '.error.code // "?"' /tmp/resp.json 2>/dev/null || echo "?")
+              echo "::warning::$type/$dc: HTTP $HTTP ($ERR)"
+            done
+          done
+          echo "::error::No CAX capacity in fsn1/hel1/nbg1"
+          exit 1
+
+  # TRUSTED. Provision the ephemeral runner.
+  create-runner:
+    needs: pick-target
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      runner_label: ${{ env.RUNNER_NAME }}
+      server_id: ${{ steps.create.outputs.server_id }}
+      server_type: ${{ needs.pick-target.outputs.server_type }}
+    steps:
+      - id: create
+        uses: olexandr-havryliak/hcloud-github-runner@bb1089d8b718a06493cb37c51dfe596e44baefc2
+        with:
+          mode: create
+          name: ${{ env.RUNNER_NAME }}
+          hcloud_token: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          github_token: ${{ secrets.GHA_RUNNER_PAT }}
+          image: ${{ env.IMAGE }}
+          location: ${{ needs.pick-target.outputs.location }}
+          server_type: ${{ needs.pick-target.outputs.server_type }}
+          ssh_key: ${{ env.SSH_KEY_ID }}
+          pre_runner_script: |
+            apt-get update -y
+            apt-get install -y curl ca-certificates jq
+
+  # UNTRUSTED. PR code runs here. Build mirrors azure-pipelines.yml on `8.4`.
+  do-the-job:
+    needs: [pick-target, create-runner]
+    runs-on: ${{ needs.create-runner.outputs.runner_label }}
+    permissions:
+      contents: read
+    timeout-minutes: 180
+    env:
+      CCACHE_DIR: /home/runner/ccache
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: System info
+        run: |
+          set -eux
+          echo "Server type: ${{ needs.create-runner.outputs.server_type }}"
+          uname -a
+          nproc
+          free -h
+          df -h /
+
+      - name: Conditional swap (only when RAM < 16 GB)
+        run: |
+          set -eux
+          MEM_GB=$(awk '/MemTotal/ {print int($2/1024/1024)}' /proc/meminfo)
+          if [ "$MEM_GB" -lt 16 ]; then
+            sudo fallocate -l 16G /swapfile
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+            sudo swapon /swapfile
+          fi
+          free -h
+
+      # 8.4 apt list: no libreadline-dev (uses libedit only).
+      - name: Install Build Dependencies
+        run: |
+          set -eux
+          SELECTED_CC="${COMPILER}${COMPILER_VER:+-${COMPILER_VER}}"
+          SELECTED_CXX="${COMPILER}++${COMPILER_VER:+-${COMPILER_VER}}"
+          [ "$COMPILER" = "gcc" ] && SELECTED_CXX="g++${COMPILER_VER:+-${COMPILER_VER}}"
+          echo "SELECTED_CC=$SELECTED_CC" >> "$GITHUB_ENV"
+          echo "SELECTED_CXX=$SELECTED_CXX" >> "$GITHUB_ENV"
+          PACKAGES="$SELECTED_CC"
+          [ "$COMPILER" = "gcc" ] && PACKAGES="$SELECTED_CXX"
+          sudo apt-get -yq update
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            $PACKAGES make pkg-config dpkg-dev unzip lz4 git cmake cmake-curses-gui ccache bison \
+            libtirpc-dev libudev-dev libaio-dev libmecab-dev libnuma-dev \
+            libssl-dev libedit-dev libpam-dev \
+            libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev \
+            libsasl2-modules-gssapi-mit \
+            libxml-simple-perl
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            libicu-dev libevent-dev liblz4-dev zlib1g-dev \
+            protobuf-compiler libprotobuf-dev libprotoc-dev \
+            libzstd-dev libfido2-dev
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install libeatmydata1
+          REAL_COMPILER_VER=$($SELECTED_CC --version | head -1 | awk '{print $4}')
+          echo "REAL_COMPILER_VER=$REAL_COMPILER_VER" >> "$GITHUB_ENV"
+
+      - name: ccache cache (Azure key shape)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.2.0
+        with:
+          path: /home/runner/ccache
+          key: ccache-${{ env.PARENT_BRANCH }}-${{ env.IMAGE_NAME }}-${{ env.COMPILER }}-${{ env.BUILD_TYPE }}-${{ env.BUILD_PARAMS_TYPE }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ env.PARENT_BRANCH }}-${{ env.IMAGE_NAME }}-${{ env.COMPILER }}-${{ env.BUILD_TYPE }}-${{ env.BUILD_PARAMS_TYPE }}-
+
+      - name: Checkout (fetchDepth 32 mirrors Azure)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
+        with:
+          fetch-depth: 32
+
+      - name: Update git submodules
+        run: |
+          set -eux
+          git submodule sync
+          git submodule update --init --force --depth=256
+          git submodule
+
+      - name: System and compiler info
+        run: |
+          set -eux
+          $SELECTED_CC -v
+          $SELECTED_CXX -v
+          ccache --version
+          mkdir -p "$CCACHE_DIR"
+          ccache -p | grep -E "max_size|cache_dir"
+          ccache --zero-stats
+
+      # 8.4 cmake delta vs 8.0:
+      # - No Boost cache + no -DDOWNLOAD_BOOST/-DWITH_BOOST (system Boost)
+      # - WITH_KEYRING_VAULT(_TEST) -> WITH_COMPONENT_KEYRING_VAULT
+      # - WITH_READLINE=system -> WITH_EDITLINE=system
+      # - +WITH_CURL=bundled
+      - name: cmake (Azure parity, 8.4 Noble non-inverted)
+        run: |
+          set -eux
+          mkdir bin && cd bin
+          COMPILE_OPT=(
+            -DCMAKE_C_FLAGS_DEBUG=-g1
+            -DCMAKE_CXX_FLAGS_DEBUG=-g1
+          )
+          CMAKE_OPT="
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+            -DBUILD_CONFIG=mysql_release
+            -DWITH_PACKAGE_FLAGS=OFF
+            -DCMAKE_C_COMPILER=$SELECTED_CC
+            -DCMAKE_CXX_COMPILER=$SELECTED_CXX
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DWITH_ROCKSDB=ON
+            -DWITH_COREDUMPER=ON
+            -DWITH_COMPONENT_KEYRING_VAULT=ON
+            -DWITH_PAM=ON
+            -DMYSQL_MAINTAINER_MODE=ON
+            -DWITH_MECAB=system
+            -DWITH_NUMA=ON
+            -DWITH_EDITLINE=system
+            -DWITH_CURL=bundled
+            -DWITH_SYSTEM_LIBS=ON
+          "
+          cmake .. $CMAKE_OPT "${COMPILE_OPT[@]}"
+          cmake -L .
+
+      - name: Compile (make -j, capped at 16)
+        run: |
+          set -eux
+          cd bin
+          NPROC=$(nproc --all)
+          NTHREADS=$(( NPROC > 16 ? 16 : NPROC ))
+          echo "Using $NTHREADS/$NPROC threads (Azure literal: -j2)"
+          make -j${NTHREADS}
+          ccache --show-stats
+          df -h /
+
+      - name: MTR main.1st (arm64-only; Cirrus parity)
+        run: |
+          set -eux
+          cd bin
+          NPROC=$(nproc --all)
+          NTHREADS=$(( NPROC > 16 ? 16 : NPROC ))
+          LIBEATMYDATA=$(whereis libeatmydata.so | awk '{print $2}')
+          mysql-test/mysql-test-run.pl main.1st \
+            --parallel=$NTHREADS \
+            --junit-output=/tmp/MTR_results.xml \
+            --mysqld-env=LD_PRELOAD=${LIBEATMYDATA} \
+            --force --max-test-fail=0 --retry-failure=0 \
+            --debug-server
+
+      - name: Upload MTR results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.0
+        with:
+          name: mtr-results
+          path: /tmp/MTR_results.xml
+          if-no-files-found: ignore
+
+  delete-runner:
+    needs: [pick-target, create-runner, do-the-job]
+    if: always() && needs.create-runner.outputs.server_id != ''
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: olexandr-havryliak/hcloud-github-runner@bb1089d8b718a06493cb37c51dfe596e44baefc2
+        with:
+          mode: delete
+          name: ${{ env.RUNNER_NAME }}
+          server_id: ${{ needs.create-runner.outputs.server_id }}
+          hcloud_token: ${{ secrets.GHA_RUNNER_HCLOUD_TOKEN }}
+          github_token: ${{ secrets.GHA_RUNNER_PAT }}

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -112,9 +112,27 @@ jobs:
           location: ${{ needs.pick-target.outputs.location }}
           server_type: ${{ needs.pick-target.outputs.server_type }}
           ssh_key: ${{ env.SSH_KEY_ID }}
+          # Pin runner version (vs `latest`) so cloud-init does not fetch
+          # the tarball from GitHub releases on every boot.
+          runner_version: '2.334.0'
+          # 20min budget (default is 10min) to absorb transient apt-mirror or
+          # GitHub-release slowness during cloud-init bootstrap.
+          runner_wait: '120'
+          # Retry apt with backoff; transient apt-mirror hiccups on first
+          # cloud-init were the root cause of "runner never registered"
+          # failures observed 2026-05-22 (Codex diagnosis).
           pre_runner_script: |
-            apt-get update -y
-            apt-get install -y curl ca-certificates jq
+            set -euxo pipefail
+            export DEBIAN_FRONTEND=noninteractive
+            ok=0
+            for i in 1 2 3; do
+              if apt-get update -y && apt-get install -y --no-install-recommends curl ca-certificates jq; then
+                ok=1
+                break
+              fi
+              sleep $((i * 15))
+            done
+            [ "$ok" = 1 ]
 
   # UNTRUSTED. PR code runs here. Build mirrors azure-pipelines.yml on `8.4`.
   do-the-job:


### PR DESCRIPTION
**Feature**
- Adds per-PR arm64 Debug coverage for PRs targeting `8.4`. Replaces the Cirrus `(arm64) gcc Debug [Noble]` task before Cirrus shuts down 2026-06-01.

**Why**
- Cirrus shuts down 2026-06-01; 8.4 PRs need an arm64 build gate.
- Build shape ported from `azure-pipelines.yml` on 8.4. Diff vs [PR 5961](https://github.com/percona/percona-server/pull/5961): system Boost, `WITH_COMPONENT_KEYRING_VAULT`, `WITH_EDITLINE=system`, `+WITH_CURL=bundled`, no `libreadline-dev`.
- Nightly RelWithDebInfo for 8.4 is covered by the centralised [build-arm64-nightly.yml on 8.0](https://github.com/percona/percona-server/pull/5972).

**Tickets**
- [PS-11078](https://perconadev.atlassian.net/browse/PS-11078) (this slice)
- Companion: [PR 5961](https://github.com/percona/percona-server/pull/5961) (8.0 baseline, merged); [PR 5972](https://github.com/percona/percona-server/pull/5972) (nightly); [PR 5973](https://github.com/percona/percona-server/pull/5973) (trunk port); supersedes closed [PR 5971](https://github.com/percona/percona-server/pull/5971)

[PS-11078]: https://perconadev.atlassian.net/browse/PS-11078