### PR TITLE
PS-10963 [8.0]: Fix sporadic group_replication.gr_acf_receiver_group …

### DIFF
--- a/mysql-test/suite/group_replication/r/gr_acf_receiver_group.result
+++ b/mysql-test/suite/group_replication/r/gr_acf_receiver_group.result
@@ -7,6 +7,11 @@ Note	####	Storing MySQL user name or password information in the connection meta
 ############################################################
 # 1. Deploy a 1 member group A in single-primary mode.
 [connection server1]
+SET SESSION sql_log_bin = 0;
+call mtr.add_suppression("Run function 'before_commit' in plugin 'group_replication' failed");
+call mtr.add_suppression("Replica SQL for channel 'ch1': Worker 1 failed executing transaction.*");
+call mtr.add_suppression("Replica SQL for channel 'ch1': ... The replica coordinator and worker threads are stopped.*");
+SET SESSION sql_log_bin = 1;
 include/start_and_bootstrap_group_replication.inc
 
 ############################################################

--- a/mysql-test/suite/group_replication/t/gr_acf_receiver_group.test
+++ b/mysql-test/suite/group_replication/t/gr_acf_receiver_group.test
@@ -25,6 +25,16 @@
 --echo # 1. Deploy a 1 member group A in single-primary mode.
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
+
+# Ensure that post test log check doesn't fail in cases when we attempt
+# to stopSQL thread on server 2 (by marking it killed) right before applying
+# the very first event (which is view change event).
+SET SESSION sql_log_bin = 0;
+call mtr.add_suppression("Run function 'before_commit' in plugin 'group_replication' failed");
+call mtr.add_suppression("Replica SQL for channel 'ch1': Worker 1 failed executing transaction.*");
+call mtr.add_suppression("Replica SQL for channel 'ch1': ... The replica coordinator and worker threads are stopped.*");
+SET SESSION sql_log_bin = 1;
+
 --let $server1_uuid= `SELECT @@server_uuid`
 --let $group_replication_group_name= aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
 --let $group_a= $group_replication_group_name


### PR DESCRIPTION
…test failures in Jenkins.

Test failed sporadically due failing post-test check for extra errors in error log. It turns out that these error messages are legitimate for the rare case when this test manages to stop replication applier on the replica server before processing the very first event.

This fix adds suppressions for these error log messages similarly to how it is done in other tests affected by this issue.