### PR TITLE
PS-10963 [8.0]: Fix memory leak in fil_ibd_same_as_default_path() det…

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -9999,6 +9999,8 @@ static bool fil_ibd_same_as_default_path(const char *space_name,
   /* Build the implicit default path for this table name under @@datadir. */
   char *default_path = Fil_path::make("", space_name, IBD);
 
+  auto guard = create_scope_guard([&]() { ut::free(default_path); });
+
   if (default_path == nullptr || default_path[0] == '\0') {
     return false;
   }
@@ -10022,7 +10024,6 @@ static bool fil_ibd_same_as_default_path(const char *space_name,
 
   df_found.close();
   df_default.close();
-  ut::free(default_path);
 
   return same;
 }


### PR DESCRIPTION
…ected by ASAN.

ASAN reported memory leak in fil_ibd_same_as_default_path() in several tests. This unsophisticated memory leak was introduced in MySQL 8.0.46 by fix for "Bug#38169053: MySQL 8.0.39/40 crashed due to Assertion failure error when running TRUNCATE"
(https://github.com/mysql/mysql-server/commit/b63930df6330cfbf81ea9d8e4c9eace3e16c3703). The problem was that default_path string was allocated but not properly freed on all return paths from this function.

Ensure that default_path string is freed in all cases by using RAII helper.