### PR TITLE
PS-10963 [8.0]: Fix rockdb.rdb_index_merge_buf_size_overflow test fai…

### DIFF
--- a/mysql-test/suite/rocksdb/t/rdb_index_merge_buf_size_overflow.test
+++ b/mysql-test/suite/rocksdb/t/rdb_index_merge_buf_size_overflow.test
@@ -1,5 +1,7 @@
 --source include/have_rocksdb.inc
 --source include/have_debug.inc
+# ASAN complains when we intentionally try to allocate too much memory.
+--source include/not_asan.inc
 
 --echo #
 --echo # Heap buffer overflow when rocksdb_merge_buf_size > 4GB:


### PR DESCRIPTION
…lure under ASAN.

This test intentionally tries to allocate too big memory block which makes ASAN unhappy. Skip this test under ASAN.