### PR TITLE
PS-10963 [8.0]: Fix main.parser test failure under ASAN.

### DIFF
--- a/mysql-test/t/parser.test
+++ b/mysql-test/t/parser.test
@@ -2,6 +2,11 @@
 # This file contains tests covering the parser
 #
 
+# ER_STACK_OVERRUN_NEED_MORE does not currently work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
+--source include/not_tsan.inc
+
 #=============================================================================
 # LEXICAL PARSER (lex)
 #=============================================================================


### PR DESCRIPTION
Test for bug#38928287 "CRASH INSIDE OF THE QUERY PARSER/PLANNER/RESOLVER" added in MySQL 8.0.46 causes stack overflow errors under ASAN.

This is common issue for tests which check that we correctly detect and error out on potential stack overflows.

Disabled the test for ASAN builds like it is done for other tests doing this (e.g. main.sp-error test).