### PR TITLE
PS-11243 [9.7]: Fix tablespace encryption recovery crashes

### DIFF
--- a/mysql-test/suite/component_keyring_file/r/tablespace_encrypt_recover_gtid.result
+++ b/mysql-test/suite/component_keyring_file/r/tablespace_encrypt_recover_gtid.result
@@ -1,0 +1,49 @@
+# ----------------------------------------------------------------------
+# Setup
+# Creating local configuration file for keyring component: component_keyring_file
+# Creating manifest file for current MySQL server instance
+# Re-starting mysql server with manifest file
+# ----------------------------------------------------------------------
+#########################################################################
+# Start from a known, unencrypted mysql tablespace.
+#########################################################################
+SET debug='+d,skip_dd_table_access_check';
+SELECT @@GLOBAL.gtid_mode;
+@@GLOBAL.gtid_mode
+ON
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='mysql';
+NAME	ENCRYPTION
+mysql	N
+# Snapshot the GTID set right before the crashing DDL. The crashing
+# ALTER does not commit, so recovery is the only thing that could add a
+# GTID afterwards.
+#########################################################################
+# Crash in the middle of ALTER TABLESPACE mysql ENCRYPTION='Y'
+#########################################################################
+SET SESSION debug='+d,alter_encrypt_tablespace_page_10';
+ALTER TABLESPACE mysql ENCRYPTION='Y';
+#########################################################################
+# Restart: InnoDB recovery resumes the encryption in a background thread
+#########################################################################
+SET debug='+d,skip_dd_table_access_check';
+# Wait for the background encryption resume to roll forward.
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='mysql';
+NAME	ENCRYPTION
+mysql	Y
+# The recovery replay must NOT have emitted a binlog event or allocated
+# a GTID for the resumed ALTER TABLESPACE.
+# OK: crash-recovery encryption replay did not change gtid_executed.
+###########
+# Cleanup #
+###########
+ALTER TABLESPACE mysql ENCRYPTION='N';
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='mysql';
+NAME	ENCRYPTION
+mysql	N
+# ----------------------------------------------------------------------
+# Teardown
+# Removing manifest file for current MySQL server instance
+# Removing local keyring file for keyring component: component_keyring_file
+# Removing local configuration file for keyring component: component_keyring_file
+# Restarting server without the manifest file
+# ----------------------------------------------------------------------

--- a/mysql-test/suite/component_keyring_file/t/tablespace_encrypt_recover_gtid-master.opt
+++ b/mysql-test/suite/component_keyring_file/t/tablespace_encrypt_recover_gtid-master.opt
@@ -1,0 +1,3 @@
+--log-bin=master-bin
+--gtid-mode=ON
+--enforce-gtid-consistency=ON

--- a/mysql-test/suite/component_keyring_file/t/tablespace_encrypt_recover_gtid.test
+++ b/mysql-test/suite/component_keyring_file/t/tablespace_encrypt_recover_gtid.test
@@ -1,0 +1,95 @@
+--source include/have_component_keyring_file.inc
+################################################################################
+# Regression test for
+#   PS-10979: Fix tablespace encryption recovery crashes
+#
+# InnoDB crash recovery can resume an unfinished ALTER TABLESPACE encryption
+# operation by executing ALTER TABLESPACE through an internal startup
+# background THD. Before the fix that replay went through the normal SQL DDL
+# path with session binlogging enabled, so it emitted a second binlog event and
+# allocated a fresh GTID for the original user DDL. Under slow keyring access
+# (e.g. component_keyring_vault) this replay was slow enough to overlap with
+# GTID/binlog startup and the mysql tablespace metadata access, tripping debug
+# assertions in executed_gtids.contains_gtid(), Mutex_cond_array and
+# THD::Attachable_trx::~Attachable_trx().
+#
+# The fix treats the recovery replay as local startup repair: it disables
+# session binlogging for the internal dd::alter_tablespace_encryption() replay
+# and skips the explicit ALTER TABLESPACE DDL binlog write for startup
+# background encryption replays. As a deterministic, keyring-backend
+# independent guard we assert here that crash recovery of an unfinished
+# ALTER TABLESPACE mysql ENCRYPTION does NOT change @@GLOBAL.gtid_executed.
+################################################################################
+
+--source include/big_test.inc
+--source include/have_debug.inc
+--source include/have_log_bin.inc
+# Disable in valgrind because of timeout, cf. Bug#22760145
+--source include/not_valgrind.inc
+
+--source ../inc/setup_component.inc
+
+--disable_query_log
+call mtr.add_suppression("Error generating data for Data ID:");
+call mtr.add_suppression("Encryption key missing:");
+call mtr.add_suppression("Decrypting a page in doublewrite file failed:");
+--enable_query_log
+
+# Waiting time when (re)starting the server
+--let $explicit_default_wait_counter=10000
+
+--echo #########################################################################
+--echo # Start from a known, unencrypted mysql tablespace.
+--echo #########################################################################
+let $restart_parameters = restart: $PLUGIN_DIR_OPT;
+--source include/restart_mysqld_no_echo.inc
+SET debug='+d,skip_dd_table_access_check';
+
+SELECT @@GLOBAL.gtid_mode;
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='mysql';
+
+--echo # Snapshot the GTID set right before the crashing DDL. The crashing
+--echo # ALTER does not commit, so recovery is the only thing that could add a
+--echo # GTID afterwards.
+--let $gtid_before = `SELECT @@GLOBAL.gtid_executed`
+
+--echo #########################################################################
+--echo # Crash in the middle of ALTER TABLESPACE mysql ENCRYPTION='Y'
+--echo #########################################################################
+SET SESSION debug='+d,alter_encrypt_tablespace_page_10';
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE mysql ENCRYPTION='Y';
+
+--echo #########################################################################
+--echo # Restart: InnoDB recovery resumes the encryption in a background thread
+--echo #########################################################################
+--source include/start_mysqld_no_echo.inc
+SET debug='+d,skip_dd_table_access_check';
+
+--echo # Wait for the background encryption resume to roll forward.
+let $wait_condition = SELECT ENCRYPTION='Y'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='mysql';
+--source include/wait_condition.inc
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='mysql';
+
+--echo # The recovery replay must NOT have emitted a binlog event or allocated
+--echo # a GTID for the resumed ALTER TABLESPACE.
+--let $gtid_after = `SELECT @@GLOBAL.gtid_executed`
+if ($gtid_before != $gtid_after)
+{
+  --echo # gtid_executed before recovery: $gtid_before
+  --echo # gtid_executed after  recovery: $gtid_after
+  --die PS-10979 regression: crash-recovery encryption replay changed gtid_executed
+}
+--echo # OK: crash-recovery encryption replay did not change gtid_executed.
+
+--echo ###########
+--echo # Cleanup #
+--echo ###########
+ALTER TABLESPACE mysql ENCRYPTION='N';
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='mysql';
+
+--source ../inc/teardown_component.inc

--- a/sql/dd/impl/dictionary_impl.cc
+++ b/sql/dd/impl/dictionary_impl.cc
@@ -73,7 +73,7 @@
 #include "sql/sql_class.h"  // THD
 #include "sql/sql_zip_dict.h"
 #include "sql/system_variables.h"
-#include "sql/thd_raii.h"                       // Disable_autocommit_guard
+#include "sql/thd_raii.h"  // Disable_autocommit_guard, Disable_binlog_guard
 #include "sql/transaction.h"                    // trans_commit()
 #include "storage/perfschema/pfs_dd_version.h"  // PFS_DD_VERSION
 
@@ -757,6 +757,13 @@ bool alter_tablespace_encryption(THD *thd, const char *tablespace_name,
                           tablespace_name + dd::String_type(" ENCRYPTION = ") +
                           dd::String_type(encryption ? "'Y'" : "'N'");
 
+  /*
+    This is used by InnoDB crash recovery to finish a local tablespace
+    encryption state transition. The original user DDL was already handled, so
+    replay runs with session binlogging disabled; the ALTER TABLESPACE executor
+    also skips its explicit DDL binlog write for startup background replays.
+  */
+  const Disable_binlog_guard binlog_guard(thd);
   bool res = execute_query(thd, query);
   error_handler.set_log_error(save_log_error);
   return res;

--- a/sql/sql_tablespace.cc
+++ b/sql/sql_tablespace.cc
@@ -1064,7 +1064,25 @@ bool Sql_cmd_alter_tablespace::execute(THD *thd) {
     return true;
   }
 
-  if (complete_stmt(thd, hton, [&]() { rollback_on_return.disable(); })) {
+  /*
+    This normal ALTER TABLESPACE execution path is also reached during InnoDB
+    crash recovery: fsp_init_resume_alter_encrypt_tablespace() resumes an
+    interrupted (un)encryption by calling dd::alter_tablespace_encryption(),
+    which builds an "ALTER TABLESPACE ... ENCRYPTION = ..." string and runs it
+    through execute_query() -> here, on the startup background THD created by
+    create_internal_thd() (system_thread == SYSTEM_THREAD_BACKGROUND).
+
+    That replay only repairs local DD/SE state for the original user DDL, which
+    was already binlogged when the user issued it; emitting a second binlog
+    event (and allocating a fresh GTID) here would be wrong. Detect the replay
+    and skip the explicit DDL binlog write below.
+  */
+  const bool recovery_replay = thd->system_thread == SYSTEM_THREAD_BACKGROUND &&
+                               m_options->encryption.str != nullptr;
+
+  if (complete_stmt(
+          thd, hton, [&]() { rollback_on_return.disable(); }, true,
+          recovery_replay)) {
     return true;
   }
 

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -52,6 +52,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include <sys/types.h>
 #include <zlib.h>
 
+#include <algorithm>
+
 #include "my_dbug.h"
 
 #include "btr0btr.h"
@@ -70,6 +72,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "ibuf0ibuf.h"
 #include "log0buf.h"
 #include "log0chkp.h"
+#include "log0ddl.h"
 #include "log0recv.h"
 #include "log0write.h"
 #include "mem0mem.h"
@@ -2378,6 +2381,12 @@ void srv_start_threads_after_ddl_recovery() {
 
   /* Resume unfinished (un)encryption process in background thread. */
   if (!ts_encrypt_ddl_records.empty()) {
+    const bool is_mysql_ibd_encryption = std::any_of(
+        ts_encrypt_ddl_records.begin(), ts_encrypt_ddl_records.end(),
+        [](const DDL_Record *ddl_record) {
+          return ddl_record->get_space_id() == dict_sys_t::s_dict_space_id;
+        });
+
     srv_threads.m_ts_alter_encrypt =
         os_thread_create(srv_ts_alter_encrypt_thread_key, 0,
                          fsp_init_resume_alter_encrypt_tablespace);
@@ -2388,6 +2397,31 @@ void srv_start_threads_after_ddl_recovery() {
     for which (un)encryption is to be rolled forward. */
     mysql_cond_wait(&resume_encryption_cond, &resume_encryption_cond_m);
     mysql_mutex_unlock(&resume_encryption_cond_m);
+
+    /*
+      The mysql tablespace (mysql.ibd) holds the DD and replication metadata
+      tables that the rest of startup opens through attachable transactions.
+
+      The resume thread finishes the interrupted (un)encryption by re-running
+      the DD metadata transition via dd::alter_tablespace_encryption(), which
+      builds an "ALTER TABLESPACE mysql ENCRYPTION = ..." string and runs it
+      through execute_query() -> Sql_cmd_alter_tablespace::execute(). That is a
+      real, committing transaction on mysql.ibd. If we let startup continue
+      while that commit is still in flight, the attachable transactions opening
+      DD/replication tables can observe the rollback/commit bookkeeping left by
+      the resume THD and hit the GTID/binlog asserts this fix targets.
+
+      So when mysql.ibd is among the spaces being rolled forward we block here
+      until the resume thread is done. This intentionally also waits for any
+      general tablespaces handled in the same batch, but that only happens in
+      the rare case that mysql.ibd itself was mid-(un)encryption at the crash;
+      the common case (only general tablespaces) keeps the existing background
+      behavior and their normal DML, including dict stats work, remains covered
+      by the usual tablespace encryption machinery.
+    */
+    if (is_mysql_ibd_encryption) {
+      srv_threads.m_ts_alter_encrypt.wait();
+    }
   }
 
   /* Start and consume all GTIDs for recovered transactions. */


### PR DESCRIPTION
The crashes were exposed by the component_keyring_vault MTR suite while running tablespace encryption crash-recovery scenarios:
    
- component_keyring_vault.mysql_ts_alter_encrypt_1
- component_keyring_vault.tablespace_encrypt_7
- component_keyring_vault.tablespace_encrypt_9
    
The observed debug assertions were in GTID/binlog bookkeeping and startup DD access paths, including executed_gtids.contains_gtid(), Mutex_cond_array::get_max_index(), and THD::Attachable_trx::~Attachable_trx() checking transaction_rollback_request.
    
InnoDB crash recovery can resume an unfinished ALTER TABLESPACE encryption operation by executing ALTER TABLESPACE through an internal startup background THD. With component_keyring_vault this replay is slow enough to overlap with GTID/binlog startup state and mysql tablespace metadata access.
    
Treat the recovery replay as local startup repair work rather than a new user-visible DDL. Disable session binlogging for the internal dd::alter_tablespace_encryption() replay, skip the explicit ALTER TABLESPACE DDL binlog write only for startup background encryption replays, and wait for mysql dictionary tablespace encryption recovery before startup continues to open DD and replication metadata tables.
    
This prevents recovery from emitting a second binlog event or allocating a fresh GTID while avoiding a broad change to normal ALTER TABLESPACE binlog behavior.