### PR TITLE
PS-11242 [9.7]: Fix InnoDB rw_trx_list ordering for preallocated trx ids

### DIFF
--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1089,7 +1089,27 @@ Requires trx_sys->mutex, unless called in the single threaded startup code.
 static inline void trx_add_to_rw_trx_list(trx_t *trx) {
   ut_ad(srv_is_being_started || trx_sys_mutex_own());
   ut_ad(!trx->in_rw_trx_list);
-  UT_LIST_ADD_FIRST(trx_sys->rw_trx_list, trx);
+  /* rw_trx_list is kept ordered by descending trx->id. For freshly
+  allocated ids that is guaranteed because the id is the greatest, so a
+  simple prepend keeps the order. A preallocated id (used by the
+  consistent snapshot clone-view feature), however, might not be received
+  in ascending order, so prepending it could break the ordering invariant
+  validated by trx_sys_validate_trx_list(). Mirror the rw_trx_ids handling
+  in trx_assign_id_for_rw() and insert it at its proper position. */
+  if (trx->preallocated_id != 0) {
+    trx_t *prev = nullptr;
+    for (auto cur : trx_sys->rw_trx_list) {
+      if (cur->id < trx->id) break;
+      prev = cur;
+    }
+    if (prev == nullptr) {
+      UT_LIST_ADD_FIRST(trx_sys->rw_trx_list, trx);
+    } else {
+      UT_LIST_INSERT_AFTER(trx_sys->rw_trx_list, prev, trx);
+    }
+  } else {
+    UT_LIST_ADD_FIRST(trx_sys->rw_trx_list, trx);
+  }
   ut_d(trx->in_rw_trx_list = true);
 }
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10979

percona.clone_consistent_snapshot crashed in a debug build with:

`  [InnoDB] Assertion failure: trx0sys.cc:821:  prev_trx == nullptr || prev_trx->id > trx->id`
```
   #5 trx_sys_validate_trx_list  trx0sys.cc:821
   #6 trx_erase_lists            trx0trx.cc:1838
   #8 trx_commit_in_memory       trx0trx.cc:2009
   ...
  #21 Clone_persist_gtid::write_to_table  clone0repl.cc:475
  #24 clone_gtid_thread                   clone0repl.cc:723
```

trx_sys->rw_trx_list is required to be ordered by descending trx->id, and trx_sys_validate_trx_list() (UNIV_DEBUG only) enforces it on every erase.

The consistent snapshot clone-view feature preallocates a transaction id for a donor read-only transaction (ReadView::clone() in read0read.cc). When that donor is later promoted to read-write via trx_set_rw_mode() -> trx_assign_id_for_rw(), it reuses the preallocated id, which - as the existing comment notes - "might not be received in ascending order" and can therefore be smaller than ids handed out to other transactions in the meantime.

trx_assign_id_for_rw() already accounts for this when maintaining the sorted rw_trx_ids vector (the std::upper_bound insert), but trx_add_to_rw_trx_list() always did UT_LIST_ADD_FIRST, which assumes the new id is the greatest. Prepending an out-of-order preallocated id breaks the descending-id ordering of rw_trx_list. The corruption goes unnoticed at insertion time because trx_set_rw_mode() (unlike trx_start_low()) has no post-insert validation, and is only caught later when an unrelated transaction - here the clone GTID persister thread - commits and runs the validation during trx_erase_lists().

Fix trx_add_to_rw_trx_list() to insert a transaction carrying a preallocated_id at the position that preserves descending-id order, mirroring the rw_trx_ids handling. The common case (a freshly allocated id, which is always the greatest) keeps the O(1) prepend, so there is no hot-path regression.