### PR TITLE
PS-11241 [9.7]: Log make_page_dirty updates as compressed page headers

### DIFF
--- a/storage/innobase/ut/ut0test.cc
+++ b/storage/innobase/ut/ut0test.cc
@@ -34,6 +34,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "dict0dd.h"
 #include "dict0dict.h"
 #include "fil0fil.h"
+#include "page0zip.h"
 #include "scope_guard.h"
 
 #define CALL_MEMBER_FN(object, ptrToMember) ((object).*(ptrToMember))
@@ -577,7 +578,13 @@ DISPATCH_FUNCTION_DEF(Tester::make_page_dirty) {
           << "Dirtying page: " << page_id
           << ", page_type=" << fil_get_page_type_str(page_type);
 
-      mlog_write_ulint(page + FIL_PAGE_TYPE, page_type, MLOG_2BYTES, &mtr);
+      auto page_zip = buf_block_get_page_zip(block);
+      if (page_zip != nullptr && fil_page_index_page_check(page)) {
+        mach_write_to_2(page + FIL_PAGE_TYPE, page_type);
+        page_zip_write_header(page_zip, page + FIL_PAGE_TYPE, 2, &mtr);
+      } else {
+        mlog_write_ulint(page + FIL_PAGE_TYPE, page_type, MLOG_2BYTES, &mtr);
+      }
     }
   }
 


### PR DESCRIPTION
The debug innodb_interpreter make_page_dirty command dirties a page by rewriting FIL_PAGE_TYPE with an MLOG_2BYTES record. When the target is a compressed index page, crash recovery later applies that generic MLOG_nBYTES record with both page and page_zip set, which violates the redo parser invariant checked in mlog_parse_nbytes().

Use page_zip_write_header() for compressed index pages so the helper logs the dummy header rewrite with MLOG_ZIP_WRITE_HEADER, matching normal compressed-page header updates. Keep the existing MLOG_2BYTES path for uncompressed and non-index pages.

Verified with: ./mysql-test-run.pl --suite=innodb dblwr_encrypt_rowcomp --debug-server --retry=0 --force --parallel=1