### PR TITLE
PS-11204 [8.4] Granting SET_USER_ID breaks replication from 8.0 to 8.4

### DIFF
--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -47,7 +47,7 @@ include/assert.inc [Expect 500+ variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 489 persisted variables in the table.]
+include/assert.inc [Expect 490 persisted variables in the table.]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -55,9 +55,9 @@ include/assert.inc [Expect 489 persisted variables in the table.]
 ************************************************************
 # restart
 
-include/assert.inc [Expect 489 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 489 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 489 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 490 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 490 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 490 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1269,6 +1269,12 @@ The following options may be given as the first argument:
  Number of times the replication applier will retry a
  transaction in case it failed with a deadlock or other
  transient error, before it gives up and stops.
+ --replica-translate-deprecated-priv 
+ Rewrite replicated SET_USER_ID to
+ SET_ANY_DEFINER,ALLOW_NONEXISTENT_DEFINER in the replica
+ SQL applier. Disabled by default, does not affect
+ user-issued GRANT/REVOKE, and can be changed only while
+ the replica SQL thread is stopped.
  --replica-type-conversions=name 
  Set of type conversions that may be used by the
  replication applier thread for row events. Allowed values
@@ -2082,6 +2088,7 @@ replica-preserve-commit-order TRUE
 replica-skip-errors (No default value)
 replica-sql-verify-checksum TRUE
 replica-transaction-retries 10
+replica-translate-deprecated-priv FALSE
 replica-type-conversions 
 replicate-same-server-id FALSE
 replication-optimize-for-static-plugin-config FALSE

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -46,7 +46,7 @@ INSERT INTO aliases(name) VALUES
 ('slave_parallel_workers'), ('slave_pending_jobs_size_max'),
 ('pseudo_slave_mode'), ('skip_slave_start');
 
-include/assert.inc [Expect 113 variables in the table.]
+include/assert.inc [Expect 114 variables in the table.]
 
 # Test SET PERSIST_ONLY
 SET PERSIST_ONLY binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -164,6 +164,7 @@ SET PERSIST_ONLY replica_preserve_commit_order = @@GLOBAL.replica_preserve_commi
 SET PERSIST_ONLY replica_skip_errors = @@GLOBAL.replica_skip_errors;
 SET PERSIST_ONLY replica_sql_verify_checksum = @@GLOBAL.replica_sql_verify_checksum;
 SET PERSIST_ONLY replica_transaction_retries = @@GLOBAL.replica_transaction_retries;
+SET PERSIST_ONLY replica_translate_deprecated_priv = @@GLOBAL.replica_translate_deprecated_priv;
 SET PERSIST_ONLY replica_type_conversions = @@GLOBAL.replica_type_conversions;
 SET PERSIST_ONLY replication_optimize_for_static_plugin_config = @@GLOBAL.replication_optimize_for_static_plugin_config;
 SET PERSIST_ONLY replication_sender_observe_commit_only = @@GLOBAL.replication_sender_observe_commit_only;
@@ -267,16 +268,16 @@ Warning	1287	'@@sync_relay_log_info' is deprecated and will be removed in a futu
 Warning	1287	'@@sync_relay_log_info' is deprecated and will be removed in a future release.
 SET PERSIST_ONLY sync_source_info = @@GLOBAL.sync_source_info;
 
-include/assert.inc [Expect 100 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 101 persisted variables in persisted_variables table.]
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc [Expect 100 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 100 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 100 persisted variables with matching persisted and global values.]
+include/assert.inc [Expect 101 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 101 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 101 persisted variables with matching persisted and global values.]
 
 ############################################################
 # 3. Test RESET PERSIST. Verify persisted variable settings
@@ -361,6 +362,7 @@ RESET PERSIST replica_preserve_commit_order;
 RESET PERSIST replica_skip_errors;
 RESET PERSIST replica_sql_verify_checksum;
 RESET PERSIST replica_transaction_retries;
+RESET PERSIST replica_translate_deprecated_priv;
 RESET PERSIST replica_type_conversions;
 RESET PERSIST replication_optimize_for_static_plugin_config;
 RESET PERSIST replication_sender_observe_commit_only;

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -25,7 +25,7 @@ VARIABLE_NAME LIKE '%source%') AND
 (VARIABLE_NAME NOT LIKE 'innodb%')
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc [Expect 113 variables in the table.]
+include/assert.inc [Expect 114 variables in the table.]
 
 # Test SET PERSIST
 SET PERSIST binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -145,6 +145,7 @@ SET PERSIST replica_skip_errors = @@GLOBAL.replica_skip_errors;
 ERROR HY000: Variable 'replica_skip_errors' is a read only variable
 SET PERSIST replica_sql_verify_checksum = @@GLOBAL.replica_sql_verify_checksum;
 SET PERSIST replica_transaction_retries = @@GLOBAL.replica_transaction_retries;
+SET PERSIST replica_translate_deprecated_priv = @@GLOBAL.replica_translate_deprecated_priv;
 SET PERSIST replica_type_conversions = @@GLOBAL.replica_type_conversions;
 SET PERSIST replication_optimize_for_static_plugin_config = @@GLOBAL.replication_optimize_for_static_plugin_config;
 SET PERSIST replication_sender_observe_commit_only = @@GLOBAL.replication_sender_observe_commit_only;
@@ -245,16 +246,16 @@ Warning	1287	'@@sync_relay_log_info' is deprecated and will be removed in a futu
 Warning	1287	'@@sync_relay_log_info' is deprecated and will be removed in a future release.
 SET PERSIST sync_source_info = @@GLOBAL.sync_source_info;
 
-include/assert.inc [Expect 88 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 89 persisted variables in persisted_variables table.]
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc [Expect 88 persisted variables in persisted_variables table.']
-include/assert.inc [Expect 88 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc [Expect 88 persisted variables with matching persisted and global values.]
+include/assert.inc [Expect 89 persisted variables in persisted_variables table.']
+include/assert.inc [Expect 89 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc [Expect 89 persisted variables with matching persisted and global values.]
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS. Verify persisted variable
@@ -377,6 +378,7 @@ Warnings:
 Warning	3615	Variable replica_skip_errors does not exist in persisted config file
 RESET PERSIST IF EXISTS replica_sql_verify_checksum;
 RESET PERSIST IF EXISTS replica_transaction_retries;
+RESET PERSIST IF EXISTS replica_translate_deprecated_priv;
 RESET PERSIST IF EXISTS replica_type_conversions;
 RESET PERSIST IF EXISTS replication_optimize_for_static_plugin_config;
 RESET PERSIST IF EXISTS replication_sender_observe_commit_only;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -83,7 +83,7 @@ INSERT INTO aliases(name) VALUES
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
 --echo
---let $expected = 113
+--let $expected = 114
 --let $assert_text = Expect $expected variables in the table.
 --let $assert_cond = [SELECT COUNT(*) as count FROM rplvars, count, 1] = $expected
 --source include/assert.inc
@@ -115,7 +115,7 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $expected = 100
+--let $expected = 101
 --let $assert_text = Expect $expected persisted variables in persisted_variables table.
 --let $assert_cond = [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $expected
 --source include/assert.inc

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -61,7 +61,7 @@ INSERT INTO rplvars (varname, varvalue)
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
 --echo
---let $expected = 113
+--let $expected = 114
 --let $assert_text = Expect $expected variables in the table.
 --let $assert_cond = [SELECT COUNT(*) as count FROM rplvars, count, 1] = $expected
 --source include/assert.inc
@@ -84,7 +84,7 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $expected = 88
+--let $expected = 89
 --let $assert_text = Expect $expected persisted variables in persisted_variables table.
 --let $assert_cond = [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $expected
 --source include/assert.inc

--- a/mysql-test/suite/rpl/r/rpl_grant_set_user_id_compat.result
+++ b/mysql-test/suite/rpl/r/rpl_grant_set_user_id_compat.result
@@ -1,0 +1,247 @@
+include/rpl/init_source_replica.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
+[connection master]
+#
+# Sanity: SET_USER_ID is (re-)registered on the source, but not on
+# the replica (this is what makes the test cross-version-like).
+#
+include/assert_grep.inc ["SET_USER_ID should be defined"]
+[connection slave]
+include/assert_grep.inc ["SET_USER_ID should not be defined"]
+CALL mtr.add_suppression(
+"Replica applier rewrote removed dynamic privilege 'SET_USER_ID' into ");
+#
+# Sanity: the new gate variable exists and defaults to OFF (opt-in).
+# Save the current value so we can restore it before deinit.
+#
+SET @save_translate_deprecated_priv =
+@@global.replica_translate_deprecated_priv;
+SELECT @@global.replica_translate_deprecated_priv;
+@@global.replica_translate_deprecated_priv
+0
+#
+# R5. The grammar/parser is not touched by the fix: a user thread
+# executing GRANT SET_USER_ID directly on the replica must still be
+# rejected with ER_SYNTAX_ERROR.  Verified here while the gate is
+# still at its OFF default, on a regular user connection (not the
+# SQL applier thread).
+#
+CREATE USER rpl_psuid@localhost;
+GRANT SET_USER_ID ON *.* TO rpl_psuid@localhost;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use
+DROP USER rpl_psuid@localhost;
+#
+# Opt in to the rewrite for the R1..R6 tests below.  The gate can
+# only be changed while the replication SQL thread is stopped, so
+# stop replication, flip it ON, and start again.
+#
+include/rpl/stop_replica.inc
+SET @@global.replica_translate_deprecated_priv = ON;
+include/rpl/start_replica.inc
+#
+# R1, R2. GRANT SET_USER_ID on the source is binlogged as-is; the
+# replica rewrites it before applying and ends up with the two
+# modern privileges granted.
+#
+[connection master]
+CREATE USER rpl_psuid@localhost;
+GRANT SET_USER_ID ON *.* TO rpl_psuid@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_psuid@localhost;
+Grants for rpl_psuid@localhost
+GRANT USAGE ON *.* TO `rpl_psuid`@`localhost`
+GRANT ALLOW_NONEXISTENT_DEFINER,SET_ANY_DEFINER ON *.* TO `rpl_psuid`@`localhost`
+#
+# R2 (GRANT OPTION preserved): the WITH GRANT OPTION flag carried by
+# the source statement must apply to both translated privileges.
+#
+[connection master]
+GRANT SET_USER_ID ON *.* TO rpl_psuid@localhost WITH GRANT OPTION;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_psuid@localhost;
+Grants for rpl_psuid@localhost
+GRANT USAGE ON *.* TO `rpl_psuid`@`localhost`
+GRANT ALLOW_NONEXISTENT_DEFINER,SET_ANY_DEFINER ON *.* TO `rpl_psuid`@`localhost` WITH GRANT OPTION
+#
+# R1 extension: ON inside a block comment must not end the privilege
+# list early; SET_USER_ID before the real ON delimiter is still
+# rewritten.
+#
+[connection master]
+GRANT /*ON*/ SET_USER_ID ON *.* TO rpl_psuid@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_psuid@localhost;
+Grants for rpl_psuid@localhost
+GRANT USAGE ON *.* TO `rpl_psuid`@`localhost`
+GRANT ALLOW_NONEXISTENT_DEFINER,SET_ANY_DEFINER ON *.* TO `rpl_psuid`@`localhost` WITH GRANT OPTION
+#
+# R1 extension: lowercase "on" inside a block comment must not end
+# the privilege list early; SET_USER_ID after the comment is still
+# rewritten on a fresh account.
+#
+[connection master]
+CREATE USER rpl_onword@localhost;
+include/rpl/sync_to_replica.inc
+[connection master]
+GRANT /* this is on and on */ SET_USER_ID ON *.* TO rpl_onword@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_onword@localhost;
+Grants for rpl_onword@localhost
+GRANT USAGE ON *.* TO `rpl_onword`@`localhost`
+GRANT ALLOW_NONEXISTENT_DEFINER,SET_ANY_DEFINER ON *.* TO `rpl_onword`@`localhost`
+#
+# R1 extension: a leading comment before GRANT must not skip the
+# rewrite; SET_USER_ID in the privilege list is still translated.
+#
+[connection master]
+GRANT /*this is a comment*/ SET_USER_ID ON *.* TO rpl_psuid@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_psuid@localhost;
+Grants for rpl_psuid@localhost
+GRANT USAGE ON *.* TO `rpl_psuid`@`localhost`
+GRANT ALLOW_NONEXISTENT_DEFINER,SET_ANY_DEFINER ON *.* TO `rpl_psuid`@`localhost` WITH GRANT OPTION
+#
+# R3. REVOKE SET_USER_ID coming from the source revokes both
+# SET_ANY_DEFINER and ALLOW_NONEXISTENT_DEFINER on the replica.
+#
+[connection master]
+REVOKE SET_USER_ID ON *.* FROM rpl_psuid@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_psuid@localhost;
+Grants for rpl_psuid@localhost
+GRANT USAGE ON *.* TO `rpl_psuid`@`localhost`
+#
+# R8. Mixed-origin REVOKE: modern privileges granted directly on the
+# replica, then REVOKE SET_USER_ID replicated from the source.
+#
+#
+# R8a. Replica holds SET_ANY_DEFINER only; replicated REVOKE removes
+# it (over-revoke of the independent grant).
+#
+[connection master]
+CREATE USER rpl_mix_sa@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+GRANT SET_ANY_DEFINER ON *.* TO rpl_mix_sa@localhost;
+[connection master]
+REVOKE SET_USER_ID ON *.* FROM rpl_mix_sa@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_mix_sa@localhost;
+Grants for rpl_mix_sa@localhost
+GRANT USAGE ON *.* TO `rpl_mix_sa`@`localhost`
+#
+# R8b. Replica holds ALLOW_NONEXISTENT_DEFINER only.
+#
+[connection master]
+CREATE USER rpl_mix_and@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+GRANT ALLOW_NONEXISTENT_DEFINER ON *.* TO rpl_mix_and@localhost;
+[connection master]
+REVOKE SET_USER_ID ON *.* FROM rpl_mix_and@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_mix_and@localhost;
+Grants for rpl_mix_and@localhost
+GRANT USAGE ON *.* TO `rpl_mix_and`@`localhost`
+#
+# R8c. Replica holds neither modern privilege; replicated REVOKE is a
+# no-op and applier keeps running.
+#
+[connection master]
+CREATE USER rpl_mix_none@localhost;
+include/rpl/sync_to_replica.inc
+[connection master]
+REVOKE SET_USER_ID ON *.* FROM rpl_mix_none@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_mix_none@localhost;
+Grants for rpl_mix_none@localhost
+GRANT USAGE ON *.* TO `rpl_mix_none`@`localhost`
+#
+# R8 cleanup
+#
+[connection master]
+DROP USER rpl_mix_sa@localhost, rpl_mix_and@localhost, rpl_mix_none@localhost;
+include/rpl/sync_to_replica.inc
+#
+# R4. SET_USER_ID used only as a DB/table identifier (after ON) must
+# round-trip unmodified.  Test both backtick-quoted and unquoted
+# forms; on 8.4+ the latter is a valid identifier, not the removed
+# dynamic privilege.
+#
+[connection master]
+CREATE DATABASE `set_user_id`;
+CREATE TABLE `set_user_id`.t (i INT);
+GRANT SELECT ON `set_user_id`.* TO rpl_psuid@localhost;
+CREATE DATABASE SET_USER_ID;
+CREATE TABLE SET_USER_ID.SET_USER_ID (i INT);
+GRANT SELECT ON SET_USER_ID.SET_USER_ID TO rpl_psuid@localhost;
+include/rpl/sync_to_replica.inc
+[connection slave]
+SHOW GRANTS FOR rpl_psuid@localhost;
+Grants for rpl_psuid@localhost
+GRANT USAGE ON *.* TO `rpl_psuid`@`localhost`
+GRANT SELECT ON `set_user_id`.* TO `rpl_psuid`@`localhost`
+GRANT SELECT ON `SET_USER_ID`.`SET_USER_ID` TO `rpl_psuid`@`localhost`
+#
+# Cleanup of the ON-mode test artifacts
+#
+[connection master]
+DROP DATABASE `set_user_id`;
+DROP DATABASE SET_USER_ID;
+DROP USER rpl_psuid@localhost, rpl_onword@localhost;
+include/rpl/sync_to_replica.inc
+#
+# R7. Turn the gate back OFF.  The same kind of statement that just
+# round-tripped successfully must now stop the SQL applier with
+# ER_SYNTAX_ERROR, proving the rewrite is gated.  The gate can only
+# be changed while the replication SQL thread is stopped.
+#
+[connection slave]
+include/rpl/stop_replica.inc
+SET @@global.replica_translate_deprecated_priv = OFF;
+include/rpl/start_replica.inc
+CALL mtr.add_suppression(
+"Worker .* failed executing transaction");
+CALL mtr.add_suppression(
+"The replica coordinator and worker threads are stopped");
+CALL mtr.add_suppression(
+"Replica SQL for channel.*Error 'You have an error in your SQL syntax");
+[connection master]
+CREATE USER rpl_psuid_off@localhost;
+GRANT SET_USER_ID ON *.* TO rpl_psuid_off@localhost;
+[connection slave]
+include/rpl/wait_for_applier_error.inc [errno=1149]
+#
+# Recover: the CREATE USER ran successfully on the replica (it
+# preceded the failing GRANT in the relay log), so the user is
+# still there even after the SQL thread stopped.  Stop replication,
+# drop the user on both sides, wipe the source's binlog so the
+# replica is not asked to re-apply the same failing event, then
+# restart replication.
+#
+include/rpl/stop_replica.inc
+RESET REPLICA;
+DROP USER rpl_psuid_off@localhost;
+[connection master]
+DROP USER rpl_psuid_off@localhost;
+RESET BINARY LOGS AND GTIDS;
+#
+# Restore the gate to its saved (default) value while the SQL thread
+# is still stopped, then resume replication.
+#
+[connection slave]
+SET @@global.replica_translate_deprecated_priv =
+@save_translate_deprecated_priv;
+include/rpl/start_replica.inc
+include/rpl/deinit.inc

--- a/mysql-test/suite/rpl/t/rpl_grant_set_user_id_compat-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_grant_set_user_id_compat-master.opt
@@ -1,0 +1,1 @@
+--loose-debug=+d,register_legacy_set_user_id_priv

--- a/mysql-test/suite/rpl/t/rpl_grant_set_user_id_compat.test
+++ b/mysql-test/suite/rpl/t/rpl_grant_set_user_id_compat.test
@@ -1,0 +1,316 @@
+# ==== Purpose ====
+#
+# Verify that the replica SQL applier accepts GRANT/REVOKE statements that
+# reference the removed SET_USER_ID dynamic privilege, by rewriting them to
+# SET_ANY_DEFINER + ALLOW_NONEXISTENT_DEFINER -- the same mapping used by
+# the offline upgrade migration (mysql_system_tables_fix.sql).
+#
+# ==== Requirements ====
+#
+# R1. The replica MUST NOT stop with ER_SYNTAX_ERROR when applying a
+#     GRANT/REVOKE statement that references SET_USER_ID coming from an
+#     older source server.
+# R2. The replica MUST grant SET_ANY_DEFINER and ALLOW_NONEXISTENT_DEFINER
+#     in place of SET_USER_ID, with the original WITH GRANT OPTION preserved.
+# R3. A REVOKE SET_USER_ID coming from the source MUST revoke both
+#     SET_ANY_DEFINER and ALLOW_NONEXISTENT_DEFINER on the replica when
+#     both were obtained via translated GRANT SET_USER_ID (all-via-rewrite).
+# R8. Mixed-origin REVOKE: replicated REVOKE SET_USER_ID when the replica
+#     holds only SET_ANY_DEFINER, only ALLOW_NONEXISTENT_DEFINER, or
+#     neither modern privilege granted directly on the replica.  The
+#     applier must not stop.  Revoking a missing replacement privilege is
+#     a no-op; an independently held replacement privilege is removed.
+# R4. SET_USER_ID in the object clause (after ON) MUST NOT be rewritten,
+#     whether quoted (`set_user_id`) or unquoted (SET_USER_ID on 8.4+).
+#     Only the bare privilege keyword in the privilege list is translated.
+# R5. The rewrite MUST run only on the replica SQL applier; a user thread
+#     executing GRANT SET_USER_ID directly MUST still fail with the
+#     original ER_SYNTAX_ERROR (the SQL grammar/mysql_grant are unchanged).
+# R6. A warning describing the rewrite MUST be written to the replica's
+#     error log so the operator can see the compatibility translation.
+# R7. The rewrite MUST be gated by the new global system variable
+#     @@global.replica_translate_deprecated_priv (OFF by default; opt-in).
+#     With the default value the SQL applier MUST fail with
+#     ER_SYNTAX_ERROR exactly as on a stock build, proving the gate
+#     defaults to disabled.  Setting the variable to ON MUST enable the
+#     rewrite path tested by R1..R6.
+#
+# ==== Limitations ====
+#
+# The rewrite is stateless: REVOKE SET_USER_ID always becomes REVOKE of
+# both SET_ANY_DEFINER and ALLOW_NONEXISTENT_DEFINER.  R3 covers the
+# all-via-rewrite case; R8 covers mixed-origin replica state.
+#
+# SET_USER_ID inside a SQL comment in the privilege list would still be
+# rewritten, but that only changes comment text the parser ignores anyway,
+# so it has no impact on the final grant result.  ON inside comments is
+# skipped atomically when locating the privilege-list boundary.
+#
+# ==== Implementation ====
+#
+# The source server is launched with --debug=+d,register_legacy_set_user_id_priv
+# (see rpl_grant_set_user_id_compat-master.opt), which re-registers
+# SET_USER_ID as a dynamic privilege only on the source.
+# This is needed only for test (the other option would be pre-recording
+# the binlog.
+# The replica boots
+# with the default privilege set (no SET_USER_ID), so any binlogged
+# GRANT/REVOKE SET_USER_ID statement from the source would fail to apply
+# without the replica-side rewrite under test.
+
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc
+--source include/rpl/init_source_replica.inc
+
+--echo #
+--echo # Sanity: SET_USER_ID is (re-)registered on the source, but not on
+--echo # the replica (this is what makes the test cross-version-like).
+--echo #
+--let $assert_privilege_name= SET_USER_ID
+--let $assert_privilege_absent= OFF
+--source include/assert_dynamic_priv.inc
+
+--source include/rpl/connection_replica.inc
+--let $assert_privilege_name= SET_USER_ID
+--let $assert_privilege_absent= ON
+--source include/assert_dynamic_priv.inc
+
+CALL mtr.add_suppression(
+  "Replica applier rewrote removed dynamic privilege 'SET_USER_ID' into ");
+
+--echo #
+--echo # Sanity: the new gate variable exists and defaults to OFF (opt-in).
+--echo # Save the current value so we can restore it before deinit.
+--echo #
+SET @save_translate_deprecated_priv =
+  @@global.replica_translate_deprecated_priv;
+SELECT @@global.replica_translate_deprecated_priv;
+
+--echo #
+--echo # R5. The grammar/parser is not touched by the fix: a user thread
+--echo # executing GRANT SET_USER_ID directly on the replica must still be
+--echo # rejected with ER_SYNTAX_ERROR.  Verified here while the gate is
+--echo # still at its OFF default, on a regular user connection (not the
+--echo # SQL applier thread).
+--echo #
+CREATE USER rpl_psuid@localhost;
+--error ER_SYNTAX_ERROR
+GRANT SET_USER_ID ON *.* TO rpl_psuid@localhost;
+DROP USER rpl_psuid@localhost;
+
+--echo #
+--echo # Opt in to the rewrite for the R1..R6 tests below.  The gate can
+--echo # only be changed while the replication SQL thread is stopped, so
+--echo # stop replication, flip it ON, and start again.
+--echo #
+--source include/rpl/stop_replica.inc
+SET @@global.replica_translate_deprecated_priv = ON;
+--source include/rpl/start_replica.inc
+
+--echo #
+--echo # R1, R2. GRANT SET_USER_ID on the source is binlogged as-is; the
+--echo # replica rewrites it before applying and ends up with the two
+--echo # modern privileges granted.
+--echo #
+--source include/rpl/connection_source.inc
+CREATE USER rpl_psuid@localhost;
+GRANT SET_USER_ID ON *.* TO rpl_psuid@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_psuid@localhost;
+
+--echo #
+--echo # R2 (GRANT OPTION preserved): the WITH GRANT OPTION flag carried by
+--echo # the source statement must apply to both translated privileges.
+--echo #
+--source include/rpl/connection_source.inc
+GRANT SET_USER_ID ON *.* TO rpl_psuid@localhost WITH GRANT OPTION;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_psuid@localhost;
+
+--echo #
+--echo # R1 extension: ON inside a block comment must not end the privilege
+--echo # list early; SET_USER_ID before the real ON delimiter is still
+--echo # rewritten.
+--echo #
+--source include/rpl/connection_source.inc
+GRANT /*ON*/ SET_USER_ID ON *.* TO rpl_psuid@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_psuid@localhost;
+
+--echo #
+--echo # R1 extension: lowercase "on" inside a block comment must not end
+--echo # the privilege list early; SET_USER_ID after the comment is still
+--echo # rewritten on a fresh account.
+--echo #
+--source include/rpl/connection_source.inc
+CREATE USER rpl_onword@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_source.inc
+GRANT /* this is on and on */ SET_USER_ID ON *.* TO rpl_onword@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_onword@localhost;
+
+--echo #
+--echo # R1 extension: a leading comment before GRANT must not skip the
+--echo # rewrite; SET_USER_ID in the privilege list is still translated.
+--echo #
+--source include/rpl/connection_source.inc
+GRANT /*this is a comment*/ SET_USER_ID ON *.* TO rpl_psuid@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_psuid@localhost;
+
+--echo #
+--echo # R3. REVOKE SET_USER_ID coming from the source revokes both
+--echo # SET_ANY_DEFINER and ALLOW_NONEXISTENT_DEFINER on the replica.
+--echo #
+--source include/rpl/connection_source.inc
+REVOKE SET_USER_ID ON *.* FROM rpl_psuid@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_psuid@localhost;
+
+--echo #
+--echo # R8. Mixed-origin REVOKE: modern privileges granted directly on the
+--echo # replica, then REVOKE SET_USER_ID replicated from the source.
+--echo #
+
+--echo #
+--echo # R8a. Replica holds SET_ANY_DEFINER only; replicated REVOKE removes
+--echo # it (over-revoke of the independent grant).
+--echo #
+--source include/rpl/connection_source.inc
+CREATE USER rpl_mix_sa@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_replica.inc
+GRANT SET_ANY_DEFINER ON *.* TO rpl_mix_sa@localhost;
+--source include/rpl/connection_source.inc
+REVOKE SET_USER_ID ON *.* FROM rpl_mix_sa@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_mix_sa@localhost;
+
+--echo #
+--echo # R8b. Replica holds ALLOW_NONEXISTENT_DEFINER only.
+--echo #
+--source include/rpl/connection_source.inc
+CREATE USER rpl_mix_and@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_replica.inc
+GRANT ALLOW_NONEXISTENT_DEFINER ON *.* TO rpl_mix_and@localhost;
+--source include/rpl/connection_source.inc
+REVOKE SET_USER_ID ON *.* FROM rpl_mix_and@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_mix_and@localhost;
+
+--echo #
+--echo # R8c. Replica holds neither modern privilege; replicated REVOKE is a
+--echo # no-op and applier keeps running.
+--echo #
+--source include/rpl/connection_source.inc
+CREATE USER rpl_mix_none@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_source.inc
+REVOKE SET_USER_ID ON *.* FROM rpl_mix_none@localhost;
+--source include/rpl/sync_to_replica.inc
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_mix_none@localhost;
+
+--echo #
+--echo # R8 cleanup
+--echo #
+--source include/rpl/connection_source.inc
+DROP USER rpl_mix_sa@localhost, rpl_mix_and@localhost, rpl_mix_none@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--echo #
+--echo # R4. SET_USER_ID used only as a DB/table identifier (after ON) must
+--echo # round-trip unmodified.  Test both backtick-quoted and unquoted
+--echo # forms; on 8.4+ the latter is a valid identifier, not the removed
+--echo # dynamic privilege.
+--echo #
+--source include/rpl/connection_source.inc
+CREATE DATABASE `set_user_id`;
+CREATE TABLE `set_user_id`.t (i INT);
+GRANT SELECT ON `set_user_id`.* TO rpl_psuid@localhost;
+CREATE DATABASE SET_USER_ID;
+CREATE TABLE SET_USER_ID.SET_USER_ID (i INT);
+GRANT SELECT ON SET_USER_ID.SET_USER_ID TO rpl_psuid@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_replica.inc
+SHOW GRANTS FOR rpl_psuid@localhost;
+
+--echo #
+--echo # Cleanup of the ON-mode test artifacts
+--echo #
+--source include/rpl/connection_source.inc
+DROP DATABASE `set_user_id`;
+DROP DATABASE SET_USER_ID;
+DROP USER rpl_psuid@localhost, rpl_onword@localhost;
+--source include/rpl/sync_to_replica.inc
+
+--echo #
+--echo # R7. Turn the gate back OFF.  The same kind of statement that just
+--echo # round-tripped successfully must now stop the SQL applier with
+--echo # ER_SYNTAX_ERROR, proving the rewrite is gated.  The gate can only
+--echo # be changed while the replication SQL thread is stopped.
+--echo #
+--source include/rpl/connection_replica.inc
+--source include/rpl/stop_replica.inc
+SET @@global.replica_translate_deprecated_priv = OFF;
+--source include/rpl/start_replica.inc
+
+CALL mtr.add_suppression(
+  "Worker .* failed executing transaction");
+CALL mtr.add_suppression(
+  "The replica coordinator and worker threads are stopped");
+CALL mtr.add_suppression(
+  "Replica SQL for channel.*Error 'You have an error in your SQL syntax");
+
+--source include/rpl/connection_source.inc
+CREATE USER rpl_psuid_off@localhost;
+GRANT SET_USER_ID ON *.* TO rpl_psuid_off@localhost;
+
+--source include/rpl/connection_replica.inc
+--let $slave_sql_errno= convert_error(ER_SYNTAX_ERROR)
+--source include/rpl/wait_for_applier_error.inc
+
+--echo #
+--echo # Recover: the CREATE USER ran successfully on the replica (it
+--echo # preceded the failing GRANT in the relay log), so the user is
+--echo # still there even after the SQL thread stopped.  Stop replication,
+--echo # drop the user on both sides, wipe the source's binlog so the
+--echo # replica is not asked to re-apply the same failing event, then
+--echo # restart replication.
+--echo #
+--let $rpl_only_running_threads= 1
+--source include/rpl/stop_replica.inc
+RESET REPLICA;
+DROP USER rpl_psuid_off@localhost;
+
+--source include/rpl/connection_source.inc
+DROP USER rpl_psuid_off@localhost;
+RESET BINARY LOGS AND GTIDS;
+
+--echo #
+--echo # Restore the gate to its saved (default) value while the SQL thread
+--echo # is still stopped, then resume replication.
+--echo #
+--source include/rpl/connection_replica.inc
+SET @@global.replica_translate_deprecated_priv =
+  @save_translate_deprecated_priv;
+--source include/rpl/start_replica.inc
+
+--source include/rpl/deinit.inc

--- a/mysql-test/suite/sys_vars/r/all_vars.result
+++ b/mysql-test/suite/sys_vars/r/all_vars.result
@@ -103,6 +103,8 @@ replica_skip_errors
 replica_skip_errors
 replica_sql_verify_checksum
 replica_sql_verify_checksum
+replica_translate_deprecated_priv
+replica_translate_deprecated_priv
 replica_type_conversions
 replica_type_conversions
 replication_optimize_for_static_plugin_config

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -13418,6 +13418,9 @@ ER_AUDIT_PARSE_SKIP_DISABLED_EVENT_SUBCLASS
 #
 start-error-number 48300
 
+ER_LOG_REPLICA_TRANSLATED_DEPRECATED_PRIVILEGE
+  eng "Replica applier rewrote removed dynamic privilege '%s' into '%s' before applying the query received from an older source server. Original query: %s"
+
 #
 # End of Percona Server 8.4 error log messages
 #

--- a/sql/auth/dynamic_privileges_impl.cc
+++ b/sql/auth/dynamic_privileges_impl.cc
@@ -320,5 +320,15 @@ bool dynamic_privilege_init(void) {
   ret += service->register_privilege(STRING_WITH_LEN("TRANSACTION_GTID_TAG"));
   ret += service->register_privilege(STRING_WITH_LEN("OPTIMIZE_LOCAL_TABLE"));
 
+  /*
+    Test-only: re-register the removed SET_USER_ID dynamic privilege so the
+    server can act as an "old source" emitting GRANT/REVOKE SET_USER_ID into
+    the binlog.  Used by mysql-test cases that exercise the replica-side
+    compatibility translation; never enabled in release builds.
+  */
+  DBUG_EXECUTE_IF("register_legacy_set_user_id_priv", {
+    ret += service->register_privilege(STRING_WITH_LEN("SET_USER_ID"));
+  });
+
   return ret != 0;
 }

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -40,7 +40,10 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <regex>
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <utility>
 
 #include "base64.h"
@@ -4405,10 +4408,293 @@ void Query_log_event::detach_temp_tables_worker(THD *thd_arg,
 }
 
 /*
+  The removed dynamic privilege we recognize, and the modern privileges
+  the rewrite produces in its place (same mapping as the offline upgrade
+  in mysql_system_tables_fix.sql).  Declared once and reused for the
+  match, the replacement text, the warning log message, and to size the
+  output buffer in the rewrite helper below.
+*/
+static constexpr std::string_view kLegacyPriv = "SET_USER_ID";
+static constexpr std::string_view kModernPrivs =
+    "SET_ANY_DEFINER,ALLOW_NONEXISTENT_DEFINER";
+static constexpr size_t kReplacementGrowth =
+    kModernPrivs.size() - kLegacyPriv.size();
+static constexpr std::string_view kGrantKeyword = "GRANT";
+static constexpr std::string_view kRevokeKeyword = "REVOKE";
+
+static bool is_sql_ident_char(unsigned char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') || c == '_';
+}
+
+static bool is_sql_space(unsigned char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+         c == '\v';
+}
+
+static const char *skip_line_terminator(const char *p, const char *end) {
+  if (p >= end) return p;
+  if (p[0] == '\r' && p + 1 < end && p[1] == '\n') return p + 2;
+  if (p[0] == '\n' || p[0] == '\r') return p + 1;
+  return p;
+}
+
+static const char *skip_sql_comment(const char *p, const char *end) {
+  // Block comment: consume /* ... */ as a single unit.
+  if (p + 1 < end && p[0] == '/' && p[1] == '*') {
+    p += 2;
+    while (p + 1 < end && !(p[0] == '*' && p[1] == '/')) ++p;
+    // Unterminated comment means this is not a rewrite candidate.
+    return p + 1 < end ? p + 2 : nullptr;
+  }
+
+  // Dash line comment: consume until line terminator or end of query text.
+  // MySQL requires whitespace after '--'; treating any '--' as a comment only
+  // conservatively misses some rewrites, never corrupts a statement.
+  if (p + 1 < end && p[0] == '-' && p[1] == '-') {
+    p += 2;
+    while (p < end && p[0] != '\n' && p[0] != '\r') ++p;
+    return skip_line_terminator(p, end);
+  }
+
+  // Hash line comment, accepted by MySQL.
+  if (p < end && p[0] == '#') {
+    ++p;
+    while (p < end && p[0] != '\n' && p[0] != '\r') ++p;
+    return skip_line_terminator(p, end);
+  }
+
+  return p;
+}
+
+static const char *skip_leading_comments_and_spaces(const char *p,
+                                                    const char *end) {
+  while (p < end) {
+    while (p < end && is_sql_space(static_cast<unsigned char>(*p))) ++p;
+    if (p >= end) return nullptr;
+
+    const char *after_comment = skip_sql_comment(p, end);
+    if (after_comment == nullptr) return nullptr;
+    if (after_comment == p) return p;
+    p = after_comment;
+  }
+
+  return nullptr;
+}
+
+/*
+  If `token` matches at p as a whole word (ASCII, case-insensitive) return the
+  pointer just past it, otherwise nullptr.  Used for the statement keyword,
+  which must be the first non-comment token, so there is nothing to scan for.
+*/
+static const char *match_keyword_at(const char *p, const char *end,
+                                    std::string_view token) {
+  if (static_cast<size_t>(end - p) < token.size()) return nullptr;
+  if (native_strncasecmp(p, token.data(), token.size()) != 0) return nullptr;
+  const char *const token_end = p + token.size();
+  // Reject when the keyword is only a prefix of a longer identifier.
+  if (token_end != end &&
+      is_sql_ident_char(static_cast<unsigned char>(*token_end)))
+    return nullptr;
+  return token_end;
+}
+
+/*
+  Find the first whole-word ASCII token outside SQL comments and return its
+  [start, end) range. This is intentionally a linear scan instead of
+  std::regex: libstdc++'s regex matcher can stack-overflow on long
+  relay-log queries before throwing an exception.
+*/
+static std::pair<const char *, const char *> find_uncommented_token(
+    const char *p, const char *end, std::string_view token) {
+  const char *const start = p;
+
+  while (p < end) {
+    if (static_cast<size_t>(end - p) < token.size()) return {nullptr, nullptr};
+
+    // Consume comments atomically, so tokens inside comment text are ignored.
+    const char *after_comment = skip_sql_comment(p, end);
+    if (after_comment == nullptr) return {nullptr, nullptr};
+    if (after_comment != p) {
+      p = after_comment;
+      continue;
+    }
+
+    // Match only on identifier boundaries, so e.g. `CONNECTION_ADMIN` does not
+    // expose a bare `ON`.  Privilege names and keywords are ASCII here.
+    if ((p == start || !is_sql_ident_char(static_cast<unsigned char>(p[-1]))) &&
+        native_strncasecmp(p, token.data(), token.size()) == 0) {
+      const char *const token_end = p + token.size();
+      if (token_end == end ||
+          !is_sql_ident_char(static_cast<unsigned char>(*token_end))) {
+        return {p, token_end};
+      }
+    }
+
+    ++p;
+  }
+
+  return {nullptr, nullptr};
+}
+
+/*
+  Function for the replica applier's legacy-privilege rewrite.
+  Operates on this event's own `query` / `q_len` and allocates on the
+  event's THD mem_root.
+
+  If `query` is a GRANT/REVOKE statement that mentions SET_USER_ID as a
+  bare word in the privilege list (the text between GRANT/REVOKE and the
+  first un-commented ON keyword), returns a {pointer, length} pair for a
+  copy with each such occurrence replaced by kModernPrivs, and logs
+  ER_LOG_REPLICA_TRANSLATED_DEPRECATED_PRIVILEGE so the operator can see
+  the compatibility translation.  Match is ASCII-case-insensitive.
+
+  Two linear scans and one std::regex pattern drive the rewrite
+  (see rewrite_legacy_set_user_id_priv):
+    match_keyword_at        GRANT/REVOKE as the first non-comment token
+    find_uncommented_token  first ON that ends the privilege list
+    re_set_user_id          SET_USER_ID tokens replaced inside the priv list
+
+  SET_USER_ID in the object clause after ON is never matched by re_set_user_id
+  and is therefore left untouched.
+
+  Limitation: the rewrite is stateless (no provenance tracking).  REVOKE
+  SET_USER_ID always becomes REVOKE of both replacement privileges.
+  Revoking one the account does not hold is a no-op, but a mixed-origin
+  account that received SET_ANY_DEFINER or ALLOW_NONEXISTENT_DEFINER
+  directly on the replica can lose that grant when an old-source REVOKE
+  SET_USER_ID is applied.  Consistent only when those privileges on the
+  replica all originated from translated SET_USER_ID on the source.
+
+  Limitation: SET_USER_ID inside a SQL comment in the privilege list
+  (e.g. SET_USER_ID embedded in a block comment before another privilege
+  in the list) is still rewritten because the bare-word scan does not skip
+  comment bodies.  That only changes comment text, which the parser discards
+  anyway, so it has no impact on the final grant result.  ON inside comments
+  is skipped atomically when locating the list boundary.
+
+  In every other case (statement is not GRANT/REVOKE, SET_USER_ID is
+  absent from the privilege list, or the rewrite buffer cannot be
+  allocated) returns {query, q_len} unchanged, so the caller can use the
+  returned (ptr, len) pair unconditionally with no nullptr or "did it
+  change" checks of its own.
+*/
+std::pair<const char *, size_t>
+Query_log_event::rewrite_legacy_set_user_id_priv() const {
+  /*
+    Cheapest possible early-out.  Any query that could mention SET_USER_ID
+    as a privilege must be at least as long as the shortest GRANT form
+    that the parser accepts:
+
+        GRANT SET_USER_ID ON *.* TO u        (29 bytes)
+
+    The shortest REVOKE form (REVOKE ... FROM u) is longer, so this
+    GRANT template defines the absolute floor.  Computed at compile time
+    from the literal so the constant stays in sync with the template
+    that motivates it.
+  */
+  static constexpr std::string_view kMinRewriteCandidate =
+      "GRANT SET_USER_ID ON *.* TO u";
+  if (query == nullptr || q_len < kMinRewriteCandidate.size())
+    return {query, q_len};
+
+  const char *const query_end = query + q_len;
+
+  /*
+    Skip leading block/line comments and whitespace, then require GRANT or
+    REVOKE at a word boundary. Binlog GRANT/REVOKE events are a single
+    statement, so matching from the first non-comment token is enough.
+    We could use find_uncommented_token() to scan forward looking for the token
+    and would walk the whole query before rejecting a non-candidate statement
+    (e.g. a long SELECT); matching in place rejects such statements in constant
+    time.
+  */
+  const char *stmt_start = skip_leading_comments_and_spaces(query, query_end);
+  if (stmt_start == nullptr) return {query, q_len};
+
+  /*
+    The statement keyword must be the first non-comment token, so match GRANT
+    or REVOKE directly at stmt_start.
+  */
+  const char *priv_start =
+      match_keyword_at(stmt_start, query_end, kGrantKeyword);
+  if (priv_start == nullptr)
+    priv_start = match_keyword_at(stmt_start, query_end, kRevokeKeyword);
+  if (priv_start == nullptr) return {query, q_len};
+
+  /*
+    Find the first real ON keyword and use its start as the end of the
+    privilege list.  Comments are consumed whole by find_uncommented_token(),
+    so ON/on inside a comment is not mistaken for the list delimiter.
+  */
+  const auto on = find_uncommented_token(priv_start, query_end, "ON");
+  if (on.first == nullptr) return {query, q_len};
+  const char *const priv_end = on.first;
+
+  std::string output;
+  try {
+    /*
+      std::regex construction/search and std::cregex_iterator are not noexcept.
+      With our fixed pattern and privilege-list-only input this is unlikely to
+      throw in practice, but an uncaught exception on the replica SQL thread
+      would call std::terminate().  Fall back to the original query on any
+      regex failure; it either applies unchanged or fails as it would without
+      the rewrite.
+
+      re_set_user_id: whole-word SET_USER_ID inside the privilege list only.
+    */
+    static const std::regex re_set_user_id(R"(\bSET_USER_ID\b)",
+                                           std::regex_constants::icase);
+    if (!std::regex_search(priv_start, priv_end, re_set_user_id))
+      return {query, q_len};
+
+    output.reserve(q_len + kReplacementGrowth);
+    output.append(query, priv_start);
+    const char *pos = priv_start;
+    for (std::cregex_iterator it(priv_start, priv_end, re_set_user_id), end;
+         it != end; ++it) {
+      const auto &m = (*it)[0];
+      output.append(pos, m.first);
+      output.append(kModernPrivs);
+      pos = m.second;
+    }
+    output.append(pos, priv_end);
+    output.append(priv_end, query_end);
+  } catch (...) {
+    return {query, q_len};
+  }
+
+  char *new_query = static_cast<char *>(thd->alloc(output.size() + 1));
+  if (new_query == nullptr) return {query, q_len};
+  memcpy(new_query, output.data(), output.size());
+  new_query[output.size()] = '\0';
+  LogErr(WARNING_LEVEL, ER_LOG_REPLICA_TRANSLATED_DEPRECATED_PRIVILEGE,
+         kLegacyPriv.data(), kModernPrivs.data(), query);
+  return {new_query, output.size()};
+}
+
+/*
   Query_log_event::do_apply_event()
 */
 int Query_log_event::do_apply_event(Relay_log_info const *rli) {
-  return do_apply_event(rli, query, q_len);
+  /*
+    Optionally rewrite the legacy SET_USER_ID dynamic privilege (removed
+    in 8.2 by WL#15875) into its modern replacements before handing the
+    query to the parser, so a GRANT/REVOKE SET_USER_ID emitted by an
+    older source server does not stop the replica SQL applier with
+    ER_SYNTAX_ERROR.  Gated by @@global.replica_translate_deprecated_priv
+    The rewrite runs only here, on the replica applier path; the SQL
+    grammar and mysql_grant() are unchanged, so user-issued and
+    BINLOG '...' statements that reference SET_USER_ID always fail with
+    the same error as before.
+  */
+  const char *effective_query = query;
+  size_t effective_len = q_len;
+  if (unlikely(opt_replica_translate_deprecated_priv)) {
+    std::tie(effective_query, effective_len) =
+        rewrite_legacy_set_user_id_priv();
+  }
+  return do_apply_event(rli, effective_query, effective_len);
 }
 
 /*

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -43,6 +43,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_set>
+#include <utility>
 
 #include "my_aes.h"
 #include "m_string.h"     // native_strncasecmp
@@ -1424,6 +1425,8 @@ class Query_log_event : public virtual mysql::binlog::event::Query_event,
 
   int do_apply_event(Relay_log_info const *rli, const char *query_arg,
                      size_t q_len_arg);
+
+  std::pair<const char *, size_t> rewrite_legacy_set_user_id_priv() const;
 #endif /* MYSQL_SERVER */
   /*
     If true, the event always be applied by slave SQL thread or be printed by

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1380,6 +1380,7 @@ ulonglong replica_type_conversions_options;
 ulong opt_mts_replica_parallel_workers;
 ulonglong opt_mts_pending_jobs_size_max;
 bool opt_replica_preserve_commit_order;
+bool opt_replica_translate_deprecated_priv;
 #ifndef NDEBUG
 uint replica_rows_last_search_algorithm_used;
 #endif

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -213,6 +213,7 @@ extern bool lower_case_file_system;
 extern bool opt_require_secure_transport;
 
 extern bool opt_replica_preserve_commit_order;
+extern bool opt_replica_translate_deprecated_priv;
 
 #ifndef NDEBUG
 extern uint replica_rows_last_search_algorithm_used;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4249,6 +4249,17 @@ static Sys_var_bool Sys_replica_preserve_commit_order(
 static Sys_var_deprecated_alias Sys_slave_preserve_commit_order(
     "slave_preserve_commit_order", Sys_replica_preserve_commit_order);
 
+static Sys_var_bool Sys_replica_translate_deprecated_priv(
+    "replica_translate_deprecated_priv",
+    "Rewrite replicated SET_USER_ID to "
+    "SET_ANY_DEFINER,ALLOW_NONEXISTENT_DEFINER in the replica SQL "
+    "applier. Disabled by default, does not affect user-issued "
+    "GRANT/REVOKE, and can be changed only while the replica SQL thread "
+    "is stopped.",
+    GLOBAL_VAR(opt_replica_translate_deprecated_priv), CMD_LINE(OPT_ARG),
+    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+    ON_CHECK(check_slave_stopped), ON_UPDATE(nullptr));
+
 bool Sys_var_charptr::global_update(THD *, set_var *var) {
   char *new_val, *ptr = var->save_result.string_value.str;
   const size_t len = var->save_result.string_value.length;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11204

Problem:
Newer replicas fail to apply replicated GRANT/REVOKE SET_USER_ID statements from older sources after SET_USER_ID was removed.

Cause:
Commit 3d0cfd5c06f ("WL#15875: Remove the deprecated SET_USER_ID privilege") removed SET_USER_ID from newer servers, but the replica SQL applier still replays the original query text from older sources and stops with ER_SYNTAX_ERROR when it encounters that legacy privilege.

Solution:
Add an opt-in compatibility rewrite in the replica applier that translates replicated SET_USER_ID to
SET_ANY_DEFINER,ALLOW_NONEXISTENT_DEFINER before parsing. Keep direct user-issued SQL unchanged, log when a rewrite happens, guard the feature with replica_translate_deprecated_priv, and cover it with an MTR test.