### PR TITLE
PS-10979 [9.7]: Fix XCom client request timeout thread lifetime

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
@@ -323,6 +323,7 @@
 #include <chrono>
 #include <future>
 #include <queue>
+#include <thread>
 #include <tuple>
 
 /* Defines and constants */
@@ -8375,17 +8376,29 @@ static xcom_send_app_wait_result xcom_send_app_wait_and_get(
   pax_msg *rp = nullptr;
 
   do {
+    retval = 0;
+    rp = nullptr;
+
     std::packaged_task<void()> send_client_app_data_task([&]() {
       retval = (int)xcom_send_client_app_data(fd, a, force);
       if (retval >= 0) rp = socket_read_msg(fd, p);
     });
 
     auto send_client_app_data_result = send_client_app_data_task.get_future();
-    std::thread(std::move(send_client_app_data_task)).detach();
+    std::thread send_client_app_data_thread(
+        std::move(send_client_app_data_task));
 
     std::future_status request_status = send_client_app_data_result.wait_for(
         std::chrono::seconds(XCOM_SEND_APP_WAIT_TIMEOUT));
-    if ((retval < 0) || request_status == std::future_status::timeout) {
+    bool const timed_out = (request_status == std::future_status::timeout);
+    if (timed_out && fd->fd >= 0) {
+      int sock = fd->fd;
+      shutdown_socket(&sock);
+    }
+    send_client_app_data_thread.join();
+
+    if ((retval < 0) || timed_out) {
+      if (rp) xdr_free((xdrproc_t)xdr_pax_msg, (char *)p);
       memset(p, 0, sizeof(*p)); /* before return so caller can free p */
       G_INFO(
           "Client sent negotiation request for protocol failed. Please check "


### PR DESCRIPTION
xcom_send_app_wait_and_get() ran the client send/recv in a detached thread and waited on its future with XCOM_SEND_APP_WAIT_TIMEOUT. On timeout the function returned while that thread was still blocked in SSL_read() on the connection. The caller then closed and freed the SSL connection, so the orphaned worker kept using freed OpenSSL state and corrupted the heap ("corrupted size vs. prev_size while consolidating") during Group Replication joins on loaded hosts.

Keep the worker thread joinable instead of detaching it. On timeout, shut down the socket (shutdown(2), RDWR) to unblock the worker's blocking I/O, then join it before returning. This guarantees the connection descriptor and the reply buffer stay valid for as long as the worker may touch them. Reading retval/rp only after the join also removes the prior data race on those variables, and a reply that arrives just as the timeout fires is now freed instead of leaked.

All call sites operate on TCP connections, where shutdown() reliably unblocks the worker, so the join cannot hang.

Verified with:
- cmake --build ../ai-deb-gcc15-rocks --target libmysqlgcs -j4
- cmake --build ../ai-deb-gcc15-rocks --target group_replication -j4
- cmake --build ../ai-deb-gcc15-rocks --target gcs_xcom_xcom_base-t -j4
- ../ai-deb-gcc15-rocks/runtime_output_directory/gcs_xcom_xcom_base-t