### PR TITLE
PS-10979 [9.7]: Fix XCom crash on NULL connection in acceptor_learner_task cleanup

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/network/network_provider_manager.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/network/network_provider_manager.cc
@@ -259,6 +259,8 @@ connection_descriptor *Network_provider_manager::open_xcom_connection(
 
 int Network_provider_manager::close_xcom_connection(
     connection_descriptor *connection_handle) {
+  if (connection_handle == nullptr) return -1;
+
   auto provider = Network_provider_manager::getInstance().get_provider(
       connection_handle->protocol_stack);
 

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
@@ -6823,6 +6823,17 @@ again:
   }
 
   FINALLY
+  /*
+    The task framework runs TERM_CHECK at the end of TASK_BEGIN, so when the
+    terminate flag is already set at task creation time it jumps straight to
+    this cleanup label before ep->rfd is assigned from the task argument above.
+    task_allocate() zero-initialises the env, so ep->rfd would be nullptr here.
+    The transport teardown now tolerates a nullptr connection, but that would
+    leak the accepted connection passed as the task argument. Recover it so it
+    is properly closed and freed.
+  */
+  if (ep->rfd == nullptr)
+    ep->rfd = static_cast<connection_descriptor *>(get_void_arg(arg));
   XCOM_IFDBG(D_BUG, FN; STRLIT(" shutdown "); NDBG(ep->rfd->fd, d);
              NDBG(task_now(), f));
   if (ep->reply_queue.suc && !link_empty(&ep->reply_queue))

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_transport.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_transport.cc
@@ -101,6 +101,8 @@ static int pm(xcom_port port) { return port == xcom_listen_port; }
 /* purecov: end */
 
 int close_open_connection(connection_descriptor *conn) {
+  if (conn == nullptr) return -1;
+
   return Network_provider_manager::getInstance().close_xcom_connection(conn);
 }
 
@@ -1943,11 +1945,15 @@ void ssl_free_con(connection_descriptor *con) {
 #endif
 
 void close_connection(connection_descriptor *con) {
+  if (con == nullptr) return;
+
   close_open_connection(con);
   set_connected(con, CON_NULL);
 }
 
 void shutdown_connection(connection_descriptor *con) {
+  if (con == nullptr) return;
+
   /* printstack(1); */
   ADD_DBG(D_TRANSPORT, add_event(EVENT_DUMP_PAD, string_arg("con->fd"));
           add_event(EVENT_DUMP_PAD, int_arg(con->fd)););

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_network_provider_manager-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_network_provider_manager-t.cc
@@ -341,4 +341,21 @@ TEST_F(XComNetworkProviderManagerTest,
 
   free(connection_to);
 }
+
+TEST_F(XComNetworkProviderManagerTest, CloseNullConnectionDoesNotCallProvider) {
+  std::shared_ptr<mock_network_provider> const mock_provider =
+      std::make_shared<mock_network_provider>();
+  EXPECT_CALL(*mock_provider, get_communication_stack())
+      .WillRepeatedly(testing::Return(XCOM_PROTOCOL));
+  EXPECT_CALL(*mock_provider, close_connection(testing::_)).Times(0);
+
+  Network_provider_manager::getInstance().add_network_provider(mock_provider);
+
+  EXPECT_EQ(
+      Network_provider_manager::getInstance().close_xcom_connection(nullptr),
+      -1);
+
+  Network_provider_manager::getInstance().remove_network_provider(
+      XCOM_PROTOCOL);
+}
 }  // namespace gcs_xcom_networkprovidermamangertest


### PR DESCRIPTION
acceptor_learner_task() assigns ep->rfd from the task argument as its first statement after TASK_BEGIN. However, TASK_BEGIN ends with TERM_CHECK, which jumps straight to the FINALLY cleanup label when the task's terminate flag is already set at creation time. Because task_allocate() zero-initialises the env, ep->rfd is then still NULL when FINALLY runs shutdown_connection(ep->rfd). That leads to close_xcom_connection() dereferencing connection_handle->protocol_stack on a NULL pointer (read at offset 0x1c) and a SIGSEGV in the gcs_xcom thread.

This is reachable under heavy load (e.g. valgrind) where Group Replication churns connections while XCom is shutting down.

Harden the whole connection teardown chain (close_xcom_connection, close_open_connection, close_connection, shutdown_connection) to tolerate a NULL connection, and add a unit test covering close_xcom_connection(nullptr).

The NULL guards alone would turn the crash into a leak of the accepted connection passed as the task argument, so also recover ep->rfd from that argument in FINALLY when it is NULL, ensuring the connection is properly closed and freed.