### PR TITLE
PS-11078 [8.4]: bump arm64 build runners to Ubuntu 26.04

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -115,14 +115,14 @@ env:
   BUILD_PARAMS_TYPE: normal
   COMPILER: gcc
   COMPILER_VER: ''
-  IMAGE_NAME: ubuntu-24.04
-  UBUNTU_CODE_NAME: noble
+  IMAGE_NAME: ubuntu-26.04
+  UBUNTU_CODE_NAME: resolute
   BOOST_VERSION: boost_1_84_0
   USE_CCACHE: '1'
   CCACHE_COMPRESS: '1'
   CCACHE_COMPRESSLEVEL: '9'
   CCACHE_CPP2: '1'
-  IMAGE: ubuntu-24.04
+  IMAGE: ubuntu-26.04
   SSH_KEY_ID: '107239874'
   EPHEMERAL_RUNNER_NAME: ps-arm64-${{ github.run_id }}-${{ github.run_attempt }}
   # PS-11179: EC2 fallback knobs. eu-central-1 chosen to match the existing
@@ -453,7 +453,7 @@ jobs:
   #   - Instance type: c7g.4xlarge (16 vCPU / 32 GB Graviton3 == cax41 parity).
   #   - Spot first across eu-central-1a/1b/1c; on InsufficientInstanceCapacity
   #     in all 3 AZs, retry on-demand across the same 3 AZs.
-  #   - AMI: Canonical Ubuntu 24.04 arm64 resolved via SSM Parameter Store
+  #   - AMI: Canonical Ubuntu 26.04 arm64 resolved via SSM Parameter Store
   #     at runtime (no hardcoded AMI ID; auto-refreshes weekly).
   #   - Self-termination: --instance-initiated-shutdown-behavior terminate
   #     combined with userData `shutdown -h now` after runner exits;
@@ -521,19 +521,19 @@ jobs:
           echo "::add-mask::$TOKEN"
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
-      # Resolve the current Canonical Ubuntu 24.04 arm64 AMI from SSM at
+      # Resolve the current Canonical Ubuntu 26.04 arm64 AMI from SSM at
       # runtime. Canonical refreshes this parameter weekly with security
       # patches; never hardcode the AMI ID in this workflow.
-      - name: Resolve Ubuntu 24.04 arm64 AMI
+      - name: Resolve Ubuntu 26.04 arm64 AMI
         id: ami
         run: |
           set -euo pipefail
           AMI=$(aws ssm get-parameter \
-            --name /aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id \
+            --name /aws/service/canonical/ubuntu/server/26.04/stable/current/arm64/hvm/ebs-gp3/ami-id \
             --region "$AWS_REGION" \
             --query Parameter.Value --output text)
           if [ -z "$AMI" ] || [ "$AMI" = "None" ]; then
-            echo "::error::Failed to resolve Ubuntu 24.04 arm64 AMI from SSM"
+            echo "::error::Failed to resolve Ubuntu 26.04 arm64 AMI from SSM"
             exit 1
           fi
           echo "Resolved AMI: $AMI"
@@ -608,7 +608,7 @@ jobs:
           for i in 1 2 3; do
             if apt-get update -y \\
                && apt-get install -y --no-install-recommends \\
-                    curl ca-certificates jq tar libicu74 git sudo; then
+                    curl ca-certificates jq tar libicu78 git sudo; then
               ok=1
               break
             fi
@@ -723,7 +723,7 @@ jobs:
           {Key=PerconaKeep,Value=True},\
           {Key=github_run_id,Value=${{ github.run_id }}},\
           {Key=github_run_attempt,Value=${{ github.run_attempt }}},\
-          {Key=github_workflow,Value=build},\
+          {Key=github_workflow,Value=builds},\
           {Key=github_repository,Value=${{ github.repository }}}]"
 
           AZS=(eu-central-1a eu-central-1b eu-central-1c)

--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
         default: false
       max_age_hours:
-        description: 'Orphan age threshold (hours); default 2h; lower at your own risk (build-arm64 has timeout-minutes: 180)'
+        description: 'Orphan age threshold (hours); default 6h; lower at your own risk (build-arm64 has timeout-minutes: 240)'
         type: string
         default: '6'
 


### PR DESCRIPTION
Move the Hetzner and AWS-fallback arm64 build runners from Ubuntu 24.04 to 26.04:

- Hetzner rapid-deploy image (IMAGE) -> ubuntu-26.04.
- AWS EC2 AMI: SSM parameter path -> .../ubuntu/server/26.04/...
- Runner bootstrap dep libicu74 -> libicu78 (26.04 ships ICU 78; the GHA runner binary needs libicu, and libicu74 does not exist on 26.04 so the EC2 userData apt install would otherwise fail and the runner would never register).
- IMAGE_NAME ccache-key label and UBUNTU_CODE_NAME (noble -> resolute).

Also fix the stale github_workflow EC2 tag value (build -> builds) so it matches the workflow name, and correct the orphan-sweep max_age_hours help text (default 6h / build-arm64 timeout-minutes: 240; was 2h/180).