### PR TITLE
PS-10414 [8.0]: Mark native-AIO read buffers defined for valgrind at the source

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -2438,6 +2438,19 @@ void LinuxAIOHandler::collect() {
         /* success */
         slot->n_bytes = events[i].res;
         slot->ret = 0;
+
+#ifdef UNIV_DEBUG_VALGRIND
+        /* The kernel filled the buffer via io_submit()/io_getevents(),
+        which memcheck does not track as defining the memory.  In a
+        WITH_VALGRIND build the buffer-pool frame was marked
+        UNIV_MEM_INVALID on allocation, so without this annotation every
+        later read of the just-read page (FIL_PAGE_TYPE classification in
+        AIOHandler::post_io_processing(), buf_zip_decompress(), zlib
+        inflate, ...) is reported as a use of uninitialised values. */
+        if (slot->type.is_read() && slot->n_bytes > 0) {
+          UNIV_MEM_VALID(slot->ptr, slot->n_bytes);
+        }
+#endif /* UNIV_DEBUG_VALGRIND */
       }
       m_array->release();
     }


### PR DESCRIPTION
Under valgrind, freshly read InnoDB pages trigger a flood of 'Conditional jump or move depends on uninitialised value(s)' reports, e.g.:

```
  Conditional jump or move depends on uninitialised value(s)
    at Encryption::is_encrypted_page(unsigned char const*)  (os0enc.cc)
    by AIOHandler::is_encrypted_page(Slot const*)           (os0file.cc:1085)
    by AIOHandler::post_io_processing(Slot*)                (os0file.cc:1292)
    by LinuxAIOHandler::poll(...)                           (os0file.cc:2500)
    by fil_aio_wait(unsigned long)                          (fil0fil.cc)
```

For compressed tablespaces the AIO read target is bpage->zip.data, and the undefined-ness of the kernel-filled buffer propagates through the whole decompression pipeline (buf_zip_decompress, zlib inflate), so suppressing the reports stack-by-stack is unbounded.

Fix the gap at its source: in LinuxAIOHandler::collect(), after io_getevents() reports a successfully completed read, mark the filled byte range UNIV_MEM_VALID(slot->ptr, slot->n_bytes).  This is exactly the information memcheck is missing - the kernel wrote those bytes via io_submit(), which valgrind does not track as defining the memory.

UNIV_MEM_VALID is a no-op unless built WITH_VALGRIND (UNIV_DEBUG_VALGRIND), so production builds are unaffected.  Partial reads are handled naturally: each completed chunk is marked at collect(), and LinuxAIOHandler::resubmit() advances slot->ptr before re-issuing the remainder.