### PR TITLE
PS-11182 [9.7]: Fix audit_log_read reopen-sequence bug

### DIFF
--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -877,10 +877,14 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
        * Starting position for reads defined ether by "start" tag or by a
        * bookmark consisting of a combination of "timestamp" and "id".
        * Only one of this two ways may be used at the same time.
+       *
+       * Initializing a new read sequence (via a "start" tag or a bookmark)
+       * while one is already open is allowed: the open sequence is implicitly
+       * closed and a fresh one is started, as documented by Oracle and as
+       * upstream MySQL behaves.
        */
       if ((has_timestamp_tag != has_id_tag) ||
-          (has_start_tag && has_timestamp_tag) ||
-          (reader_context != nullptr && (has_start_tag || has_timestamp_tag))) {
+          (has_start_tag && has_timestamp_tag)) {
         my_error(ER_UDF_ERROR, MYF(0), "audit_log_read",
                  "Wrong argument format");
         *error = 1;
@@ -957,14 +961,24 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
 
     bool is_new_session_request = !reader_args->timestamp.empty();
 
-    if ((reader_context == nullptr && !is_new_session_request) ||
-        (reader_context != nullptr && is_new_session_request)) {
+    if (reader_context == nullptr && !is_new_session_request) {
       my_error(ER_UDF_ERROR, MYF(0), "audit_log_read", "Wrong arguments list");
       *error = 1;
       return result;
     }
 
     if (is_new_session_request) {
+      /*
+       * A new read sequence implicitly closes an already-open one before
+       * starting fresh from the requested position.
+       */
+      if (reader_context != nullptr) {
+        log_reader->close_reader_session(reader_context);
+        SysVars::set_log_reader_context(thd, nullptr);
+        delete reader_context;
+        reader_context = nullptr;
+      }
+
       reader_context = log_reader->init_reader_session(thd, reader_args.get());
 
       if (reader_context == nullptr) {

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_reopen_sequence.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_reopen_sequence.result
@@ -1,0 +1,55 @@
+#
+# PS-11182: Audit log read sequence needs to be closed before a new
+#           read sequence is initialized
+# https://perconadev.atlassian.net/browse/PS-11182
+#
+# PS is running with JSON audit log format in REDUCED event mode.
+#
+# When a read sequence is already open (for example, started with a
+# "start" timestamp), initializing a NEW read sequence with a bookmark
+# ("timestamp" + "id") must implicitly close the open sequence and start
+# a fresh one, exactly as documented by Oracle:
+#
+#   "It is unnecessary to close reading explicitly. Reading is closed
+#    implicitly when the session ends or a new read sequence is
+#    initialized by calling audit_log_read() with an argument that
+#    indicates the position at which to begin."
+#
+#
+# Set up a filter that logs table access events so that the audit log
+# contains readable events.
+CREATE TABLE t1 (c1 INT);
+SELECT audit_log_filter_set_filter('log_inserts', '{"filter": { "class": {"name": "table_access", "event": {"name": "insert", "log": true} } } }');
+audit_log_filter_set_filter('log_inserts', '{"filter": { "class": {"name": "table_access", "event": {"name": "insert", "log": true} } } }')
+OK
+SELECT audit_log_filter_set_user('%', 'log_inserts');
+audit_log_filter_set_user('%', 'log_inserts')
+OK
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+INSERT INTO t1 VALUES (5);
+#
+# Rotate to flush the events to a closed log file, then capture a valid
+# bookmark (timestamp + id) for the events written so far.
+SET @bookmark := audit_log_read_bookmark();
+#
+# Step 1: open a read sequence using a "start" timestamp, reading only a
+#         single event (max_array_length = 1) so that the read sequence
+#         stays OPEN (it is not read to the end, so it is not implicitly
+#         closed on session end).
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:10:00"}, "max_array_length": 1}');
+#
+# Step 2: without explicitly closing, initialize a NEW read sequence
+#         using the bookmark. This implicitly closes the sequence opened
+#         in step 1 and succeeds (as it does in upstream MySQL).
+SELECT audit_log_read(@bookmark) AS reopen_with_bookmark;
+#
+# Close the read sequence explicitly.
+SELECT audit_log_read('null');
+audit_log_read('null')
+OK
+#
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_reopen_sequence-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_reopen_sequence-master.opt
@@ -1,0 +1,3 @@
+--loose-audit_log_filter.format=JSON
+--loose-audit_log_filter.event_mode=REDUCED
+--loose-audit_log_filter.file=udf_audit_log_read_reopen_sequence.json.log

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_reopen_sequence.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_reopen_sequence.test
@@ -1,0 +1,69 @@
+--echo #
+--echo # PS-11182: Audit log read sequence needs to be closed before a new
+--echo #           read sequence is initialized
+--echo # https://perconadev.atlassian.net/browse/PS-11182
+--echo #
+--echo # PS is running with JSON audit log format in REDUCED event mode.
+--echo #
+--echo # When a read sequence is already open (for example, started with a
+--echo # "start" timestamp), initializing a NEW read sequence with a bookmark
+--echo # ("timestamp" + "id") must implicitly close the open sequence and start
+--echo # a fresh one, exactly as documented by Oracle:
+--echo #
+--echo #   "It is unnecessary to close reading explicitly. Reading is closed
+--echo #    implicitly when the session ends or a new read sequence is
+--echo #    initialized by calling audit_log_read() with an argument that
+--echo #    indicates the position at which to begin."
+--echo #
+
+--source include/have_component_audit_log.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+--echo #
+--echo # Set up a filter that logs table access events so that the audit log
+--echo # contains readable events.
+CREATE TABLE t1 (c1 INT);
+
+SELECT audit_log_filter_set_filter('log_inserts', '{"filter": { "class": {"name": "table_access", "event": {"name": "insert", "log": true} } } }');
+SELECT audit_log_filter_set_user('%', 'log_inserts');
+
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+INSERT INTO t1 VALUES (5);
+
+--echo #
+--echo # Rotate to flush the events to a closed log file, then capture a valid
+--echo # bookmark (timestamp + id) for the events written so far.
+--let $audit_filter_rotate_name=`SELECT audit_log_rotate()`
+SET @bookmark := audit_log_read_bookmark();
+
+--echo #
+--echo # Step 1: open a read sequence using a "start" timestamp, reading only a
+--echo #         single event (max_array_length = 1) so that the read sequence
+--echo #         stays OPEN (it is not read to the end, so it is not implicitly
+--echo #         closed on session end).
+--disable_result_log
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:10:00"}, "max_array_length": 1}');
+--enable_result_log
+
+--echo #
+--echo # Step 2: without explicitly closing, initialize a NEW read sequence
+--echo #         using the bookmark. This implicitly closes the sequence opened
+--echo #         in step 1 and succeeds (as it does in upstream MySQL).
+--disable_result_log
+SELECT audit_log_read(@bookmark) AS reopen_with_bookmark;
+--enable_result_log
+
+--echo #
+--echo # Close the read sequence explicitly.
+SELECT audit_log_read('null');
+
+--echo #
+--echo # Cleanup
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc
+
+DROP TABLE t1;


### PR DESCRIPTION
audit_log_read() must implicitly close an already-open read sequence when a new read sequence is initialized (via a "start" timestamp or a "timestamp"+"id" bookmark), as documented by Oracle and as upstream MySQL behaves. Percona Server instead rejected the new sequence with

    ERROR 3200 (HY000): audit_log_read UDF failed; Wrong argument format

and required an explicit audit_log_read('null') to close the previous sequence first.

Two guards in audit_udf.cc enforced the wrong behavior:
 - the argument-validation check rejected a new sequence while one was open (reader_context != nullptr && (has_start_tag || has_timestamp_tag));
 - the arguments-list check rejected the open-sequence-plus-new-request case (reader_context != nullptr && is_new_session_request).

Fix:
 - drop the open-sequence clause from the argument-validation check; the remaining clauses still enforce that timestamp/id come as a pair and that a "start" tag and a bookmark are not combined;
 - narrow the arguments-list check to only reject the genuinely invalid case (reader_context == nullptr && !is_new_session_request);
 - in the new-session branch, close and delete the existing reader context before init_reader_session(), so the open sequence is torn down cleanly before the new one starts.

Add an MTR regression test under component_audit_log_filter that:
 - runs with JSON format in REDUCED event mode (as in the report),
 - opens a read sequence with a partial read (max_array_length=1) so the sequence stays open (a full read would be implicitly closed on is_session_end by audit_log_read_udf_deinit),
 - then issues a bookmark read without closing, which now succeeds.