### PR TITLE
PS-11186 [8.4]: Fix max_array_length nested inside "start"

### DIFF
--- a/components/audit_log_filter/audit_udf.cc
+++ b/components/audit_log_filter/audit_udf.cc
@@ -920,10 +920,22 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
         return result;
       }
 
+      /*
+       * "max_array_length" may be given at the top level or, for "start"
+       * reads, nested inside the "start" object (PS-11186). A top-level value
+       * takes precedence when both are present.
+       */
+      const rapidjson::Value *max_array_length_val = nullptr;
       if (json_doc.HasMember("max_array_length")) {
-        if (json_doc["max_array_length"].IsUint()) {
-          reader_args->max_array_length =
-              json_doc["max_array_length"].GetUint();
+        max_array_length_val = &json_doc["max_array_length"];
+      } else if (has_start_tag &&
+                 json_doc["start"].HasMember("max_array_length")) {
+        max_array_length_val = &json_doc["start"]["max_array_length"];
+      }
+
+      if (max_array_length_val != nullptr) {
+        if (max_array_length_val->IsUint()) {
+          reader_args->max_array_length = max_array_length_val->GetUint();
         } else {
           my_error(ER_UDF_ERROR, MYF(0), "audit_log_read",
                    "Wrong JSON argument, bad max_array_length format");

--- a/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_max_array_length_in_start.result
+++ b/mysql-test/suite/component_audit_log_filter/r/udf_audit_log_read_max_array_length_in_start.result
@@ -1,0 +1,80 @@
+#
+# PS-11186: max_array_length does not work in FULL/REDUCED mode audit logs
+# https://perconadev.atlassian.net/browse/PS-11186
+#
+# PS is running with JSON audit log format in FULL event mode.
+#
+# audit_log_read() must honour the "max_array_length" limit both when it
+# is placed at the top level next to "start":
+#
+#   audit_log_read('{"start": {"timestamp": "..."}, "max_array_length": 1}')
+#
+# and when it is nested INSIDE the "start" object, as in the bug report:
+#
+#   audit_log_read('{"start": {"timestamp": "...", "max_array_length": 1}}')
+#
+# Previously the nested form silently ignored the limit and returned ALL
+# matching events. The bug was in the UDF argument parsing and does not
+# depend on the event_mode (REDUCED mode is affected too).
+#
+SET GLOBAL audit_log_filter.event_mode=FULL;
+#
+# Set up a filter that logs table access events and generate five
+# events with deterministic timestamps (10:01:00 .. 10:05:00).
+CREATE TABLE t1 (c1 INT);
+SELECT audit_log_filter_set_filter('log_inserts', '{"filter": { "class": {"name": "table_access", "event": {"name": "insert", "log": true} } } }');
+audit_log_filter_set_filter('log_inserts', '{"filter": { "class": {"name": "table_access", "event": {"name": "insert", "log": true} } } }')
+OK
+SELECT audit_log_filter_set_user('%', 'log_inserts');
+audit_log_filter_set_user('%', 'log_inserts')
+OK
+SET GLOBAL DEBUG='+d,audit_log_filter_debug_timestamp';
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+INSERT INTO t1 VALUES (5);
+#
+# Rotate so that all five events are flushed to a closed log file.
+SELECT audit_log_rotate();
+audit_log_rotate()
+<file_name>
+#
+# max_array_length at the TOP level limits the result to a single event.
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00"}, "max_array_length": 1}');
+audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00"}, "max_array_length": 1}')
+[
+{"timestamp": "2022-08-09 10:01:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (1)", "sql_command": "insert"}}
+]
+
+SELECT audit_log_read('null');
+audit_log_read('null')
+OK
+#
+# max_array_length nested INSIDE "start" (the bug report's form) now also
+# limits the result to a single event.
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00", "max_array_length": 1}}');
+audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00", "max_array_length": 1}}')
+[
+{"timestamp": "2022-08-09 10:01:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (1)", "sql_command": "insert"}}
+]
+
+SELECT audit_log_read('null');
+audit_log_read('null')
+OK
+#
+# A top-level max_array_length takes precedence over a nested one.
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00", "max_array_length": 5}, "max_array_length": 2}');
+audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00", "max_array_length": 5}, "max_array_length": 2}')
+[
+{"timestamp": "2022-08-09 10:01:00", "id": 0, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (1)", "sql_command": "insert"}},
+{"timestamp": "2022-08-09 10:02:00", "id": 1, "class": "table_access", "event": "insert", "connection_id": <id>, "account": {"user": "root", "host": "localhost"}, "login": {"user": "root", "os": "", "ip": "", "proxy": ""}, "table_access_data": {"db": "test", "table": "t1", "query": "INSERT INTO t1 VALUES (2)", "sql_command": "insert"}}
+]
+
+SELECT audit_log_read('null');
+audit_log_read('null')
+OK
+#
+# Cleanup
+DROP TABLE t1;
+SET GLOBAL DEBUG='-d,audit_log_filter_debug_timestamp';

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_max_array_length_in_start-master.opt
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_max_array_length_in_start-master.opt
@@ -1,0 +1,2 @@
+--loose-audit_log_filter.format=JSON
+--loose-audit_log_filter.file=udf_audit_log_read_max_array_length_in_start.json.log

--- a/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_max_array_length_in_start.test
+++ b/mysql-test/suite/component_audit_log_filter/t/udf_audit_log_read_max_array_length_in_start.test
@@ -1,0 +1,74 @@
+--echo #
+--echo # PS-11186: max_array_length does not work in FULL/REDUCED mode audit logs
+--echo # https://perconadev.atlassian.net/browse/PS-11186
+--echo #
+--echo # PS is running with JSON audit log format in FULL event mode.
+--echo #
+--echo # audit_log_read() must honour the "max_array_length" limit both when it
+--echo # is placed at the top level next to "start":
+--echo #
+--echo #   audit_log_read('{"start": {"timestamp": "..."}, "max_array_length": 1}')
+--echo #
+--echo # and when it is nested INSIDE the "start" object, as in the bug report:
+--echo #
+--echo #   audit_log_read('{"start": {"timestamp": "...", "max_array_length": 1}}')
+--echo #
+--echo # Previously the nested form silently ignored the limit and returned ALL
+--echo # matching events. The bug was in the UDF argument parsing and does not
+--echo # depend on the event_mode (REDUCED mode is affected too).
+--echo #
+
+--source include/have_component_audit_log.inc
+--source include/have_debug.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+SET GLOBAL audit_log_filter.event_mode=FULL;
+
+--echo #
+--echo # Set up a filter that logs table access events and generate five
+--echo # events with deterministic timestamps (10:01:00 .. 10:05:00).
+CREATE TABLE t1 (c1 INT);
+SELECT audit_log_filter_set_filter('log_inserts', '{"filter": { "class": {"name": "table_access", "event": {"name": "insert", "log": true} } } }');
+SELECT audit_log_filter_set_user('%', 'log_inserts');
+
+--source clean_all_audit_logs.inc
+SET GLOBAL DEBUG='+d,audit_log_filter_debug_timestamp';
+
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+INSERT INTO t1 VALUES (5);
+
+--echo #
+--echo # Rotate so that all five events are flushed to a closed log file.
+--replace_column 1 <file_name>
+SELECT audit_log_rotate();
+
+--echo #
+--echo # max_array_length at the TOP level limits the result to a single event.
+--replace_regex /"connection_id": \d*/"connection_id": <id>/
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00"}, "max_array_length": 1}');
+SELECT audit_log_read('null');
+
+--echo #
+--echo # max_array_length nested INSIDE "start" (the bug report's form) now also
+--echo # limits the result to a single event.
+--replace_regex /"connection_id": \d*/"connection_id": <id>/
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00", "max_array_length": 1}}');
+SELECT audit_log_read('null');
+
+--echo #
+--echo # A top-level max_array_length takes precedence over a nested one.
+--replace_regex /"connection_id": \d*/"connection_id": <id>/
+SELECT audit_log_read('{"start": {"timestamp": "2022-08-09 10:00:00", "max_array_length": 5}, "max_array_length": 2}');
+SELECT audit_log_read('null');
+
+--echo #
+--echo # Cleanup
+DROP TABLE t1;
+SET GLOBAL DEBUG='-d,audit_log_filter_debug_timestamp';
+
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc


### PR DESCRIPTION
audit_log_read() ignored the "max_array_length" limit when it was nested inside the "start" object, e.g.
```
    audit_log_read('{"start": {"timestamp": "...", "max_array_length": 1}}')
```
returning ALL matching events instead of at most max_array_length. The limit was only honoured at the top level, next to "start".

Root cause: the UDF argument parser only looked for "max_array_length" at the top level of the JSON document, so a key nested inside "start" was silently dropped and the reader ran unbounded.

Fix: when "max_array_length" is absent at the top level but present inside the "start" object, read it from there. A top-level value still takes precedence when both are given. The bug was purely in argument parsing, so this restores the limit for both FULL and REDUCED event modes.

Add an MTR regression test under component_audit_log_filter that:
 - runs with JSON format in FULL event mode (as in the report),
 - generates five table_access events with deterministic debug timestamps (10:01:00 .. 10:05:00),
 - asserts the top-level placement returns a single event,
 - asserts the report's nested placement now returns a single event,
 - asserts a top-level max_array_length takes precedence over a nested one.