### PR TITLE
PS-11297 [trunk]: Avoid calling validate() in non-debug in rec_offs_*()

### DIFF
--- a/storage/innobase/include/rem0wrec.h
+++ b/storage/innobase/include/rem0wrec.h
@@ -153,7 +153,7 @@ void validate_rec_offset(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   /* Returns nonzero if the extern bit is set in nth field of rec. */
   return rec_offs_base(offsets)[1 + n] & REC_OFFS_EXTERNAL;
 }

--- a/storage/innobase/rem/rem0wrec.cc
+++ b/storage/innobase/rem/rem0wrec.cc
@@ -129,7 +129,7 @@ ulint rec_offs_nth_sql_null(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   return (rec_offs_nth_sql_null_low(offsets, n));
 }
 
@@ -139,7 +139,7 @@ ulint rec_offs_nth_default(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   return (rec_offs_nth_default_low(offsets, n));
 }
 
@@ -149,7 +149,7 @@ ulint rec_offs_nth_size(const dict_index_t *index, const ulint *offsets,
     n = index->get_field_off_pos(n);
   }
 
-  validate_rec_offset(index, offsets, n, UT_LOCATION_HERE);
+  ut_d(validate_rec_offset(index, offsets, n, UT_LOCATION_HERE));
   return (rec_offs_nth_size_low(offsets, n));
 }
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11297

trunk equivalent of #6042 (and #5922 / #6041).

validate_rec_offset() in the rec_offs_*() helpers of rem0wrec was called
unconditionally, including in non-debug builds where it does no useful work.
Wrap these calls in ut_d() so they are compiled only in debug builds, removing
the per-call overhead on release builds.
