### PR TITLE
PS-10595 [trunk]: Add innodb_buffer_pool_populate to control page pre-population

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_populate_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_populate_basic.result
@@ -1,0 +1,62 @@
+SET @start_global_value = @@global.innodb_buffer_pool_populate;
+SELECT @start_global_value;
+@start_global_value
+0
+Valid values are 'ON' and 'OFF'
+select @@global.innodb_buffer_pool_populate in (0, 1);
+@@global.innodb_buffer_pool_populate in (0, 1)
+1
+select @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+0
+select @@session.innodb_buffer_pool_populate;
+ERROR HY000: Variable 'innodb_buffer_pool_populate' is a GLOBAL variable
+show global variables like 'innodb_buffer_pool_populate';
+Variable_name	Value
+innodb_buffer_pool_populate	OFF
+show session variables like 'innodb_buffer_pool_populate';
+Variable_name	Value
+innodb_buffer_pool_populate	OFF
+select * from performance_schema.global_variables where variable_name='innodb_buffer_pool_populate';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_buffer_pool_populate	OFF
+select * from performance_schema.session_variables where variable_name='innodb_buffer_pool_populate';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_buffer_pool_populate	OFF
+set global innodb_buffer_pool_populate='ON';
+select @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+1
+set @@global.innodb_buffer_pool_populate=0;
+select @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+0
+set global innodb_buffer_pool_populate=1;
+select @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+1
+set @@global.innodb_buffer_pool_populate='OFF';
+select @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+0
+set session innodb_buffer_pool_populate='OFF';
+ERROR HY000: Variable 'innodb_buffer_pool_populate' is a GLOBAL variable and should be set with SET GLOBAL
+set @@session.innodb_buffer_pool_populate='ON';
+ERROR HY000: Variable 'innodb_buffer_pool_populate' is a GLOBAL variable and should be set with SET GLOBAL
+set global innodb_buffer_pool_populate=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_buffer_pool_populate'
+set global innodb_buffer_pool_populate=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_buffer_pool_populate'
+set global innodb_buffer_pool_populate=2;
+ERROR 42000: Variable 'innodb_buffer_pool_populate' can't be set to the value of '2'
+set global innodb_buffer_pool_populate=-3;
+ERROR 42000: Variable 'innodb_buffer_pool_populate' can't be set to the value of '-3'
+select @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+0
+set global innodb_buffer_pool_populate='AUTO';
+ERROR 42000: Variable 'innodb_buffer_pool_populate' can't be set to the value of 'AUTO'
+SET @@global.innodb_buffer_pool_populate = @start_global_value;
+SELECT @@global.innodb_buffer_pool_populate;
+@@global.innodb_buffer_pool_populate
+0

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_populate_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_populate_basic.test
@@ -1,0 +1,60 @@
+#
+# Basic test for innodb_buffer_pool_populate
+#
+# It is a dynamic, global-only boolean that defaults to OFF.
+#
+
+SET @start_global_value = @@global.innodb_buffer_pool_populate;
+SELECT @start_global_value;
+
+#
+# exists as global only
+#
+--echo Valid values are 'ON' and 'OFF'
+select @@global.innodb_buffer_pool_populate in (0, 1);
+select @@global.innodb_buffer_pool_populate;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_buffer_pool_populate;
+show global variables like 'innodb_buffer_pool_populate';
+show session variables like 'innodb_buffer_pool_populate';
+--disable_warnings
+select * from performance_schema.global_variables where variable_name='innodb_buffer_pool_populate';
+select * from performance_schema.session_variables where variable_name='innodb_buffer_pool_populate';
+--enable_warnings
+
+#
+# show that it's writable
+#
+set global innodb_buffer_pool_populate='ON';
+select @@global.innodb_buffer_pool_populate;
+set @@global.innodb_buffer_pool_populate=0;
+select @@global.innodb_buffer_pool_populate;
+set global innodb_buffer_pool_populate=1;
+select @@global.innodb_buffer_pool_populate;
+set @@global.innodb_buffer_pool_populate='OFF';
+select @@global.innodb_buffer_pool_populate;
+--error ER_GLOBAL_VARIABLE
+set session innodb_buffer_pool_populate='OFF';
+--error ER_GLOBAL_VARIABLE
+set @@session.innodb_buffer_pool_populate='ON';
+
+#
+# incorrect types
+#
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_buffer_pool_populate=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_buffer_pool_populate=1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_buffer_pool_populate=2;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_buffer_pool_populate=-3;
+select @@global.innodb_buffer_pool_populate;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_buffer_pool_populate='AUTO';
+
+#
+# Cleanup
+#
+SET @@global.innodb_buffer_pool_populate = @start_global_value;
+SELECT @@global.innodb_buffer_pool_populate;

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2666,8 +2666,8 @@ withdraw_retry:
       while (chunk < echunk) {
         ulonglong unit = srv_buf_pool_chunk_unit;
 
-        if (!buf_chunk_init(buf_pool, chunk, unit,
-                            static_cast<bool>(srv_numa_interleave), nullptr)) {
+        if (!buf_chunk_init(buf_pool, chunk, unit, srv_buf_pool_populate,
+                            nullptr)) {
           ib::error(ER_IB_MSG_65) << "buffer pool " << i
                                   << " : failed to allocate"
                                      " new memory.";

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -24166,7 +24166,9 @@ static MYSQL_SYSVAR_BOOL(use_native_aio, srv_use_native_aio,
 static MYSQL_SYSVAR_BOOL(
     numa_interleave, srv_numa_interleave,
     PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
-    "Use NUMA interleave memory policy to allocate InnoDB buffer pool.",
+    "Use NUMA interleave memory policy to allocate InnoDB buffer pool."
+    " Note: it is recommended to keep it enabled when using large pages"
+    " on systems with multiple NUMA nodes.",
     nullptr, nullptr, true);
 #endif /* HAVE_LIBNUMA */
 
@@ -24177,6 +24179,15 @@ static MYSQL_SYSVAR_BOOL(
     " instead of eagerly while the buffer pool is built. Speeds up buffer"
     " pool initialization for large pools at the cost of slightly slower first"
     " use of each page, which then pays the latch construction.",
+    nullptr, nullptr, false);
+
+static MYSQL_SYSVAR_BOOL(
+    buffer_pool_populate, srv_buf_pool_populate, PLUGIN_VAR_NOCMDARG,
+    "Enforce page faults for InnoDB buffer pool allocations at allocation time"
+    " (pre-populate pages). When OFF (default), the pre-population is skipped"
+    " to reduce startup time and page-faults happen on first page accesses."
+    " Note: it is recommended to turn on this variable when using large pages"
+    " on systems with multiple NUMA nodes.",
     nullptr, nullptr, false);
 
 static MYSQL_SYSVAR_BOOL(
@@ -24636,6 +24647,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(numa_interleave),
 #endif /* HAVE_LIBNUMA */
     MYSQL_SYSVAR(buffer_pool_lazy_latch_init),
+    MYSQL_SYSVAR(buffer_pool_populate),
     MYSQL_SYSVAR(change_buffering),
     MYSQL_SYSVAR(change_buffer_max_size),
 #if defined UNIV_DEBUG || defined UNIV_IBUF_DEBUG

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -419,6 +419,11 @@ and their latches (mutex, rw-locks) are created lazily on first use. When
 false (default), latches are created eagerly while the buffer pool is built. */
 extern bool srv_buf_pool_lazy_latch_init;
 
+/** Whether buffer pool allocations (huge and regular pages) are pre-populated
+(MAP_POPULATE and the explicit prefault step) at allocation time. Backed by the
+innodb_buffer_pool_populate system variable. */
+extern bool srv_buf_pool_populate;
+
 /* The innodb_directories variable value. This a list of directories
 deliminated by ';', i.e the FIL_PATH_SEPARATOR. */
 extern char *srv_innodb_directories;

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -228,6 +228,11 @@ bool srv_numa_interleave = false;
 /** See srv0srv.h. Default off: latches are created eagerly. */
 bool srv_buf_pool_lazy_latch_init = false;
 
+/** Whether buffer pool allocations (huge and regular pages) are pre-populated
+(MAP_POPULATE and the explicit prefault step) at allocation time. Exposed as the
+innodb_buffer_pool_populate system variable. */
+bool srv_buf_pool_populate = false;
+
 #ifdef UNIV_DEBUG
 /** Force all user tables to use page compression. */
 ulong srv_debug_compress;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1615,7 +1615,7 @@ dberr_t srv_start(bool create_new_db) {
   ib::info(ER_IB_MSG_1130, size, unit, srv_buf_pool_instances, chunk_size,
            chunk_unit);
 
-  err = buf_pool_init(srv_buf_pool_size, static_cast<bool>(srv_numa_interleave),
+  err = buf_pool_init(srv_buf_pool_size, srv_buf_pool_populate,
                       srv_buf_pool_instances);
 
   if (err != DB_SUCCESS) {
@@ -1625,6 +1625,18 @@ dberr_t srv_start(bool create_new_db) {
   }
 
   ib::info(ER_IB_MSG_1132);
+
+  if (srv_numa_interleave && os_use_large_pages && !srv_buf_pool_populate) {
+    ib::warn() << "innodb_numa_interleave is enabled together with large "
+                  "pages, but innodb_buffer_pool_populate is OFF. Large pages "
+                  "are not subject to NUMA rebalancing and the interleave "
+                  "policy is only a hint: if a node is temporarily out of "
+                  "free memory when a page is first touched, the page can "
+                  "land on the wrong node and stay there permanently. To "
+                  "avoid this, drop the page cache before starting MySQL and "
+                  "enable innodb_buffer_pool_populate when both "
+                  "innodb_numa_interleave and large_pages are ON.";
+  }
 
 #ifdef UNIV_DEBUG
   /* We have observed deadlocks with a 5MB buffer pool but


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10595

This patch is inspired by the contribution from Alexey Bychko <abychko@gmail.com>.

Introduce a new InnoDB boolean server variable innodb_buffer_pool_populate
that controls whether the buffer pool pages are pre-populated (page-faulted)
at allocation time (at startup).

The control is decoupled from innodb_numa_interleave: pre-population no longer
requires NUMA interleaving to be enabled, and enabled NUMA interleaving does
not automatically enforce page-faults at startup.

Note: the interleave memory policy (that we need to distribute pages across
NUMA nodes in uniform way, to minimize the traffic between NUMA nodes) is only
a hint - if there was no free memory available at a given node, page would be
allocated from a different node (as a fallback). Because huge pages are never
migrated by the kernel's NUMA balancer and the interleave memory policy is only
honored at fault time, a startup warning is emitted when innodb_numa_interleave
and large_pages are both enabled while innodb_buffer_pool_populate is OFF,
suggesting to enable it and also pointing out that it might be worth to drop
the page cache before starting MySQL, to ensure we will not run out of memory
on a node (which would result in physical allocation of pages on different nodes,
which is problem if these were huge pages because they can't be migrated and the
imbalance would result in increased traffic between NUMA nodes).

By default, innodb_buffer_pool_populate is OFF, so the server starts faster,
and page faults happen in runtime on each page first access.
