### PR TITLE
PS-11217: GCS_DEBUG_TRACE log not possible to rotate/archive without …

### DIFF
--- a/mysql-test/suite/group_replication/r/gr_gcs_debug_trace_auto_rotation.result
+++ b/mysql-test/suite/group_replication/r/gr_gcs_debug_trace_auto_rotation.result
@@ -1,0 +1,34 @@
+include/group_replication.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
+[connection server1]
+
+# 1. Set communication_debug_max_file_size and start GR.
+#    Trace file with timestamp are created.
+SET GLOBAL group_replication_communication_debug_max_file_size = 200;
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_ALL";
+include/start_and_bootstrap_group_replication.inc
+Initial trace file is timestamped, as expected
+No plain GCS_DEBUG_TRACE created, as expected
+
+# 2. Size-based rotation: old file stays, new timestamped file created.
+Size-based rotation created a new timestamped file, as expected
+Original file still exists after rotation (no archiving), as expected
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_NONE";
+
+# 3. Restart Group Replication -- a new timestamped file is created on start.
+Recorded file count before restart
+include/stop_group_replication.inc
+include/start_and_bootstrap_group_replication.inc
+New timestamped file created on GR restart, as expected
+
+# 4. Group Replication is ONLINE.
+include/assert.inc [Member is ONLINE after automatic rotation]
+
+# 5. Cleanup.
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_NONE";
+SET GLOBAL group_replication_communication_debug_max_file_size = 0;
+include/stop_group_replication.inc
+Cleanup complete
+include/group_replication_end.inc

--- a/mysql-test/suite/group_replication/r/gr_gcs_debug_trace_reopen.result
+++ b/mysql-test/suite/group_replication/r/gr_gcs_debug_trace_reopen.result
@@ -1,0 +1,23 @@
+include/group_replication.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
+[connection server1]
+
+# 1. Start Group Replication.
+include/start_and_bootstrap_group_replication.inc
+
+# 2. Enable GCS_DEBUG_ALL tracing.
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_ALL";
+
+# 3. Remove GCS_DEBUG_TRACE.
+
+# 4. Wait for stat auto-detection -- GCS_DEBUG_TRACE must reappear
+
+# 5. Group Replication is ONLINE.
+include/assert.inc [Member is ONLINE after stale-fd detection and reopen]
+
+# 6. cleanup
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_NONE";
+include/stop_group_replication.inc
+include/group_replication_end.inc

--- a/mysql-test/suite/group_replication/r/gr_persist_only_variables.result
+++ b/mysql-test/suite/group_replication/r/gr_persist_only_variables.result
@@ -30,6 +30,7 @@ SET PERSIST_ONLY group_replication_bootstrap_group = @@GLOBAL.group_replication_
 SET PERSIST_ONLY group_replication_certification_loop_chunk_size = @@GLOBAL.group_replication_certification_loop_chunk_size;
 SET PERSIST_ONLY group_replication_certification_loop_sleep_time = @@GLOBAL.group_replication_certification_loop_sleep_time;
 SET PERSIST_ONLY group_replication_clone_threshold = @@GLOBAL.group_replication_clone_threshold;
+SET PERSIST_ONLY group_replication_communication_debug_max_file_size = @@GLOBAL.group_replication_communication_debug_max_file_size;
 SET PERSIST_ONLY group_replication_communication_debug_options = @@GLOBAL.group_replication_communication_debug_options;
 SET PERSIST_ONLY group_replication_communication_max_message_size = @@GLOBAL.group_replication_communication_max_message_size;
 SET PERSIST_ONLY group_replication_communication_stack = @@GLOBAL.group_replication_communication_stack;
@@ -87,7 +88,7 @@ SET PERSIST_ONLY group_replication_view_change_uuid = @@GLOBAL.group_replication
 SET PERSIST_ONLY group_replication_xcom_ssl_accept_retries = @@GLOBAL.group_replication_xcom_ssl_accept_retries;
 SET PERSIST_ONLY group_replication_xcom_ssl_socket_timeout = @@GLOBAL.group_replication_xcom_ssl_socket_timeout;
 
-include/assert.inc ['Expect 65 persisted variables.']
+include/assert.inc ['Expect 66 persisted variables.']
 
 ############################################################
 # 2. Restart server, it must bootstrap the group and preserve
@@ -96,9 +97,9 @@ include/assert.inc ['Expect 65 persisted variables.']
 include/rpl/reconnect.inc
 include/gr_wait_for_member_state.inc
 
-include/assert.inc ['Expect 65 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 64 variables which last value was set through SET PERSIST.']
-include/assert.inc ['Expect 64 persisted variables with matching persisted and global values.']
+include/assert.inc ['Expect 66 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 65 variables which last value was set through SET PERSIST.']
+include/assert.inc ['Expect 65 persisted variables with matching persisted and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS.
@@ -112,6 +113,7 @@ RESET PERSIST IF EXISTS group_replication_bootstrap_group;
 RESET PERSIST IF EXISTS group_replication_certification_loop_chunk_size;
 RESET PERSIST IF EXISTS group_replication_certification_loop_sleep_time;
 RESET PERSIST IF EXISTS group_replication_clone_threshold;
+RESET PERSIST IF EXISTS group_replication_communication_debug_max_file_size;
 RESET PERSIST IF EXISTS group_replication_communication_debug_options;
 RESET PERSIST IF EXISTS group_replication_communication_max_message_size;
 RESET PERSIST IF EXISTS group_replication_communication_stack;

--- a/mysql-test/suite/group_replication/r/gr_persist_variables.result
+++ b/mysql-test/suite/group_replication/r/gr_persist_variables.result
@@ -32,6 +32,7 @@ SET PERSIST group_replication_bootstrap_group = @@GLOBAL.group_replication_boots
 SET PERSIST group_replication_certification_loop_chunk_size = @@GLOBAL.group_replication_certification_loop_chunk_size;
 SET PERSIST group_replication_certification_loop_sleep_time = @@GLOBAL.group_replication_certification_loop_sleep_time;
 SET PERSIST group_replication_clone_threshold = @@GLOBAL.group_replication_clone_threshold;
+SET PERSIST group_replication_communication_debug_max_file_size = @@GLOBAL.group_replication_communication_debug_max_file_size;
 SET PERSIST group_replication_communication_debug_options = @@GLOBAL.group_replication_communication_debug_options;
 SET PERSIST group_replication_communication_max_message_size = @@GLOBAL.group_replication_communication_max_message_size;
 SET PERSIST group_replication_communication_stack = @@GLOBAL.group_replication_communication_stack;
@@ -91,7 +92,7 @@ Warning	1681	'group_replication_view_change_uuid' is deprecated and will be remo
 SET PERSIST group_replication_xcom_ssl_accept_retries = @@GLOBAL.group_replication_xcom_ssl_accept_retries;
 SET PERSIST group_replication_xcom_ssl_socket_timeout = @@GLOBAL.group_replication_xcom_ssl_socket_timeout;
 
-include/assert.inc ['Expect 65 persisted variables.']
+include/assert.inc ['Expect 66 persisted variables.']
 
 ############################################################
 # 2. Restart server, it must bootstrap the group and preserve
@@ -100,9 +101,9 @@ include/assert.inc ['Expect 65 persisted variables.']
 include/rpl/reconnect.inc
 include/gr_wait_for_member_state.inc
 
-include/assert.inc ['Expect 65 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 64 variables which last value was set through SET PERSIST.']
-include/assert.inc ['Expect 64 variables which last value was set through SET PERSIST is equal to its global value.']
+include/assert.inc ['Expect 66 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 65 variables which last value was set through SET PERSIST.']
+include/assert.inc ['Expect 65 variables which last value was set through SET PERSIST is equal to its global value.']
 
 ############################################################
 # 3. Test RESET PERSIST.
@@ -116,6 +117,7 @@ RESET PERSIST group_replication_bootstrap_group;
 RESET PERSIST group_replication_certification_loop_chunk_size;
 RESET PERSIST group_replication_certification_loop_sleep_time;
 RESET PERSIST group_replication_clone_threshold;
+RESET PERSIST group_replication_communication_debug_max_file_size;
 RESET PERSIST group_replication_communication_debug_options;
 RESET PERSIST group_replication_communication_max_message_size;
 RESET PERSIST group_replication_communication_stack;

--- a/mysql-test/suite/group_replication/r/gr_set_option_during_stop.result
+++ b/mysql-test/suite/group_replication/r/gr_set_option_during_stop.result
@@ -30,6 +30,7 @@ SELECT VARIABLE_NAME FROM performance_schema.global_variables
 WHERE VARIABLE_NAME LIKE 'group_replication_%'
  AND VARIABLE_NAME != 'group_replication_allow_local_lower_version_join'
  AND VARIABLE_NAME != 'group_replication_bootstrap_group'
+ AND VARIABLE_NAME != 'group_replication_communication_debug_max_file_size'
  AND VARIABLE_NAME != 'group_replication_communication_stack'
  AND VARIABLE_NAME != 'group_replication_consistency'
  AND VARIABLE_NAME != 'group_replication_exit_state_action'
@@ -187,6 +188,8 @@ SET @value= @@GLOBAL.group_replication_certification_loop_chunk_size;
 SET @@GLOBAL.group_replication_certification_loop_chunk_size= @value;
 SET @value= @@GLOBAL.group_replication_certification_loop_sleep_time;
 SET @@GLOBAL.group_replication_certification_loop_sleep_time= @value;
+SET @value= @@GLOBAL.group_replication_communication_debug_max_file_size;
+SET @@GLOBAL.group_replication_communication_debug_max_file_size= @value;
 SET @value= @@GLOBAL.group_replication_communication_stack;
 SET @@GLOBAL.group_replication_communication_stack= @value;
 SET @value= @@GLOBAL.group_replication_consistency;

--- a/mysql-test/suite/group_replication/r/gr_show_global_and_session_variables.result
+++ b/mysql-test/suite/group_replication/r/gr_show_global_and_session_variables.result
@@ -7,8 +7,8 @@ Note	####	Storing MySQL user name or password information in the connection meta
 include/start_and_bootstrap_group_replication.inc
 include/stop_group_replication.inc
 
-# Test#1: Basic check that there are 66 GR variables.
-include/assert.inc [There are 66 GR variables at present.]
+# Test#1: Basic check that there are 67 GR variables.
+include/assert.inc [There are 67 GR variables at present.]
 
 # Test#2: Verify group replication related variables at GLOBAL scope.
 SET @@SESSION.group_replication_allow_local_lower_version_join= 1;

--- a/mysql-test/suite/group_replication/r/gr_variables_default_values.result
+++ b/mysql-test/suite/group_replication/r/gr_variables_default_values.result
@@ -28,9 +28,9 @@ include/stop_group_replication.inc
 #
 # Test Unit#1
 # Set global/session group replication variables to default.
-# Curently there are 66 group replication variables.
+# Curently there are 67 group replication variables.
 #
-include/assert.inc [There are 66 GR variables at present.]
+include/assert.inc [There are 67 GR variables at present.]
 SET @@GLOBAL.group_replication_auto_increment_increment= default;
 ERROR 42000: Variable 'group_replication_auto_increment_increment' can't be set to the value of 'DEFAULT'
 SET @@GLOBAL.group_replication_compression_threshold= default;
@@ -118,6 +118,7 @@ include/assert.inc [Default group_replication_ssl_mode is DISABLED]
 include/assert.inc [Default group_replication_start_on_boot is ON/1]
 include/assert.inc [Default group_replication_transaction_size_limit is 150000000]
 include/assert.inc [Default group_replication_communication_debug_options is "GCS_DEBUG_NONE"]
+include/assert.inc [Default group_replication_communication_debug_max_file_size is 0]
 include/assert.inc [Default group_replication_unreachable_majority_timeout is 0]
 include/assert.inc [Default group_replication_member_weight is 50]
 include/assert.inc [Default group_replication_recovery_public_key_path is ""(EMPTY)]

--- a/mysql-test/suite/group_replication/r/gr_variables_privileges.result
+++ b/mysql-test/suite/group_replication/r/gr_variables_privileges.result
@@ -43,6 +43,8 @@ SET GLOBAL group_replication_certification_loop_sleep_time = @@GLOBAL.group_repl
 ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 SET GLOBAL group_replication_clone_threshold = @@GLOBAL.group_replication_clone_threshold;
 ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
+SET GLOBAL group_replication_communication_debug_max_file_size = @@GLOBAL.group_replication_communication_debug_max_file_size;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 SET GLOBAL group_replication_communication_debug_options = @@GLOBAL.group_replication_communication_debug_options;
 ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 SET GLOBAL group_replication_communication_max_message_size = @@GLOBAL.group_replication_communication_max_message_size;
@@ -182,6 +184,7 @@ SET GLOBAL group_replication_bootstrap_group = @@GLOBAL.group_replication_bootst
 SET GLOBAL group_replication_certification_loop_chunk_size = @@GLOBAL.group_replication_certification_loop_chunk_size;
 SET GLOBAL group_replication_certification_loop_sleep_time = @@GLOBAL.group_replication_certification_loop_sleep_time;
 SET GLOBAL group_replication_clone_threshold = @@GLOBAL.group_replication_clone_threshold;
+SET GLOBAL group_replication_communication_debug_max_file_size = @@GLOBAL.group_replication_communication_debug_max_file_size;
 SET GLOBAL group_replication_communication_debug_options = @@GLOBAL.group_replication_communication_debug_options;
 SET GLOBAL group_replication_communication_max_message_size = @@GLOBAL.group_replication_communication_max_message_size;
 SET GLOBAL group_replication_communication_stack = @@GLOBAL.group_replication_communication_stack;

--- a/mysql-test/suite/group_replication/t/gr_gcs_debug_trace_auto_rotation.test
+++ b/mysql-test/suite/group_replication/t/gr_gcs_debug_trace_auto_rotation.test
@@ -1,0 +1,168 @@
+################################################################################
+#
+# This test confirms AUTOMATIC rotation of the GCS_DEBUG_TRACE file.
+#
+# When group_replication_communication_debug_max_file_size > 0:
+#   - Every file (including the first) gets a timestamp in its name:
+#       GCS_DEBUG_TRACE.YYYYMMDDTHHMMSS (UTC)
+#   - Rotation creates a new timestamped file; the old file is left in place
+#     (no archiving/renaming -- same model as binary logs).
+#   - Each START GROUP_REPLICATION also opens a fresh timestamped file.
+#
+# Test steps:
+#   1. Set communication_debug_max_file_size and start GR.
+#      Trace file with timestamp are created.
+#   2. Size-based rotation: old file stays, new timestamped file appears.
+#   3. Restart Group Replication: another new timestamped file is created.
+#   4. Group Replication is ONLINE.
+#   5. Cleanup.
+################################################################################
+
+--source include/have_group_replication_plugin.inc
+--let $rpl_skip_group_replication_start= 1
+--source include/group_replication.inc
+
+--connection server1
+
+--echo
+--echo # 1. Set communication_debug_max_file_size and start GR.
+--echo #    Trace file with timestamp are created.
+
+--error 0,1
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/GCS_DEBUG_TRACE
+SET GLOBAL group_replication_communication_debug_max_file_size = 200;
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_ALL";
+--source include/start_and_bootstrap_group_replication.inc
+
+# Confirm file with timestamp was created.
+perl;
+  use strict;
+  use File::Glob ':glob';
+  my $dir = "$ENV{MYSQLTEST_VARDIR}/mysqld.1/data";
+  my $deadline = time() + 30;
+  my @files;
+  while (time() < $deadline) {
+    @files = bsd_glob("$dir/GCS_DEBUG_TRACE.[0-9]*");
+    last if @files;
+    select(undef, undef, undef, 0.5);
+  }
+  die "ERROR: no timestamped GCS_DEBUG_TRACE.* file appeared within 30s\n"
+      unless @files;
+  print "Initial trace file is timestamped, as expected\n";
+
+  die "ERROR: plain GCS_DEBUG_TRACE must not be created when max_file_size > 0\n"
+      if -f "$dir/GCS_DEBUG_TRACE";
+  print "No plain GCS_DEBUG_TRACE created, as expected\n";
+
+  # Save first file path for step 2
+  my $out = "$ENV{MYSQLTEST_VARDIR}/tmp/gcs_first_file.txt";
+  open(my $fh, '>', $out) or die "Cannot write $out: $!\n";
+  print $fh $files[0] . "\n";
+  close $fh;
+EOF
+
+--echo
+--echo # 2. Size-based rotation: old file stays, new timestamped file created.
+
+# Confirm some new trace file was created due to rotation.
+perl;
+  use strict;
+  use File::Glob ':glob';
+  my $dir = "$ENV{MYSQLTEST_VARDIR}/mysqld.1/data";
+
+  # Retrieve first file saved in step 1
+  my $in = "$ENV{MYSQLTEST_VARDIR}/tmp/gcs_first_file.txt";
+  open(my $fh, '<', $in) or die "Cannot open $in: $!\n";
+  my $first_file = <$fh>;
+  chomp $first_file;
+  close $fh;
+
+  # Wait for a second timestamped file (rotation at 200-byte threshold)
+  my $deadline = time() + 30;
+  my @files;
+  while (time() < $deadline) {
+    @files = bsd_glob("$dir/GCS_DEBUG_TRACE.[0-9]*");
+    last if scalar(@files) >= 2;
+    select(undef, undef, undef, 0.5);
+  }
+  die "ERROR: size-based rotation did not produce a second file within 30s\n"
+      unless scalar(@files) >= 2;
+  print "Size-based rotation created a new timestamped file, as expected\n";
+
+  # Old file must still be present -- no archiving or renaming
+  die "ERROR: original file '$first_file' was removed after rotation " .
+      "(archiving must not happen)\n"
+      unless -f $first_file;
+  print "Original file still exists after rotation (no archiving), as expected\n";
+EOF
+
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_NONE";
+
+--echo
+--echo # 3. Restart Group Replication -- a new timestamped file is created on start.
+
+# Not number of files before restart
+perl;
+  use strict;
+  use File::Glob ':glob';
+  my $dir = "$ENV{MYSQLTEST_VARDIR}/mysqld.1/data";
+  my @files = bsd_glob("$dir/GCS_DEBUG_TRACE.[0-9]*");
+  my $out = "$ENV{MYSQLTEST_VARDIR}/tmp/gcs_count_before_restart.txt";
+  open(my $fh, '>', $out) or die "Cannot write $out: $!\n";
+  print $fh scalar(@files) . "\n";
+  close $fh;
+  print "Recorded file count before restart\n";
+EOF
+
+--source include/stop_group_replication.inc
+--source include/start_and_bootstrap_group_replication.inc
+
+# Confirm more GCS_DEBUG_TRACE.* file exists post restart
+perl;
+  use strict;
+  use File::Glob ':glob';
+  my $in = "$ENV{MYSQLTEST_VARDIR}/tmp/gcs_count_before_restart.txt";
+  open(my $fh, '<', $in) or die "Cannot open $in: $!\n";
+  my $before = int(<$fh>);
+  close $fh;
+
+  my $dir = "$ENV{MYSQLTEST_VARDIR}/mysqld.1/data";
+  my $deadline = time() + 30;
+  my @files;
+  while (time() < $deadline) {
+    @files = bsd_glob("$dir/GCS_DEBUG_TRACE.[0-9]*");
+    last if scalar(@files) > $before;
+    select(undef, undef, undef, 0.5);
+  }
+  die "ERROR: expected a new timestamped file on GR restart " .
+      "(before=$before, after=" . scalar(@files) . ")\n"
+      unless scalar(@files) > $before;
+  print "New timestamped file created on GR restart, as expected\n";
+EOF
+
+--echo
+--echo # 4. Group Replication is ONLINE.
+
+--let $assert_text= Member is ONLINE after automatic rotation
+--let $assert_cond= COUNT(*) = 1 FROM performance_schema.replication_group_members WHERE MEMBER_STATE = "ONLINE"
+--source include/assert.inc
+
+--echo
+--echo # 5. Cleanup.
+
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_NONE";
+SET GLOBAL group_replication_communication_debug_max_file_size = 0;
+--source include/stop_group_replication.inc
+perl;
+  use strict;
+  use File::Glob ':glob';
+  my $dir = "$ENV{MYSQLTEST_VARDIR}/mysqld.1/data";
+  for my $f (bsd_glob("$dir/GCS_DEBUG_TRACE*")) {
+    unlink $f or warn "Could not remove $f: $!\n";
+  }
+  unlink "$ENV{MYSQLTEST_VARDIR}/tmp/gcs_first_file.txt";
+  unlink "$ENV{MYSQLTEST_VARDIR}/tmp/gcs_count_before_restart.txt";
+  print "Cleanup complete\n";
+EOF
+
+--source include/group_replication_end.inc

--- a/mysql-test/suite/group_replication/t/gr_gcs_debug_trace_reopen.test
+++ b/mysql-test/suite/group_replication/t/gr_gcs_debug_trace_reopen.test
@@ -1,0 +1,63 @@
+################################################################################
+#
+# This test case proves that when GCS_DEBUG_TRACE is moved or deleted while the
+# fd is open, subsequent writes go to the newly created file.
+#
+# Test steps:
+#   1. Start Group Replication.
+#   2. Enable GCS_DEBUG_ALL tracing.
+#   3. Remove GCS_DEBUG_TRACE.
+#   4. Wait for stat auto-detection -- GCS_DEBUG_TRACE must reappear
+#   5. Group Replication is ONLINE.
+#   6. Cleanup.
+################################################################################
+
+--source include/have_group_replication_plugin.inc
+--let $rpl_skip_group_replication_start= 1
+--source include/group_replication.inc
+
+--connection server1
+
+--echo
+--echo # 1. Start Group Replication.
+
+--error 0,1
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/GCS_DEBUG_TRACE
+
+--source include/start_and_bootstrap_group_replication.inc
+
+--echo
+--echo # 2. Enable GCS_DEBUG_ALL tracing.
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_ALL";
+--let $wait_condition = SELECT LENGTH(LOAD_FILE(CONCAT(@@datadir, 'GCS_DEBUG_TRACE'))) > 0
+--source include/wait_condition.inc
+
+--echo
+--echo # 3. Remove GCS_DEBUG_TRACE.
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/GCS_DEBUG_TRACE
+
+--echo
+--echo # 4. Wait for stat auto-detection -- GCS_DEBUG_TRACE must reappear
+
+# Wait for GCS_DEBUG_TRACE re-creation and logs to be written.
+--let $wait_condition = SELECT LENGTH(LOAD_FILE(CONCAT(@@datadir, 'GCS_DEBUG_TRACE'))) > 0
+--source include/wait_condition.inc
+
+--file_exists $MYSQLTEST_VARDIR/mysqld.1/data/GCS_DEBUG_TRACE
+
+--echo
+--echo # 5. Group Replication is ONLINE.
+
+--let $assert_text= Member is ONLINE after stale-fd detection and reopen
+--let $assert_cond= COUNT(*) = 1 FROM performance_schema.replication_group_members WHERE MEMBER_STATE = "ONLINE"
+--source include/assert.inc
+
+--echo
+--echo # 6. cleanup
+
+SET GLOBAL group_replication_communication_debug_options = "GCS_DEBUG_NONE";
+--source include/stop_group_replication.inc
+
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/GCS_DEBUG_TRACE
+
+--source include/group_replication_end.inc

--- a/mysql-test/suite/group_replication/t/gr_set_option_during_stop.test
+++ b/mysql-test/suite/group_replication/t/gr_set_option_during_stop.test
@@ -63,6 +63,7 @@ INSERT INTO gr_options_that_cannot_be_change (name)
  WHERE VARIABLE_NAME LIKE 'group_replication_%'
  AND VARIABLE_NAME != 'group_replication_allow_local_lower_version_join'
  AND VARIABLE_NAME != 'group_replication_bootstrap_group'
+ AND VARIABLE_NAME != 'group_replication_communication_debug_max_file_size'
  AND VARIABLE_NAME != 'group_replication_communication_stack'
  AND VARIABLE_NAME != 'group_replication_consistency'
  AND VARIABLE_NAME != 'group_replication_exit_state_action'

--- a/mysql-test/suite/group_replication/t/gr_show_global_and_session_variables.test
+++ b/mysql-test/suite/group_replication/t/gr_show_global_and_session_variables.test
@@ -30,7 +30,7 @@
 --source include/start_and_bootstrap_group_replication.inc
 --source include/stop_group_replication.inc
 
---let $gr_var_count= 66
+--let $gr_var_count= 67
 
 --echo
 --echo # Test#1: Basic check that there are $gr_var_count GR variables.

--- a/mysql-test/suite/group_replication/t/gr_variables_default_values.test
+++ b/mysql-test/suite/group_replication/t/gr_variables_default_values.test
@@ -96,7 +96,7 @@ SET @@GLOBAL.group_replication_preemptive_garbage_collection = default;
 --let $saved_gr_xcom_ssl_accept_retries = `SELECT @@GLOBAL.group_replication_xcom_ssl_accept_retries;`
 
 # Total number of GR variables.
---let $total_gr_vars= 66
+--let $total_gr_vars= 67
 
 --echo #
 --echo # Test Unit#1
@@ -301,6 +301,11 @@ SET @@SESSION.group_replication_consistency= default;
 # group_replication_communication_debug_options
 --let $assert_text= Default group_replication_communication_debug_options is "GCS_DEBUG_NONE"
 --let $assert_cond= "[SELECT @@GLOBAL.group_replication_communication_debug_options]" = "GCS_DEBUG_NONE"
+--source include/assert.inc
+
+# group_replication_communication_debug_max_file_size
+--let $assert_text= Default group_replication_communication_debug_max_file_size is 0
+--let $assert_cond= "[SELECT @@GLOBAL.group_replication_communication_debug_max_file_size]" = 0
 --source include/assert.inc
 
 # group_replication_unreachable_majority_timeout

--- a/plugin/group_replication/include/plugin_variables.h
+++ b/plugin/group_replication/include/plugin_variables.h
@@ -261,6 +261,11 @@ struct plugin_options_variables {
 
   char *communication_debug_options_var;
 
+#define DEFAULT_COMMUNICATION_DEBUG_MAX_FILE_SIZE 0UL
+#define MIN_COMMUNICATION_DEBUG_MAX_FILE_SIZE 0UL
+#define MAX_COMMUNICATION_DEBUG_MAX_FILE_SIZE ~0UL
+  ulong communication_debug_max_file_size_var;
+
   const char *exit_state_actions[4] = {"READ_ONLY", "ABORT_SERVER",
                                        "OFFLINE_MODE", (char *)nullptr};
   TYPELIB exit_state_actions_typelib_t = {3, "exit_state_actions_typelib_t",

--- a/plugin/group_replication/libmysqlgcs/include/mysql/gcs/gcs_logging_system.h
+++ b/plugin/group_replication/libmysqlgcs/include/mysql/gcs/gcs_logging_system.h
@@ -835,6 +835,85 @@ class Gcs_file_sink : public Sink_interface {
   */
   Gcs_file_sink(Gcs_file_sink &d);
   Gcs_file_sink &operator=(const Gcs_file_sink &d);
+
+  /*
+    Full path of the currently open trace file. Updated on every
+    initialize/rotate/reopen so stale-fd detection checks the right path.
+  */
+  std::string m_current_path;
+  /*
+    Open a new timestamped file (e.g. gcs_debug_trace.log.20260706T165057)
+    and switch m_fd to it. Needed for size-based rotation.
+    The old file is not deleted similar to binlog.
+
+    @note Do not call during fd error like disk full etc. Existing file
+    descriptors are not closed if reopen fails, so user can continue to
+    write to existing fd. If reopen is successful existing fd are closed.
+    @note Manual deletion of logs is needed.
+
+    @retval GCS_OK  new file is open; m_current_path updated.
+    @retval GCS_NOK could not open the new file; old fd remains valid.
+  */
+  enum_gcs_error rotate();
+
+  /*
+    Same as rotate(): open a new timestamped file and switch m_fd to it.
+    Called when the current file was moved or deleted externally.
+
+    @refer rotate(), notes have been added in rotate, same applicable here
+
+    @retval GCS_OK  new file is open; m_current_path updated.
+    @retval GCS_NOK could not open/create the file; old fd remains valid.
+  */
+  enum_gcs_error reopen();
+
+  /*
+    Maximum size, in bytes, of the file before it is automatically rotated.
+    0 disables size-based rotation.
+    Static to avoid major changes to class like constructor param,
+    initialization etc.
+  */
+  static size_t m_max_file_size;
+
+  /*
+    Bytes written to the current file since it was last opened or rotated.
+  */
+  size_t m_current_file_size{0};
+
+  /*
+    Timestamp, in microseconds, of the last stale-file check.
+  */
+  ulonglong m_last_stat_check_time{0};
+
+  /*
+    Minimum time, in microseconds, between two stale-file checks. The check
+    costs two syscalls (my_stat on the path + my_fstat on the fd), so running
+    it on every trace line is wasteful.
+  */
+  static constexpr ulonglong STAT_CHECK_INTERVAL_US = 100ULL * 1000ULL;
+
+  /* Returns true if enough time elapsed to run the stale-file check again. */
+  bool should_check_file();
+
+  /*
+    Timestamp, in microseconds, when the most recent rotation error was written
+    to the error log. A value of zero means that no error has been logged yet.
+  */
+  ulonglong m_last_logged_error_time{0};
+
+  /*
+    Minimum time, in microseconds, between rotation error messages.
+  */
+  static constexpr ulonglong ERROR_LOG_INTERVAL_US = 1ULL * 1000ULL * 1000ULL;
+
+  /* Returns true if time has elapsed to log another error. */
+  bool should_log_error();
+
+ public:
+  /* @refer m_max_file_size above */
+  static void set_max_debug_file_size(size_t file_size) {
+    m_max_file_size = file_size;
+  }
 };
 #endif /* XCOM_STANDALONE */
 

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_interface.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_interface.cc
@@ -331,6 +331,32 @@ enum_gcs_error Gcs_xcom_interface::initialize(
   m_wait_for_ssl_init_cond.init(
       key_GCS_COND_Gcs_xcom_interface_m_wait_for_ssl_init_cond);
 
+#ifndef XCOM_STANDALONE
+  {
+    /*
+     Either we can modify the constructors of Gcs_file_sink and pass the
+     parameters initialize_logging or we need to init set_max_debug_file_size
+     first before the log file is created.
+     Otherwise first log file will always be GCS_DEBUG_TRACE (without
+     timestamp) since set_max_debug_file_size has not been called yet, which
+     is not a big issue, but we can initialize
+     communication_debug_max_file_size first.
+    */
+    const std::string *debug_max_file_size =
+        interface_params.get_parameter("communication_debug_max_file_size");
+    if (debug_max_file_size != nullptr && !debug_max_file_size->empty()) {
+      try {
+        // This should not fail since debug_max_file_size is originally long
+        ulong max_file_size = std::stoul(*debug_max_file_size);
+        Gcs_file_sink::set_max_debug_file_size(max_file_size);
+      } catch (const std::exception &) {
+        MYSQL_GCS_LOG_ERROR(
+            "Failed to initialize GCS_DEBUG_TRACE log rotation. Could not read "
+            "parameter communication_debug_max_file_size.");
+      }
+    }
+  }
+#endif
   /*
     Initialize logging sub-systems.
   */

--- a/plugin/group_replication/libmysqlgcs/src/interface/gcs_logging_system.cc
+++ b/plugin/group_replication/libmysqlgcs/src/interface/gcs_logging_system.cc
@@ -37,9 +37,12 @@
 #include "my_dir.h"
 #include "my_io.h"
 #include "my_sys.h"
+#include "my_systime.h"
 #endif /* XCOM_STANDALONE */
 
 #include "plugin/group_replication/libmysqlgcs/include/mysql/gcs/gcs_logging_system.h"
+
+size_t Gcs_file_sink::m_max_file_size = 0;
 
 void *consumer_function(void *ptr);
 
@@ -343,6 +346,65 @@ enum_gcs_error Gcs_default_debugger::finalize() { return m_sink->finalize(); }
 Gcs_default_debugger *Gcs_debug_manager::m_debugger = nullptr;
 
 #ifndef XCOM_STANDALONE
+
+/*
+  Generate a conflict-safe rotation name for the active trace file.
+  Form: <base>.YYYYMMDDTHHMMSS (UTC).
+  If the timestamped file already exists:
+    <base>.YYYYMMDDTHHMMSS.1, <base>.YYYYMMDDTHHMMSS.2, ...
+    up to .1000
+
+  If timestamp generation fails:
+    <base>.1, <base>.2, ...
+    up to .1000
+
+  @note Entire usage of gcs_generate_rotated_name is inside XCOM_STANDALONE.
+
+  @returns
+    0: on success and sets out_path;
+    1: if all 1000 names are taken.
+*/
+static int gcs_generate_rotated_name(const std::string &base_name,
+                                     std::string &out_path) {
+  char ts_buf[32];
+  std::string rotation_base = base_name;
+  MY_STAT st_buf;
+
+  const unsigned long long us = my_micro_time();
+  const time_t sec = static_cast<time_t>(us / 1000000);
+
+  struct tm tm_info;
+  if (gmtime_r(&sec, &tm_info) != nullptr) {
+    const int len =
+        snprintf(ts_buf, sizeof(ts_buf), "%04d%02d%02dT%02d%02d%02d",
+                 tm_info.tm_year + 1900, tm_info.tm_mon + 1, tm_info.tm_mday,
+                 tm_info.tm_hour, tm_info.tm_min, tm_info.tm_sec);
+
+    if (len >= 0 && static_cast<size_t>(len) < sizeof(ts_buf)) {
+      rotation_base += ".";
+      rotation_base += ts_buf;
+    }
+  }
+  if (my_stat(rotation_base.c_str(), &st_buf, MYF(0)) == nullptr) {
+    out_path = rotation_base;
+    return 0;
+  }
+
+  for (int n = 1; n <= 1000; ++n) {
+    std::string candidate = rotation_base + "." + std::to_string(n);
+
+    if (my_stat(candidate.c_str(), &st_buf, MYF(0)) == nullptr) {
+      out_path = candidate;
+      return 0;
+    }
+  }
+
+  MYSQL_GCS_LOG_ERROR("GCS debug trace: all rotation names for '"
+                      << rotation_base.c_str()
+                      << "' are taken. Cannot rotate.");
+  return 1;
+}
+
 Gcs_file_sink::Gcs_file_sink(const std::string &file_name,
                              const std::string &dir_name)
     : m_fd(0),
@@ -402,6 +464,18 @@ enum_gcs_error Gcs_file_sink::initialize() {
       return GCS_NOK;
     }
   }
+  /*
+    If size-based rotation is enabled, open a new timestamped file so each
+    GR run is cleanly separated.
+  */
+  if (m_max_file_size > 0) {
+    std::string new_name;
+    if (gcs_generate_rotated_name(file_name_buffer, new_name) == 0) {
+      strncpy(file_name_buffer, new_name.c_str(), FN_REFLEN - 1);
+      file_name_buffer[FN_REFLEN - 1] = '\0';
+    }
+    /* If name generation fails fall through and open canonical (appends). */
+  }
 
   if ((m_fd = my_create(file_name_buffer, 0640, O_CREAT | O_WRONLY | O_APPEND,
                         MYF(0))) < 0) {
@@ -416,6 +490,8 @@ enum_gcs_error Gcs_file_sink::initialize() {
     return GCS_NOK;
   }
 
+  m_current_path = file_name_buffer;
+  m_current_file_size = 0;
   m_initialized = true;
 
   return GCS_OK;
@@ -432,6 +508,131 @@ enum_gcs_error Gcs_file_sink::finalize() {
   return GCS_OK;
 }
 
+bool Gcs_file_sink::should_log_error() {
+  const ulonglong now = my_micro_time();
+  if (now - m_last_logged_error_time < ERROR_LOG_INTERVAL_US) {
+    return false;
+  }
+  m_last_logged_error_time = now;
+  return true;
+}
+
+bool Gcs_file_sink::should_check_file() {
+  const ulonglong now = my_micro_time();
+  if (now - m_last_stat_check_time < STAT_CHECK_INTERVAL_US) {
+    return false;
+  }
+  m_last_stat_check_time = now;
+  return true;
+}
+
+/*
+  Since reopen() is called only when file is renamed/deleted, there is no need
+  to suppress logging to avoid flooding since stats itself is controlled by
+  should_check_file().
+*/
+enum_gcs_error Gcs_file_sink::reopen() {
+  if (!m_initialized) return GCS_OK;
+  char file_name_buffer[FN_REFLEN];
+
+  if (get_file_name(file_name_buffer)) {
+    MYSQL_GCS_LOG_ERROR("GCS debug trace reopen: error validating file name '"
+                        << m_file_name << "'.");
+    return GCS_NOK;
+  }
+
+  std::string new_name = file_name_buffer;
+  if (m_max_file_size > 0) {
+    if (gcs_generate_rotated_name(file_name_buffer, new_name) != 0) {
+      MYSQL_GCS_LOG_ERROR(
+          "GCS debug trace reopen: could not generate new file "
+          "name for '"
+          << file_name_buffer << "'.");
+      return GCS_NOK;
+    }
+  }
+
+  File new_fd =
+      my_create(new_name.c_str(), 0640, O_CREAT | O_WRONLY | O_APPEND, MYF(0));
+  /*
+    We have not closed existing file descriptors, so even if my_create fails
+    call to existing fd are still safe. write continues to write to detached
+    file descriptor without any error.
+    We keep the old fd active in case of error.
+   */
+  if (new_fd < 0) {
+    int errno_gcs = 0;
+#if defined(_WIN32)
+    errno_gcs = WSAGetLastError();
+#else
+    errno_gcs = errno;
+#endif
+    MYSQL_GCS_LOG_ERROR("GCS debug trace reopen: error opening file '"
+                        << new_name.c_str() << "': " << strerror(errno_gcs)
+                        << ".");
+    return GCS_NOK;
+  }
+
+  /* ignore any error, we have new FD */
+  my_sync(m_fd, MYF(0));
+  my_close(m_fd, MYF(0));
+  m_fd = new_fd;
+  m_current_path = new_name;
+  m_initialized = true;
+  m_current_file_size = 0;
+
+  return GCS_OK;
+}
+
+enum_gcs_error Gcs_file_sink::rotate() {
+  if (!m_initialized) return GCS_OK;
+  char file_name_buffer[FN_REFLEN];
+
+  if (get_file_name(file_name_buffer)) {
+    if (should_log_error()) {
+      MYSQL_GCS_LOG_ERROR("GCS debug trace rotate: error validating file name '"
+                          << m_file_name << "'.");
+    }
+    return GCS_NOK;
+  }
+
+  std::string new_name = file_name_buffer;
+  if (gcs_generate_rotated_name(file_name_buffer, new_name) != 0) {
+    if (should_log_error()) {
+      MYSQL_GCS_LOG_ERROR(
+          "GCS debug trace rotate: could not generate new file "
+          "name for '"
+          << file_name_buffer << "'.");
+    }
+    return GCS_NOK;
+  }
+
+  File new_fd =
+      my_create(new_name.c_str(), 0640, O_CREAT | O_WRONLY | O_APPEND, MYF(0));
+  if (new_fd < 0) {
+    int errno_gcs = 0;
+#if defined(_WIN32)
+    errno_gcs = WSAGetLastError();
+#else
+    errno_gcs = errno;
+#endif
+    if (should_log_error()) {
+      MYSQL_GCS_LOG_ERROR("GCS debug trace rotate: error opening new file '"
+                          << new_name << "': " << strerror(errno_gcs) << ".");
+    }
+    return GCS_NOK;
+  }
+
+  my_sync(m_fd, MYF(0));
+  my_close(m_fd, MYF(0));
+  m_fd = new_fd;
+  m_current_path = new_name;
+  m_initialized = true;
+  m_current_file_size = 0;
+
+  return GCS_OK;
+}
+
 void Gcs_file_sink::log_event(const std::string &message) {
   log_event(message.c_str(), message.length());
 }
@@ -440,6 +641,30 @@ void Gcs_file_sink::log_event(const char *message, size_t message_size) {
   size_t written;
 
   written = my_write(m_fd, (const uchar *)message, message_size, MYF(0));
+
+  if (written != MY_FILE_ERROR) {
+    m_current_file_size += written;
+    if (m_max_file_size > 0 && m_current_file_size >= m_max_file_size) {
+      rotate();
+    } else if (should_check_file()) {
+      /*
+        Check if the current trace file was moved or deleted.
+        It was noted when the trace file was moved/deleted, no debug trace
+        was later generated in the session.
+
+        Note: the check is done after the write (and only once per
+        should_check_file() interval), so if the file is removed between our
+        write and this check, the line just written goes to the orphaned inode
+        and some logs are lost until reopen() creates a new file.
+      */
+      MY_STAT path_st, fd_st;
+      bool path_gone =
+          (my_stat(m_current_path.c_str(), &path_st, MYF(0)) == nullptr);
+      bool ino_changed = !path_gone && my_fstat(m_fd, &fd_st) == 0 &&
+                         path_st.st_ino != fd_st.st_ino;
+      if (path_gone || ino_changed) reopen();
+    }
+  }
 
   if (written == MY_FILE_ERROR) {
     int errno_gcs = 0;
@@ -455,12 +680,15 @@ void Gcs_file_sink::log_event(const char *message, size_t message_size) {
 
 const std::string Gcs_file_sink::get_information() const {
   std::string invalid("invalid");
-  char file_name_buffer[FN_REFLEN];
 
   if (!m_initialized) return invalid;
-
-  if (get_file_name(file_name_buffer)) return invalid;
-
-  return std::string(file_name_buffer);
+  /*
+    Although m_current_path can now be mutated from a different thread by
+    rotate()/reopen() during logging, it is safe to read it here without a
+    mutex: get_information() is only called from the initialization path (see
+    Gcs_xcom_interface::initialize_logging), before any concurrent logging
+    thread can rotate/reopen the file.
+  */
+  return std::string(m_current_path);
 }
 #endif /* XCOM_STANDALONE */

--- a/plugin/group_replication/src/plugin.cc
+++ b/plugin/group_replication/src/plugin.cc
@@ -2750,6 +2750,17 @@ int build_gcs_parameters(Gcs_interface_parameters &gcs_module_parameters) {
   gcs_module_parameters.add_parameter("communication_debug_path",
                                       mysql_real_data_home);
 
+  /*
+    Maximum size, in bytes, of the GCS debug trace file before it is
+    automatically rotated. 0 disables size-based rotation. Read once here,
+    at Group Replication start -- like communication_debug_file/_path above.
+
+    @note changing this sysvar takes effect at the next Group Replication start
+  */
+  gcs_module_parameters.add_parameter(
+      "communication_debug_max_file_size",
+      std::to_string(ov.communication_debug_max_file_size_var));
+
   sv.deinit();
   return result;
 }
@@ -4970,6 +4981,21 @@ static MYSQL_SYSVAR_STR(
     "GCS_DEBUG_NONE"                   /* default */
 );
 
+static MYSQL_SYSVAR_ULONG(
+    communication_debug_max_file_size,                     /* name */
+    ov.communication_debug_max_file_size_var,              /* var */
+    PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_PERSIST_AS_READ_ONLY, /* optional var */
+    "Maximum size, in bytes, of the GCS debug trace file (GCS_DEBUG_TRACE) "
+    "before it is automatically rotated. 0 disables size-based rotation. "
+    "Takes effect at the next Group Replication start.",
+    nullptr,                                   /* check func. */
+    nullptr,                                   /* update func. */
+    DEFAULT_COMMUNICATION_DEBUG_MAX_FILE_SIZE, /* default */
+    MIN_COMMUNICATION_DEBUG_MAX_FILE_SIZE,     /* min */
+    MAX_COMMUNICATION_DEBUG_MAX_FILE_SIZE,     /* max */
+    0                                          /* block */
+);
+
 static MYSQL_SYSVAR_ENUM(exit_state_action,        /* name */
                          ov.exit_state_action_var, /* var */
                          PLUGIN_VAR_OPCMDARG |
@@ -5470,6 +5496,7 @@ static SYS_VAR *group_replication_system_vars[] = {
     MYSQL_SYSVAR(flow_control_applier_threshold),
     MYSQL_SYSVAR(transaction_size_limit),
     MYSQL_SYSVAR(communication_debug_options),
+    MYSQL_SYSVAR(communication_debug_max_file_size),
     MYSQL_SYSVAR(exit_state_action),
     MYSQL_SYSVAR(autorejoin_tries),
     MYSQL_SYSVAR(unreachable_majority_timeout),


### PR DESCRIPTION
…restarting replication

https://perconadev.atlassian.net/browse/PS-11217

Problem 1:
Group Replication's GCS_DEBUG_TRACE file descriptor was opened once and never revisited. So, if an operator externally moved or removed the file output kept going to the stale/detached file descriptor with no error reported. The only fix was a full Group Replication restart.

Problem 2:
GCS_DEBUG_TRACE are always written to a same file, which mean file can grow huge and logs of all MySQL sessions are written in a same file, no automatic rotation of logs is available.

Resolution:
stats the GCS_DEBUG_TRACE on every write (O(1) syscall). If the file is gone (moved/deleted) reopen the file.

Log Rotation:
Size-based: new sysvar group_replication_communication_debug_max_file_size (bytes, default 0 = disabled) caps the trace file size, like max_binlog_size.
Additinally timestamp is added to the file name that can help in opening the right log file if huge logs are generated.
Similarly during every START GROUP_REPLICATION logs will be written to a new trace file.