### PR TITLE
PS-11413 [8.4] Improve the json error handling and logging of OIDC co…

### DIFF
--- a/mysql-test/suite/auth_openid_connect/r/auth.result
+++ b/mysql-test/suite/auth_openid_connect/r/auth.result
@@ -17,6 +17,7 @@ mysql_oidc_user@localhost	mysql_oidc_user@%
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'invalid sysvar prefix");
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'invalid value for system variable'");
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'cannot open config file:");
+CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'extra content after correct JSON document'");
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'syntax error");
 SET GLOBAL auth_openid_connect_configuration = 'INVD://';
 ERROR 42000: Variable 'auth_openid_connect_configuration' can't be set to the value of 'INVD://'
@@ -24,6 +25,8 @@ SET GLOBAL auth_openid_connect_configuration = 'JSON://{"invalid"[}';
 ERROR 42000: Variable 'auth_openid_connect_configuration' can't be set to the value of 'JSON://{"invalid"[}'
 SET GLOBAL auth_openid_connect_configuration = 'FILE://nonexistent_path/nonexistent_file.json';
 ERROR 42000: Variable 'auth_openid_connect_configuration' can't be set to the value of 'FILE://nonexistent_path/nonexistent_file.json'
+SET GLOBAL auth_openid_connect_configuration = 'JSON://{"oidc-idp": {"issuer-name": "https://idp-test.com/realms/dummy", "keys": [{"kid": "rsa-key-1", "kty": "RSA", "n": "ptR4YxjdrF2RrYiY9XYH3KcXKzlS6b2foGAeHN9dViAs5yKStKAucUf81kszq6LkzkOOPX5SbToLBRv5wwOtrBLKVkqhw4i5kS0b-7jpR9g7lER3qfDVYfe0nneaJzc-1Iz6id0oVj4ay8lGmWg5JX5Z8nBs52_7rfDIBtyAsyIQ2dF2tW4e72cypvskw_TwdbsqelY5ZezzTmKx8Ra4-o9Pu5_Vxe1Hhlkx1K_tfbGH9ZUsbFy90b0Vcw5w6EKPEkM9mZTUoj8TMeHTHaiOREK4llIJ6hokXbEG8BsKJuMuYrzx98e23JkaWaWQY27LUGK5sx-lsX_n8DO2kEASRw", "e": "AQAB", "use": "sig", "alg": "RS256"}], "audiences": ["ee2811b9-10b8","https://api.example.com"]}} , {"oidc-idp": {"issuer-name":"name"}}';
+ERROR 42000: Variable 'auth_openid_connect_configuration' can't be set to the value of 'JSON://{"oidc-idp": {"issuer-name": "https://idp-test.com/realms/dummy", "keys": [{"kid": "rsa-key-1", "kty": "RSA", "n": "ptR4YxjdrF2RrYiY9XYH3KcXKzlS6b2foGAeHN9dViAs5yKStKAucUf81kszq6LkzkOOPX5SbToLB'
 SET GLOBAL auth_openid_connect_configuration = 'JSON://{}';
 
 ### Client side validations (FR.5)

--- a/mysql-test/suite/auth_openid_connect/t/auth.test
+++ b/mysql-test/suite/auth_openid_connect/t/auth.test
@@ -49,6 +49,7 @@ CREATE USER mysql_oidc_user IDENTIFIED WITH 'auth_openid_connect' AS '{"identity
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'invalid sysvar prefix");
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'invalid value for system variable'");
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'cannot open config file:");
+CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'extra content after correct JSON document'");
 CALL mtr.add_suppression("Plugin auth_openid_connect reported: 'syntax error");
 
 # invalid prefix, expect error
@@ -63,10 +64,15 @@ SET GLOBAL auth_openid_connect_configuration = 'JSON://{"invalid"[}';
 --error ER_WRONG_VALUE_FOR_VAR
 SET GLOBAL auth_openid_connect_configuration = 'FILE://nonexistent_path/nonexistent_file.json';
 
+# valid JSON + extra non-parsed element at the end
+--error ER_WRONG_VALUE_FOR_VAR
+--eval SET GLOBAL auth_openid_connect_configuration = '$CONFIG_JSON , {\"oidc-idp\": {\"issuer-name\":\"name\"}}'
+
 # valid JSON, but missing the configuration inside, expect error on connection
 SET GLOBAL auth_openid_connect_configuration = 'JSON://{}';
 --error 1
 --exec $MYSQL $MYSQL_OIDC_USER
+
 
 #####################################
 --echo

--- a/mysql-test/suite/auth_openid_connect/t/group_role.test
+++ b/mysql-test/suite/auth_openid_connect/t/group_role.test
@@ -7,7 +7,6 @@ if ($CREATE_ID_TOKEN == "")
 
 --echo ### INITIALIZE TESTS
 --let $CONFIG_FILE = FILE://$MYSQL_TEST_DIR/std_data/oidc/dummy_oidc_conf.json
---let $CONFIG_JSON = JSON://{\"oidc-idp\": {\"issuer-name\": \"https://idp-test.com/realms/dummy\", \"keys\": [{\"kid\": \"rsa-key-1\", \"kty\": \"RSA\", \"n\": \"ptR4YxjdrF2RrYiY9XYH3KcXKzlS6b2foGAeHN9dViAs5yKStKAucUf81kszq6LkzkOOPX5SbToLBRv5wwOtrBLKVkqhw4i5kS0b-7jpR9g7lER3qfDVYfe0nneaJzc-1Iz6id0oVj4ay8lGmWg5JX5Z8nBs52_7rfDIBtyAsyIQ2dF2tW4e72cypvskw_TwdbsqelY5ZezzTmKx8Ra4-o9Pu5_Vxe1Hhlkx1K_tfbGH9ZUsbFy90b0Vcw5w6EKPEkM9mZTUoj8TMeHTHaiOREK4llIJ6hokXbEG8BsKJuMuYrzx98e23JkaWaWQY27LUGK5sx-lsX_n8DO2kEASRw\", \"e\": \"AQAB\", \"use\": \"sig\", \"alg\": \"RS256\"}], \"audiences\": [\"ee2811b9-10b8\",\"https://api.example.com\"]}}
 --let $TOKEN_FILE = $MYSQLTEST_VARDIR/tmp/id_token.txt
 --let $COMMON_TOKEN_ARGS = --key $MYSQL_TEST_DIR/std_data/oidc/idp_private.pem --sub oidc-user --iss https://idp-test.com/realms/dummy --aud ee2811b9-10b8 --out $TOKEN_FILE  --kid rsa-key-1
 --let $MYSQL_OIDC_USER = --authentication-openid-connect-client-id-token-file=$TOKEN_FILE --plugin-dir=$AUTH_OIDC_DIR --user=mysql_oidc_user

--- a/plugin/auth_openid_connect/src/config.cc
+++ b/plugin/auth_openid_connect/src/config.cc
@@ -82,6 +82,22 @@ static const T &json_get(const picojson::object &obj, const std::string &key,
   return it->second.get<T>();
 }
 
+static inline std::string json_parse(picojson::value &json_document,
+                                     std::string_view json_txt) {
+  std::string err;
+  auto end =
+      picojson::parse(json_document, json_txt.begin(), json_txt.end(), &err);
+  // Syntax error in the JSON document itself
+  if (!err.empty()) return err;
+  // Skip any trailing whitespace
+  while (end != json_txt.end() &&
+         std::isspace(static_cast<unsigned char>(*end)) != 0)
+    ++end;
+  // There is extra non‑whitespace content after the parsed JSON
+  if (end != json_txt.end()) return "extra content after correct JSON document";
+  return {};
+}
+
 int Idp_configs::check(MYSQL_THD thd [[maybe_unused]],
                        SYS_VAR *var [[maybe_unused]], void *save,
                        st_mysql_value *value) {
@@ -155,8 +171,7 @@ std::shared_timed_mutex &Idp_configs::mutex() {
 
 void Idp_configs::load(const std::string &config_json) {
   picojson::value json_obj;
-  if (const std::string err = picojson::parse(json_obj, config_json);
-      !err.empty())
+  if (const std::string err = json_parse(json_obj, config_json); !err.empty())
     throw std::runtime_error(err);
 
   if (!json_obj.is<picojson::object>())
@@ -269,7 +284,7 @@ bool Idp_config::load_keys() noexcept {
     if (jwks.get_url().empty()) return true;
     const std::string body = jwks.http_get();
     picojson::value root;
-    const std::string err = picojson::parse(root, body);
+    const std::string err = json_parse(root, body);
     if (!err.empty()) {
       throw std::runtime_error("JWKS: invalid JSON: " + err);
     }
@@ -413,7 +428,7 @@ bool Idp_configs::check(const char *variable) noexcept {
     std::string config_json;
     parse_var(variable, config_json);
     picojson::value json_obj;
-    const std::string err{picojson::parse(json_obj, config_json)};
+    const std::string err{json_parse(json_obj, config_json)};
     if (err.empty()) return false;
     LogPluginErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG, err.c_str());
   } catch (const std::exception &e) {


### PR DESCRIPTION
…nfiguration

Problem:
The configuration parser parsed until the end of a valid JSON document. Any strings after that in the config file or config string were ignored. E.g. IDP configuration added at the end of the config (not before the closing brace) was silently ignored.

Fix:
Added check if anything other than whitespaces were left after the document. If so, issue an error on setting auth_openid_connect_configuration and log an appropriate message.
Added check in a MTR test to verify the above.