### PR TITLE
PS-11202 [10.x]: Handle corrupted page-tracking groups during recovery

### DIFF
--- a/mysql-test/suite/innodb/r/page_tracking_corruption.result
+++ b/mysql-test/suite/innodb/r/page_tracking_corruption.result
@@ -1,0 +1,40 @@
+#
+# Enable page tracking
+#
+INSTALL COMPONENT 'file://component_mysqlbackup';
+SELECT mysqlbackup_page_track_set(1);
+mysqlbackup_page_track_set(1)
+#
+#
+# Generate data to create page tracking archive files
+#
+CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY, b TEXT) ENGINE=InnoDB;
+UPDATE t1 SET b = REPEAT('y', 1000);
+#
+# Verify page tracking works before corruption
+#
+SELECT mysqlbackup_page_track_get_changed_page_count(mysqlbackup_page_track_get_start_lsn(), mysqlbackup_page_track_get_start_lsn() + 1);
+mysqlbackup_page_track_get_changed_page_count(mysqlbackup_page_track_get_start_lsn(), mysqlbackup_page_track_get_start_lsn() + 1)
+#
+#
+# Shutdown the server
+#
+#
+# Corrupt page tracking archive files
+#
+Page tracking archive files corrupted successfully.
+#
+# Restart the server — should succeed despite corrupted archive files
+#
+# restart
+#
+# Verify page tracking query does not crash after corruption
+#
+SELECT mysqlbackup_page_track_get_changed_page_count(mysqlbackup_page_track_get_start_lsn(), mysqlbackup_page_track_get_start_lsn() + 1);
+mysqlbackup_page_track_get_changed_page_count(mysqlbackup_page_track_get_start_lsn(), mysqlbackup_page_track_get_start_lsn() + 1)
+#
+#
+# Cleanup
+#
+DROP TABLE t1;
+UNINSTALL COMPONENT 'file://component_mysqlbackup';

--- a/mysql-test/suite/innodb/t/page_tracking_corruption.test
+++ b/mysql-test/suite/innodb/t/page_tracking_corruption.test
@@ -1,0 +1,120 @@
+# Test that the server starts despite corrupted page tracking archive files.
+#
+# When ib_page_* files in #ib_archive are corrupted (e.g. truncated),
+# the server should detect the problem, log a warning, and continue
+# starting up rather than crashing.
+#
+--source include/not_valgrind.inc
+
+--disable_query_log
+call mtr.add_suppression("Page Archiver's doublewrite buffer initialisation failed");
+call mtr.add_suppression("Page archiver system's recovery failed");
+call mtr.add_suppression("Page archiver: ");
+call mtr.add_suppression("Operating system error number .* in a file operation");
+call mtr.add_suppression("Error number .* means");
+call mtr.add_suppression("'rmdir' returned OS error");
+call mtr.add_suppression("bytes should have been read. Only .* bytes read");
+call mtr.add_suppression("Retry attempts for reading partial data failed");
+--enable_query_log
+
+let MYSQLD_DATADIR = `SELECT @@datadir`;
+
+--echo #
+--echo # Enable page tracking
+--echo #
+INSTALL COMPONENT 'file://component_mysqlbackup';
+--replace_column 1 #
+SELECT mysqlbackup_page_track_set(1);
+
+--echo #
+--echo # Generate data to create page tracking archive files
+--echo #
+CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY, b TEXT) ENGINE=InnoDB;
+
+--disable_query_log
+--let $i = 100
+while ($i)
+{
+  INSERT INTO t1 (b) VALUES (REPEAT('x', 1000));
+  --dec $i
+}
+--enable_query_log
+
+UPDATE t1 SET b = REPEAT('y', 1000);
+
+--echo #
+--echo # Verify page tracking works before corruption
+--echo #
+--replace_column 1 #
+SELECT mysqlbackup_page_track_get_changed_page_count(mysqlbackup_page_track_get_start_lsn(), mysqlbackup_page_track_get_start_lsn() + 1);
+
+--echo #
+--echo # Shutdown the server
+--echo #
+--source include/shutdown_mysqld.inc
+
+--echo #
+--echo # Corrupt page tracking archive files
+--echo #
+
+perl;
+use File::Find;
+use strict;
+use warnings;
+
+my $datadir = $ENV{'MYSQLD_DATADIR'};
+chomp $datadir if defined $datadir;
+die "MYSQLD_DATADIR not set\n" unless defined $datadir && length $datadir;
+
+$datadir .= '/' unless $datadir =~ m{/$};
+my $archive_dir = "${datadir}#ib_archive";
+
+die "Archive directory $archive_dir not found.\n" unless -d $archive_dir;
+
+my $corrupted = 0;
+
+find(sub {
+    # Truncate the doublewrite buffer so it cannot restore corrupted blocks.
+    if (/^dblwr_\d+$/ && -f $File::Find::name) {
+        truncate($File::Find::name, 0) or die "Cannot truncate $File::Find::name: $!\n";
+    }
+
+    return unless /^ib_page_\d+$/;
+    my $path = $File::Find::name;
+    my $size = -s $path;
+    return unless defined $size && $size > 16384;
+
+    # Truncate just past the first block (the reset block). This preserves
+    # the valid reset entries that reference data blocks further in the file,
+    # but removes those data blocks. During recovery, fetch_reset_lsn() will
+    # try to read a referenced data block past the end of the file and hit
+    # the assertion (debug) or fatal read error (release).
+    # The size must be > ARCH_PAGE_BLK_SIZE (16384) so that
+    # cleanup_if_required() does not delete the file.
+    truncate($path, 16385) or die "Cannot truncate $path: $!\n";
+
+    $corrupted++;
+}, $archive_dir);
+
+die "No ib_page_* files found under $archive_dir.\n" if $corrupted == 0;
+
+print "Page tracking archive files corrupted successfully.\n";
+EOF
+
+--echo #
+--echo # Restart the server — should succeed despite corrupted archive files
+--echo #
+--source include/start_mysqld.inc
+
+--echo #
+--echo # Verify page tracking query does not crash after corruption
+--echo #
+--replace_column 1 #
+SELECT mysqlbackup_page_track_get_changed_page_count(mysqlbackup_page_track_get_start_lsn(), mysqlbackup_page_track_get_start_lsn() + 1);
+
+--echo #
+--echo # Cleanup
+--echo #
+DROP TABLE t1;
+UNINSTALL COMPONENT 'file://component_mysqlbackup';
+--force-rmdir $MYSQLD_DATADIR/#ib_archive

--- a/storage/innobase/arch/arch0arch.cc
+++ b/storage/innobase/arch/arch0arch.cc
@@ -31,6 +31,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
  *******************************************************/
 
 #include "arch0arch.h"
+#include "arch0page.h"
 #include "os0thread-create.h"
 
 /** Log Archiver system global */
@@ -454,17 +455,22 @@ dberr_t Arch_File_Ctx::open_next(lsn_t start_lsn, uint64_t file_offset,
 }
 
 dberr_t Arch_File_Ctx::read(byte *to_buffer, uint64_t offset, uint size) {
-  ut_ad(offset + size <= m_size);
   ut_ad(!is_closed());
+
+  if (offset > m_size || static_cast<uint64_t>(size) > (m_size - offset)) {
+    ib::error(ER_IB_MSG_17)
+        << "Page archiver: attempt to read " << size << " bytes at offset "
+        << offset << " from file '" << m_path_name << "' exceeds its size of "
+        << m_size << " bytes.";
+    return DB_IO_ERROR;
+  }
 
   IORequest request(IORequest::READ);
   request.disable_compression();
   request.clear_encrypted();
 
-  auto err =
-      os_file_read(request, m_path_name, m_file, to_buffer, offset, size);
-
-  return (err);
+  return os_file_read_no_error_handling(request, m_path_name, m_file, to_buffer,
+                                        offset, size, nullptr);
 }
 
 dberr_t Arch_File_Ctx::resize_and_overwrite_with_zeros(uint64_t file_size) {

--- a/storage/innobase/arch/arch0page.cc
+++ b/storage/innobase/arch/arch0page.cc
@@ -438,7 +438,10 @@ bool Arch_File_Ctx::find_reset_point(lsn_t check_lsn, Arch_Point &reset_point) {
 
   if (reset_point_it == reset_start_point.end() ||
       reset_point_it->lsn != check_lsn) {
-    ut_ad(reset_point_it != reset_start_point.begin());
+    /* This scenario can happen only for corrupted page-tracking data. */
+    if (reset_point_it == reset_start_point.begin()) {
+      return (false);
+    }
     --reset_point_it;
   }
 
@@ -599,8 +602,8 @@ bool Arch_File_Ctx::validate_stop_point_in_file(Arch_Group *group,
   byte buf[ARCH_PAGE_BLK_SIZE];
 
   /* Read the entire reset block. */
-  dberr_t err =
-      os_file_read(request, m_path_name, file, buf, offset, ARCH_PAGE_BLK_SIZE);
+  dberr_t err = os_file_read_no_error_handling(
+      request, m_path_name, file, buf, offset, ARCH_PAGE_BLK_SIZE, nullptr);
 
   if (err != DB_SUCCESS) {
     return (false);
@@ -628,8 +631,8 @@ bool Arch_File_Ctx::validate_reset_block_in_file(pfs_os_file_t file,
   byte buf[ARCH_PAGE_BLK_SIZE];
 
   /* Read the entire reset block. */
-  dberr_t err =
-      os_file_read(request, m_path_name, file, buf, 0, ARCH_PAGE_BLK_SIZE);
+  dberr_t err = os_file_read_no_error_handling(request, m_path_name, file, buf,
+                                               0, ARCH_PAGE_BLK_SIZE, nullptr);
 
   if (err != DB_SUCCESS) {
     return (false);
@@ -1228,14 +1231,24 @@ uint64_t Arch_Block::get_file_offset(uint64_t block_num, Arch_Blk_Type type) {
 
 bool Arch_Block::validate(byte *block) {
   auto data_length = Arch_Block::get_data_len(block);
+
+  /* data_length is read from the (possibly corrupted) block header. Bound it
+  before computing the checksum, otherwise ut_crc32() would read past the end
+  of the block. This runs on untrusted doublewrite buffer content during
+  recovery, so treat an out-of-range length as an invalid block. */
+  if (data_length > ARCH_PAGE_BLK_SIZE - ARCH_PAGE_BLK_HEADER_LENGTH) {
+    ib::warn(ER_IB_ERR_PAGE_ARCH_INVALID_DOUBLE_WRITE_BUF)
+        << Arch_Block::get_block_number(block);
+    return (false);
+  }
+
   auto block_checksum = Arch_Block::get_checksum(block);
   auto checksum = ut_crc32(block + ARCH_PAGE_BLK_HEADER_LENGTH, data_length);
 
   if (checksum != block_checksum) {
     ib::warn(ER_IB_ERR_PAGE_ARCH_INVALID_DOUBLE_WRITE_BUF)
         << Arch_Block::get_block_number(block);
-    ut_d(ut_error);
-    ut_o(return (false));
+    return (false);
   } else if (ut::is_zeros(block, ARCH_PAGE_BLK_SIZE)) {
     return (false);
   }
@@ -1898,14 +1911,29 @@ int Arch_Page_Sys::get_pages(MYSQL_THD thd, Page_Track_Callback cbk_func,
       auto data_len = Arch_Block::get_data_len(header_buf);
       bytes_left = data_len + ARCH_PAGE_BLK_HEADER_LENGTH;
 
-      ut_ad(bytes_left <= ARCH_PAGE_BLK_SIZE);
-      ut_ad(block_stop_lsn != LSN_MAX);
+      if (bytes_left > ARCH_PAGE_BLK_SIZE || block_stop_lsn == LSN_MAX) {
+        err = ER_PAGE_TRACKING_RANGE_NOT_TRACKED;
+        break;
+      }
+
+      if (cur_pos.m_offset > bytes_left) {
+        ib::error(ER_IB_MSG_17)
+            << "Page archiver: reset point references block "
+            << cur_pos.m_block_num << " with an out-of-range offset "
+            << cur_pos.m_offset << " (block holds " << bytes_left
+            << " bytes); the page-tracking data is corrupted.";
+        err = ER_PAGE_TRACKING_RANGE_NOT_TRACKED;
+        break;
+      }
 
       bytes_left -= cur_pos.m_offset;
 
       if (data_len == 0 || cur_pos.m_block_num == last_pos.m_block_num ||
           block_stop_lsn > stop_id) {
-        ut_ad(block_stop_lsn >= stop_id);
+        if (block_stop_lsn < stop_id) {
+          err = ER_PAGE_TRACKING_RANGE_NOT_TRACKED;
+          break;
+        }
         stop_id = block_stop_lsn;
         last_block = true;
       }
@@ -2939,8 +2967,8 @@ int Arch_Group::read_from_file(Arch_Page_Pos *read_pos, uint read_len,
   request.disable_compression();
   request.clear_encrypted();
 
-  auto db_err =
-      os_file_read(request, file_name, file, read_buff, offset, read_len);
+  auto db_err = os_file_read_no_error_handling(
+      request, file_name, file, read_buff, offset, read_len, nullptr);
 
   os_file_close(file);
 
@@ -3057,7 +3085,9 @@ int Arch_Page_Sys::fetch_group_within_lsn_range(lsn_t &start_id, lsn_t &stop_id,
   auto latest_stop_lsn = m_latest_stop_lsn;
   arch_oper_mutex_exit();
 
-  ut_ad(latest_stop_lsn != LSN_MAX);
+  if (latest_stop_lsn == LSN_MAX) {
+    return (ER_PAGE_TRACKING_RANGE_NOT_TRACKED);
+  }
 
   if (start_id == 0 || stop_id == 0) {
     if (m_current_group == nullptr || !m_current_group->is_active()) {
@@ -3066,7 +3096,9 @@ int Arch_Page_Sys::fetch_group_within_lsn_range(lsn_t &start_id, lsn_t &stop_id,
 
     *group = m_current_group;
 
-    ut_ad(m_last_lsn != LSN_MAX);
+    if (m_last_lsn == LSN_MAX) {
+      return (ER_PAGE_TRACKING_RANGE_NOT_TRACKED);
+    }
 
     start_id = (start_id == 0) ? m_last_lsn : start_id;
     stop_id = (stop_id == 0) ? latest_stop_lsn : stop_id;

--- a/storage/innobase/arch/arch0recv.cc
+++ b/storage/innobase/arch/arch0recv.cc
@@ -43,6 +43,7 @@ dberr_t Arch_Page_Sys::recover() {
 
   if (err == DB_FILE_READ_BEYOND_SIZE) {
     ib::error(ER_IB_ERR_PAGE_ARCH_DBLWR_INIT_FAILED);
+    return err;
   }
 
   /* Scan for group directories and files */
@@ -126,8 +127,6 @@ void Arch_Dblwr_Ctx::validate_and_fill_blocks(size_t num_files) {
     auto block_num = Arch_Block::get_block_number(dblwr_block_offset);
     uint file_index = Arch_Block::get_file_index(
         block_num, Arch_Block::get_type(dblwr_block_offset));
-
-    ut_ad(file_index < num_files);
 
     /* If the block does not belong to the last file then ignore. */
     if (file_index != num_files - 1) {
@@ -400,6 +399,13 @@ dberr_t Arch_Page_Sys::Recovery::recover() {
        info != m_dir_group_info_map.end(); ++info) {
     auto &group_info = info->second;
 
+    if (group_info.m_num_files == 0) {
+      ib::error(ER_IB_MSG_17)
+          << "Page archiver: group " << ARCH_PAGE_DIR << group_info.m_start_lsn
+          << " is empty. Skipping.";
+      continue;
+    }
+
     Arch_Group *group = ut::new_withkey<Arch_Group>(
         ut::make_psi_memory_key(mem_key_archive), group_info.m_start_lsn,
         ARCH_PAGE_FILE_HDR_SIZE, m_page_sys->get_mutex());
@@ -411,12 +417,34 @@ dberr_t Arch_Page_Sys::Recovery::recover() {
     err = group->recover(group_info, &m_dblwr_ctx);
 
     if (err != DB_SUCCESS) {
-      ut::delete_(group);
-      break;
-    }
+      /* We want to prevent deleting page-tracking group directories with
+      durable file marker during recovery. We do this by bumping up
+      the counter of clients referencing the group for durable archiving. */
+      if (group_info.m_durable) {
+        group->set_durable();
+      }
 
-    if (group_info.m_num_files == 0) {
+      /* The group's data files are preserved for manual inspection, but the
+      group must not be treated as active on subsequent restarts. Otherwise
+      every recovery would replay the shared (possibly stale) doublewrite
+      buffer into the preserved files, and a doublewrite belonging to a newer
+      active group could be spliced into this group's files. Deleting the
+      'active' marker leaves the data files intact while quarantining the
+      group. */
+      if (group_info.m_active) {
+        int mark_err = group->mark_inactive();
+
+        if (mark_err != 0) {
+          ib::error(ER_IB_MSG_17)
+              << "Page archiver: failed to remove the 'active' marker of the "
+                 "corrupted page-tracking group "
+              << ARCH_PAGE_DIR << group_info.m_start_lsn << ".";
+        }
+      }
+
+      group->disable(LSN_MAX);
       ut::delete_(group);
+      err = DB_SUCCESS;
       continue;
     }
 
@@ -484,9 +512,12 @@ dberr_t Arch_Group::recover(Arch_Recv_Group_Info &group_info,
     return err;
   }
 
-  if (group_info.m_active) {
+  if (group_info.m_active && group_info.m_num_files > 0) {
     /* Since the group was active at the time of crash it's possible that the
-    doublewrite buffer might have the latest data in case of a crash. */
+    doublewrite buffer might have the latest data in case of a crash.
+
+    Doublewrite recovery requires at least one page-tracking file to be
+    available. There's no point in running it otherwise. */
 
     err = group_recv.replace_pages_from_dblwr(dblwr_ctx);
 
@@ -604,12 +635,20 @@ dberr_t Arch_Group::Recovery::parse(Arch_Recv_Group_Info &info) {
     err = file_ctx_recv.parse_reset_points(file_index, last_file, info);
 
     if (err != DB_SUCCESS) {
+      ib::error(ER_IB_MSG_17)
+          << "Page archiver: failed to recover page-tracking information group "
+          << ARCH_PAGE_DIR << m_group->m_begin_lsn << " (" << ARCH_PAGE_FILE
+          << file_index << ").";
       break;
     }
 
     err = file_ctx_recv.parse_stop_points(last_file, info);
 
     if (err != DB_SUCCESS) {
+      ib::error(ER_IB_MSG_17)
+          << "Page archiver: failed to recover page-tracking information group "
+          << ARCH_PAGE_DIR << m_group->m_begin_lsn << " (" << ARCH_PAGE_FILE
+          << file_index << ").";
       break;
     }
   }
@@ -643,6 +682,26 @@ dberr_t Arch_File_Ctx::Recovery::parse_stop_points(bool last_file,
   }
 
   auto stop_lsn = Arch_Block::get_stop_lsn(buf);
+  auto data_len = Arch_Block::get_data_len(buf);
+
+  if (stop_lsn == LSN_MAX) {
+    ib::error(ER_IB_MSG_17)
+        << "Page archiver: last data block of page-tracking file reports an"
+           " invalid stop LSN.";
+    return DB_CORRUPTION;
+  }
+
+  /* data_len is read from the on-disk block header. A corrupted value would
+  make the resumed writer continue at an out-of-bounds offset inside the
+  block, so reject it as corruption. */
+  if (data_len > ARCH_PAGE_BLK_SIZE - ARCH_PAGE_BLK_HEADER_LENGTH) {
+    ib::error(ER_IB_MSG_17)
+        << "Page archiver: last data block of page-tracking file reports an"
+           " invalid data length of "
+        << data_len << " bytes.";
+    return DB_CORRUPTION;
+  }
+
   m_file_ctx.m_stop_points.push_back(stop_lsn);
 
   if (last_file) {
@@ -652,8 +711,7 @@ dberr_t Arch_File_Ctx::Recovery::parse_stop_points(bool last_file,
 
   info.m_write_pos.init();
   info.m_write_pos.m_block_num = Arch_Block::get_block_number(buf);
-  info.m_write_pos.m_offset =
-      Arch_Block::get_data_len(buf) + ARCH_PAGE_BLK_HEADER_LENGTH;
+  info.m_write_pos.m_offset = data_len + ARCH_PAGE_BLK_HEADER_LENGTH;
 
   return err;
 }
@@ -682,11 +740,23 @@ dberr_t Arch_File_Ctx::Recovery::parse_reset_points(
   if (file_index != block_num) {
     /* This means there was no reset for this file and hence the
     reset block was not flushed. */
+    if (!ut::is_zeros(buf, ARCH_PAGE_BLK_SIZE)) {
+      ib::error(ER_IB_MSG_17)
+          << "Page archiver: reset block of page-tracking file " << file_index
+          << " is corrupted; expected an empty (zero-filled) block.";
+      return DB_CORRUPTION;
+    }
 
-    ut_ad(ut::is_zeros(buf, ARCH_PAGE_BLK_SIZE));
     info.m_reset_pos.init();
     info.m_reset_pos.m_block_num = file_index;
     return err;
+  }
+
+  if (data_len > ARCH_PAGE_BLK_SIZE - ARCH_PAGE_BLK_HEADER_LENGTH) {
+    ib::error(ER_IB_MSG_17)
+        << "Page archiver: reset block of page-tracking file " << file_index
+        << " reports an invalid data length of " << data_len << " bytes.";
+    return DB_CORRUPTION;
   }
 
   /* Normal case. */
@@ -702,11 +772,16 @@ dberr_t Arch_File_Ctx::Recovery::parse_reset_points(
   reset_file.m_file_index = file_index;
 
   if (data_len != 0) {
+    if (data_len < ARCH_PAGE_FILE_HEADER_RESET_LSN_SIZE +
+                       ARCH_PAGE_FILE_HEADER_RESET_POS_SIZE) {
+      ib::error(ER_IB_MSG_17)
+          << "Page archiver: reset block of page-tracking file " << file_index
+          << " has a truncated reset entry (data length " << data_len << ").";
+      return DB_CORRUPTION;
+    }
+
     uint length = 0;
     byte *buf1 = buf + ARCH_PAGE_BLK_HEADER_LENGTH;
-
-    ut_ad(data_len >= ARCH_PAGE_FILE_HEADER_RESET_LSN_SIZE +
-                          ARCH_PAGE_FILE_HEADER_RESET_POS_SIZE);
 
     reset_file.m_lsn = mach_read_from_8(buf1);
     length += ARCH_PAGE_FILE_HEADER_RESET_LSN_SIZE;
@@ -714,8 +789,13 @@ dberr_t Arch_File_Ctx::Recovery::parse_reset_points(
     Arch_Point start_point;
     Arch_Page_Pos pos;
 
-    while (length != data_len) {
-      ut_ad((data_len - length) % ARCH_PAGE_FILE_HEADER_RESET_POS_SIZE == 0);
+    while (length < data_len) {
+      if ((data_len - length) < ARCH_PAGE_FILE_HEADER_RESET_POS_SIZE) {
+        ib::error(ER_IB_MSG_17)
+            << "Page archiver: reset block of page-tracking file " << file_index
+            << " contains an incomplete reset point entry.";
+        return DB_CORRUPTION;
+      }
 
       pos.m_block_num = mach_read_from_2(buf1 + length);
       length += ARCH_PAGE_FILE_HEADER_RESET_BLOCK_NUM_SIZE;
@@ -723,7 +803,23 @@ dberr_t Arch_File_Ctx::Recovery::parse_reset_points(
       pos.m_offset = mach_read_from_2(buf1 + length);
       length += ARCH_PAGE_FILE_HEADER_RESET_BLOCK_OFFSET_SIZE;
 
+      if (pos.m_offset < ARCH_PAGE_BLK_HEADER_LENGTH ||
+          pos.m_offset > ARCH_PAGE_BLK_SIZE) {
+        ib::error(ER_IB_MSG_17)
+            << "Page archiver: reset point in page-tracking file " << file_index
+            << " has an invalid block offset " << pos.m_offset << ".";
+        return DB_CORRUPTION;
+      }
+
       start_point.lsn = m_file_ctx.fetch_reset_lsn(pos.m_block_num);
+
+      if (start_point.lsn == LSN_MAX) {
+        ib::error(ER_IB_MSG_17)
+            << "Page archiver: reset point in page-tracking file " << file_index
+            << " references an invalid block " << pos.m_block_num << ".";
+        return DB_CORRUPTION;
+      }
+
       start_point.pos = pos;
 
       reset_file.m_start_point.push_back(start_point);
@@ -739,13 +835,14 @@ dberr_t Arch_File_Ctx::Recovery::parse_reset_points(
 
 lsn_t Arch_File_Ctx::fetch_reset_lsn(uint64_t block_num) {
   ut_ad(!is_closed());
-  ut_ad(Arch_Block::get_file_index(block_num, ARCH_DATA_BLOCK) == m_index);
+
+  if (Arch_Block::get_file_index(block_num, ARCH_DATA_BLOCK) != m_index) {
+    return (LSN_MAX);
+  }
 
   byte buf[ARCH_PAGE_BLK_SIZE];
 
   auto offset = Arch_Block::get_file_offset(block_num, ARCH_DATA_BLOCK);
-
-  ut_ad(offset + ARCH_PAGE_BLK_SIZE <= get_phy_size());
 
   auto err = read(buf, offset, ARCH_PAGE_BLK_HEADER_LENGTH);
 
@@ -753,9 +850,5 @@ lsn_t Arch_File_Ctx::fetch_reset_lsn(uint64_t block_num) {
     return (LSN_MAX);
   }
 
-  auto lsn = Arch_Block::get_reset_lsn(buf);
-
-  ut_ad(lsn != LSN_MAX);
-
-  return (lsn);
+  return Arch_Block::get_reset_lsn(buf);
 }

--- a/storage/innobase/include/arch0arch.h
+++ b/storage/innobase/include/arch0arch.h
@@ -1110,6 +1110,11 @@ class Arch_Group {
   @return true if there is at least 1 client that requires durable archiving*/
   bool is_durable() const { return (m_dur_ref_count > 0); }
 
+  /** Make group durable, regardless of whether it has any clients requiring
+  durable archiving. One use is protecting page-tracking information files from
+  being deleted if group recovery fails. */
+  void set_durable() { ++m_dur_ref_count; }
+
   /** Purge archived files until the specified purge LSN.
   @param[in]    purge_lsn       LSN until which archived files needs to be
   purged


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11202

Treat invalid page archive file reads as corruption instead of terminating the
server. Log errors for corrupted page-tracking groups, keep them on disk for
manual cleanup, and do not load them so page-tracking reads skip unusable
groups. This allows startup to continue and keeps CLONE and creation of new
page-tracking files working.