### PR TITLE
PS-11078 [8.0]: Skip orphan-sweep runs on forks

### DIFF
--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -2,6 +2,10 @@
 # GHA runners. Companion to builds.yml; catches orphans from control-plane
 # crashes, cancelled workflows, and probe-step leaks.
 #
+# Runs only in percona/percona-server: forks that enable Actions would
+# otherwise inherit the hourly cron and fail every run (no secrets, and
+# the AWS OIDC trust rejects fork subjects), spamming the fork owner.
+#
 # PS-11179 (2026-05-28): EC2 sweep added for the AWS fallback path.
 
 name: orphan-sweep
@@ -30,6 +34,7 @@ concurrency:
 
 jobs:
   sweep:
+    if: github.repository == 'percona/percona-server'
     runs-on: ubuntu-latest
     permissions: {}
     env:
@@ -143,6 +148,7 @@ jobs:
   # OIDC -> STS via the same AWS_ROLE_ARN used by builds.yml. Region pinned
   # to eu-central-1 (matches create-runner-aws).
   sweep-ec2:
+    if: github.repository == 'percona/percona-server'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
**Bug**
- Forks with Actions enabled inherit the hourly `orphan-sweep` cron and fail every run: the fork has no `GHA_RUNNER_HCLOUD_TOKEN`, and the AWS OIDC trust rejects fork subjects by design. The fork owner gets a failure email every hour.

**Fix**
- Job-level `if: github.repository == 'percona/percona-server'` on both jobs, so the workflow no-ops outside the canonical repo.

**Tickets**
- [PS-11078](https://perconadev.atlassian.net/browse/PS-11078) (parent). Siblings: [#6087](https://github.com/percona/percona-server/pull/6087) (8.4), [#6088](https://github.com/percona/percona-server/pull/6088) (9.7), [#6089](https://github.com/percona/percona-server/pull/6089) (trunk)


[PS-11078]: https://perconadev.atlassian.net/browse/PS-11078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ