### PR TITLE
PS-11446 [9.7]: Fix inverted old/young check in LRUItr::start() that always restarted the LRU scan

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3106,7 +3106,7 @@ the LRU list it resets the value to the tail of the LRU list.
 buf_page_t *LRUItr::start() {
   ut_ad(mutex_own(m_mutex));
 
-  if (!m_hp || m_hp->old) {
+  if (!m_hp || !m_hp->old) {
     m_hp = UT_LIST_GET_LAST(m_buf_pool->LRU);
   }
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11446

LRUItr::start() is meant to leave the scan hand pointer (m_hp) in
place while it is still within the "old" (cold) sublist of the LRU
list, and only rewind it to the tail of the LRU list once the pointer
has advanced past the old/young boundary into the young (hot) sublist.

The boundary check was inverted: `m_hp->old` is true while the
pointer is still in the old region, so the scan was rewound on every
call instead of only at the old -> young transition. This defeated
the intended optimization by repeatedly restarting the scan from the
tail rather than letting it continue.

Fix the condition to `!m_hp->old`, so the pointer is only reset once
it has crossed into the young sublist.

Port of #6085 to the 9.7 branch (same bug present identically upstream).