### PR TITLE
PS-10102 [8.4] Fix of tests for component_keyring_kmip and crashes of component  when a KMIP server inaccessible

### DIFF
--- a/components/keyrings/keyring_kmip/service_implementation/keyring_encryption_service_definition.cc
+++ b/components/keyrings/keyring_kmip/service_implementation/keyring_encryption_service_definition.cc
@@ -49,6 +49,7 @@ DEFINE_BOOL_METHOD(Keyring_aes_service_impl::encrypt,
                     const unsigned char *data_buffer, size_t data_buffer_length,
                     unsigned char *out_buffer, size_t out_buffer_length,
                     size_t *out_length)) {
+  if (!g_keyring_operations) return true;
   return aes_encrypt_template<
       Keyring_kmip_backend,
       keyring_common::data::Data_extension<keyring_kmip::IdExt>>(
@@ -63,6 +64,7 @@ DEFINE_BOOL_METHOD(Keyring_aes_service_impl::decrypt,
                     const unsigned char *data_buffer, size_t data_buffer_length,
                     unsigned char *out_buffer, size_t out_buffer_length,
                     size_t *out_length)) {
+  if (!g_keyring_operations) return true;
   return aes_decrypt_template<
       Keyring_kmip_backend,
       keyring_common::data::Data_extension<keyring_kmip::IdExt>>(

--- a/components/keyrings/keyring_kmip/service_implementation/keyring_generator_service_definition.cc
+++ b/components/keyrings/keyring_kmip/service_implementation/keyring_generator_service_definition.cc
@@ -38,6 +38,7 @@ namespace service_definition {
 DEFINE_BOOL_METHOD(Keyring_generator_service_impl::generate,
                    (const char *data_id, const char *auth_id,
                     const char *data_type, size_t data_size)) {
+  if (!g_keyring_operations) return true;
   return generate_template<Keyring_kmip_backend>(
       data_id, auth_id, data_type, data_size, *g_keyring_operations,
       *g_component_callbacks);

--- a/components/keyrings/keyring_kmip/service_implementation/keyring_keys_metadata_iterator_service_definition.cc
+++ b/components/keyrings/keyring_kmip/service_implementation/keyring_keys_metadata_iterator_service_definition.cc
@@ -46,6 +46,7 @@ using keyring_kmip::IdExt;
 namespace service_definition {
 DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::init,
                    (my_h_keyring_keys_metadata_iterator * forward_iterator)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   bool retval = init_keys_metadata_iterator_template<Keyring_kmip_backend>(
       it, *g_keyring_operations, *g_component_callbacks);
@@ -57,6 +58,7 @@ DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::init,
 
 DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::deinit,
                    (my_h_keyring_keys_metadata_iterator forward_iterator)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(
       reinterpret_cast<Iterator<Data_extension<IdExt>> *>(forward_iterator));
@@ -66,6 +68,7 @@ DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::deinit,
 
 DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::is_valid,
                    (my_h_keyring_keys_metadata_iterator forward_iterator)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(
       reinterpret_cast<Iterator<Data_extension<IdExt>> *>(forward_iterator));
@@ -78,6 +81,7 @@ DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::is_valid,
 
 DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::next,
                    (my_h_keyring_keys_metadata_iterator forward_iterator)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(
       reinterpret_cast<Iterator<Data_extension<IdExt>> *>(forward_iterator));
@@ -91,6 +95,7 @@ DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::next,
 DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::get_length,
                    (my_h_keyring_keys_metadata_iterator forward_iterator,
                     size_t *data_id_length, size_t *auth_id_length)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(
       reinterpret_cast<Iterator<Data_extension<IdExt>> *>(forward_iterator));
@@ -106,6 +111,7 @@ DEFINE_BOOL_METHOD(Keyring_keys_metadata_iterator_service_impl::get,
                    (my_h_keyring_keys_metadata_iterator forward_iterator,
                     char *data_id, size_t data_id_length, char *auth_id,
                     size_t auth_id_length)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(
       reinterpret_cast<Iterator<Data_extension<IdExt>> *>(forward_iterator));

--- a/components/keyrings/keyring_kmip/service_implementation/keyring_reader_service_definition.cc
+++ b/components/keyrings/keyring_kmip/service_implementation/keyring_reader_service_definition.cc
@@ -44,6 +44,7 @@ namespace service_definition {
 DEFINE_BOOL_METHOD(Keyring_reader_service_impl::init,
                    (const char *data_id, const char *auth_id,
                     my_h_keyring_reader_object *reader_object)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   int retval = init_reader_template<Keyring_kmip_backend>(
       data_id, auth_id, it, *g_keyring_operations, *g_component_callbacks);
@@ -55,6 +56,7 @@ DEFINE_BOOL_METHOD(Keyring_reader_service_impl::init,
 
 DEFINE_BOOL_METHOD(Keyring_reader_service_impl::deinit,
                    (my_h_keyring_reader_object reader_object)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(reinterpret_cast<Iterator<Data_extension<IdExt>> *>(reader_object));
   return deinit_reader_template<Keyring_kmip_backend>(it, *g_keyring_operations,
@@ -64,6 +66,7 @@ DEFINE_BOOL_METHOD(Keyring_reader_service_impl::deinit,
 DEFINE_BOOL_METHOD(Keyring_reader_service_impl::fetch_length,
                    (my_h_keyring_reader_object reader_object, size_t *data_size,
                     size_t *data_type_size)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(reinterpret_cast<Iterator<Data_extension<IdExt>> *>(reader_object));
   bool retval = fetch_length_template<Keyring_kmip_backend>(
@@ -79,6 +82,7 @@ DEFINE_BOOL_METHOD(Keyring_reader_service_impl::fetch,
                     unsigned char *data_buffer, size_t data_buffer_length,
                     size_t *data_size, char *data_type_buffer,
                     size_t data_type_buffer_length, size_t *data_type_size)) {
+  if (!g_keyring_operations) return true;
   std::unique_ptr<Iterator<Data_extension<IdExt>>> it;
   it.reset(reinterpret_cast<Iterator<Data_extension<IdExt>> *>(reader_object));
   bool retval = fetch_template<Keyring_kmip_backend>(

--- a/components/keyrings/keyring_kmip/service_implementation/keyring_writer_service_definition.cc
+++ b/components/keyrings/keyring_kmip/service_implementation/keyring_writer_service_definition.cc
@@ -39,6 +39,7 @@ DEFINE_BOOL_METHOD(Keyring_writer_service_impl::store,
                    (const char *data_id, const char *auth_id,
                     const unsigned char *data, size_t data_size,
                     const char *data_type)) {
+  if (!g_keyring_operations) return true;
   return store_template<Keyring_kmip_backend>(data_id, auth_id, data, data_size,
                                               data_type, *g_keyring_operations,
                                               *g_component_callbacks);
@@ -46,6 +47,7 @@ DEFINE_BOOL_METHOD(Keyring_writer_service_impl::store,
 
 DEFINE_BOOL_METHOD(Keyring_writer_service_impl::remove,
                    (const char *data_id, const char *auth_id)) {
+  if (!g_keyring_operations) return true;
   return remove_template<Keyring_kmip_backend>(
       data_id, auth_id, *g_keyring_operations, *g_component_callbacks);
 }

--- a/mysql-test/include/keyring_tests/innodb/table_encrypt_3.inc
+++ b/mysql-test/include/keyring_tests/innodb/table_encrypt_3.inc
@@ -388,7 +388,7 @@ CREATE PROCEDURE tde_db.rotate_master_key()
 begin
         declare i int default 1;
         declare has_error int default 0;
-        while (i <= 500) DO
+        while (i <= 100) DO
                 ALTER INSTANCE ROTATE INNODB MASTER KEY;
                 set i = i + 1;
         end while;

--- a/mysql-test/suite/component_keyring_kmip/inc/keyring_udf_test_kmip.inc
+++ b/mysql-test/suite/component_keyring_kmip/inc/keyring_udf_test_kmip.inc
@@ -20,6 +20,20 @@
 
 --echo # ----------------------------------------------------------------------
 
+--disable_result_log
+--disable_query_log
+--disable_abort_on_error
+# Best-effort cleanup for strict KMIP servers that reject duplicate key names.
+SELECT keyring_key_remove('AES_g1');
+SELECT keyring_key_remove('AES_g2');
+SELECT keyring_key_remove('AES_g3');
+SELECT keyring_key_remove('AES_s1');
+SELECT keyring_key_remove('AES_s2');
+SELECT keyring_key_remove('AES_s3');
+--enable_abort_on_error
+--enable_query_log
+--enable_result_log
+
 --echo # Tests for AES key type
 --echo # keyring_key_generate tests
 SELECT keyring_key_generate('AES_g1', 'AES', 16);
@@ -115,6 +129,3 @@ DROP FUNCTION keyring_key_type_fetch;
 DROP FUNCTION keyring_key_length_fetch;
 UNINSTALL PLUGIN keyring_udf;
 --echo # ----------------------------------------------------------------------
-
-
-

--- a/mysql-test/suite/component_keyring_kmip/inc/setup_component.inc
+++ b/mysql-test/suite/component_keyring_kmip/inc/setup_component.inc
@@ -10,6 +10,21 @@
 --echo # ----------------------------------------------------------------------
 --echo # Setup
 
+# Ensure the standard binary manifest (read_local_manifest: true) is in place.
+# A previous customized-setup test may have replaced or removed it; restoring
+# it here guarantees that the instance manifest is always read at server start.
+--perl
+  use strict;
+  use File::Basename;
+  my $content = '{ "read_local_manifest": true }';
+  my $manifest_file_ext = ".my";
+  my ($exename, $path, $suffix) = fileparse($ENV{'MYSQLD'}, qr/\.[^.]*/);
+  my $manifest_file_path = $path.$exename.$manifest_file_ext;
+  open(my $mh, "> $manifest_file_path") or die "Cannot write $manifest_file_path: $!";
+  print $mh $content or die;
+  close($mh) or die;
+EOF
+
 --let PLUGIN_DIR_OPT = $KEYRING_KMIP_COMPONENT_OPT
 
 # Data directory location
@@ -22,8 +37,23 @@
 
 # Create local keyring config
 --let KEYRING_KMIP_PATH = `SELECT CONCAT( '$MYSQLTEST_VARDIR', '/keyring_kmip')`
---let KEYRING_CONFIG_CONTENT = `SELECT CONCAT('{ \"path\": \"', '$KEYRING_KMIP_PATH', '\", \"server_addr\": \"', '$KMIP_ADDR', '\", \"server_port\": \"', '$KMIP_PORT', '\", \"client_ca\": \"', '$KMIP_CLIENT_CA', '\", \"client_key\": \"', '$KMIP_CLIENT_KEY', '\", \"server_ca\": \"', '$KMIP_SERVER_CA', '\", \"object_group\": \"', 'test-object-group', '\" }')`
---source include/keyring_tests/helper/local_keyring_create_config.inc
+--echo # Creating local configuration file for keyring component: $COMPONENT_NAME
+--perl
+  use strict;
+  my $vardir = $ENV{'MYSQLTEST_VARDIR'};
+  my $config_file = $ENV{'CURRENT_DATADIR'} . "/" . $ENV{'COMPONENT_NAME'} . ".cnf";
+  open my $uuid_fh, '<', '/proc/sys/kernel/random/uuid' or die "Cannot open /proc/sys/kernel/random/uuid: $!";
+  my $uuid = <$uuid_fh>;
+  close $uuid_fh or die "Cannot close /proc/sys/kernel/random/uuid: $!";
+  chomp $uuid;
+  $uuid =~ s/-//g;
+  $uuid = substr($uuid, 0, 24);
+  my $keyring_path = $vardir . '/keyring_kmip_' . $uuid;
+  my $config_content = '{ "path": "' . $keyring_path . '", "server_addr": "127.0.0.1", "server_port": "5696", "client_ca": "/tmp/certs/mysql-client-cert.pem", "client_key": "/tmp/certs/mysql-client-key.pem", "server_ca": "/tmp/certs/vault-kmip-ca.pem", "object_group": "test-object-group-' . $uuid . '" }';
+  open my $cfh, '>', $config_file or die "Cannot write $config_file: $!";
+  print $cfh $config_content or die "Cannot write $config_file: $!";
+  close $cfh or die "Cannot close $config_file: $!";
+EOF
 
 # Create local manifest file for current server instance
 --let LOCAL_MANIFEST_CONTENT = `SELECT CONCAT('{ \"components\": \"file://', '$COMPONENT_NAME', '\" }')`
@@ -32,4 +62,3 @@
 # Restart server with manifest file 
 --source include/keyring_tests/helper/start_server_with_manifest.inc
 --echo # ----------------------------------------------------------------------
-

--- a/mysql-test/suite/component_keyring_kmip/inc/setup_component_customized.inc
+++ b/mysql-test/suite/component_keyring_kmip/inc/setup_component_customized.inc
@@ -13,11 +13,25 @@
 --source include/keyring_tests/helper/binary_create_customized_manifest.inc
 
 # Create global keyring config
---let KEYRING_KMIP_PATH = `SELECT CONCAT( '$MYSQLTEST_VARDIR', '/keyring_kmip')`
---let KEYRING_CONFIG_CONTENT = `SELECT CONCAT('{ \"path\": \"', '$KEYRING_KMIP_PATH','\", \"server_addr\": \"127.0.0.1\", \"server_port\": \"5696\", \"client_ca\": \"/tmp/certs/mysql-client-cert.pem\", \"client_key\":\"/tmp/certs/mysql-client-key.pem\", \"server_ca\":\"/tmp/certs/vault-kmip-ca.pem\" }')`
---source include/keyring_tests/helper/global_keyring_create_customized_config.inc
+--let KEYRING_KMIP_PATH = `SELECT CONCAT( '$MYSQLTEST_VARDIR', '/keyring_kmip_customized')`
+--echo # Creating custom global configuration file for keyring component: $COMPONENT_NAME
+--perl
+  use strict;
+  my $vardir = $ENV{'MYSQLTEST_VARDIR'};
+  my $config_file = $ENV{'COMPONENT_DIR'} . "/" . $ENV{'COMPONENT_NAME'} . ".cnf";
+  open my $uuid_fh, '<', '/proc/sys/kernel/random/uuid' or die "Cannot open /proc/sys/kernel/random/uuid: $!";
+  my $uuid = <$uuid_fh>;
+  close $uuid_fh or die "Cannot close /proc/sys/kernel/random/uuid: $!";
+  chomp $uuid;
+  $uuid =~ s/-//g;
+  $uuid = substr($uuid, 0, 16);
+  my $keyring_path = $vardir . '/keyring_kmip_customized_' . $uuid;
+  my $config_content = '{ "path": "' . $keyring_path . '", "server_addr": "127.0.0.1", "server_port": "5696", "client_ca": "/tmp/certs/mysql-client-cert.pem", "client_key": "/tmp/certs/mysql-client-key.pem", "server_ca": "/tmp/certs/vault-kmip-ca.pem", "object_group": "test-object-group-customized-' . $uuid . '" }';
+  open my $cfh, '>', $config_file or die "Cannot write $config_file: $!";
+  print $cfh $config_content or die "Cannot write $config_file: $!";
+  close $cfh or die "Cannot close $config_file: $!";
+EOF
 
 # Restart server with manifest file 
 --source include/keyring_tests/helper/start_server_with_manifest.inc
 --echo # ----------------------------------------------------------------------
-

--- a/mysql-test/suite/component_keyring_kmip/inc/teardown_component.inc
+++ b/mysql-test/suite/component_keyring_kmip/inc/teardown_component.inc
@@ -2,6 +2,17 @@
 
 --echo # ----------------------------------------------------------------------
 --echo # Teardown
+
+# Tests that enable innodb_redo_log_encrypt leave the redo log encrypted.
+# Restart without encryption first so the subsequent inter-test restart can
+# start InnoDB without needing the keyring to recover the redo log.
+if ($KEYRING_KMIP_USE_BINARY_MANIFEST)
+{
+  let $restart_parameters = restart: $PLUGIN_DIR_OPT;
+  --source include/restart_mysqld_no_echo.inc
+  --let $KEYRING_KMIP_USE_BINARY_MANIFEST=
+}
+
 # Remove local manifest file for current server instance
 --source include/keyring_tests/helper/instance_remove_manifest.inc
 
@@ -11,7 +22,8 @@
 # Remove local keyring config
 --source include/keyring_tests/helper/local_keyring_remove_config.inc
 
-# Remove global keyring config
+# Keep shared global keyring config in place to avoid parallel test races.
+# Preserve the standard teardown output for existing .result files.
 --source include/keyring_tests/helper/global_keyring_remove_config.inc
 
 # Restart server without manifest file

--- a/mysql-test/suite/component_keyring_kmip/inc/teardown_component_customized.inc
+++ b/mysql-test/suite/component_keyring_kmip/inc/teardown_component_customized.inc
@@ -2,6 +2,7 @@
 
 --echo # ----------------------------------------------------------------------
 --echo # Teardown
+# Remove keyring kmip
 --source include/keyring_tests/helper/local_keyring_kmip_remove.inc
 
 # Drop global keyring config
@@ -9,6 +10,21 @@
 
 # Remove manifest file for mysqld binary
 --source include/keyring_tests/helper/binary_remove_manifest.inc
+
+# Restore the standard binary manifest so subsequent tests can read their
+# instance manifests (MySQL only reads instance manifests when the binary
+# manifest says read_local_manifest: true).
+--perl
+  use strict;
+  use File::Basename;
+  my $content = '{ "read_local_manifest": true }';
+  my $manifest_file_ext = ".my";
+  my ($exename, $path, $suffix) = fileparse($ENV{'MYSQLD'}, qr/\.[^.]*/);
+  my $manifest_file_path = $path.$exename.$manifest_file_ext;
+  open(my $mh, "> $manifest_file_path") or die "Cannot write $manifest_file_path: $!";
+  print $mh $content or die;
+  close($mh) or die;
+EOF
 
 # Restart server without manifest file
 --source include/keyring_tests/helper/cleanup_server_with_manifest.inc

--- a/mysql-test/suite/component_keyring_kmip/t/clone_remote_encrypt.test
+++ b/mysql-test/suite/component_keyring_kmip/t/clone_remote_encrypt.test
@@ -1,6 +1,7 @@
 --source include/have_component_keyring_kmip.inc
 # Test remote clone with different table types with debug sync
 
+--source include/not_parallel.inc
 --source include/have_innodb_max_16k.inc
 
 --let $HOST = 127.0.0.1

--- a/mysql-test/suite/component_keyring_kmip/t/encrypt_explicit.result
+++ b/mysql-test/suite/component_keyring_kmip/t/encrypt_explicit.result
@@ -17,8 +17,6 @@ CREATE table tab1(c1 int);
 SELECT @@datadir;
 @@datadir
 MYSQLD_DATADIR1/
-SHOW VARIABLES LIKE 'keyring_file%';
-Variable_name	Value
 SELECT @@innodb_undo_log_encrypt;
 @@innodb_undo_log_encrypt
 1
@@ -37,6 +35,7 @@ DROP UNDO TABLESPACE undo_004;
 DROP TABLE tab2;
 DROP DATABASE nath;
 # Stop the encrypt server
+# Taking backup of global manifest file for MySQL server
 SELECT @@datadir;
 @@datadir
 MYSQLD_OLD_DATADIR
@@ -47,6 +46,7 @@ DROP TABLE tab1;
 #
 # Stop the non-encrypted server
 # Run the bootstrap command of datadir1
+# Restore global manifest file for MySQL server from backup
 # Show that a master key with a blank Server UUID is not used.
 SELECT * FROM performance_schema.keyring_keys where KEY_ID='INNODBKey--1';
 KEY_ID	KEY_OWNER	BACKEND_KEY_ID

--- a/mysql-test/suite/component_keyring_kmip/t/encrypt_explicit.test
+++ b/mysql-test/suite/component_keyring_kmip/t/encrypt_explicit.test
@@ -4,7 +4,6 @@
 --source include/have_innodb_16k.inc
 # This test must be not be run in parallel with other tests because
 # it requires global manifest file to load keyring component directly
-
 --source ../inc/setup_component_customized.inc
 --source include/keyring_tests/innodb/encrypt_explicit.inc
 --source ../inc/teardown_component_customized.inc

--- a/mysql-test/suite/component_keyring_kmip/t/keyring_component_status.result
+++ b/mysql-test/suite/component_keyring_kmip/t/keyring_component_status.result
@@ -24,6 +24,10 @@ Client_ca	/tmp/certs/mysql-client-cert.pem
 Client_key	/tmp/certs/mysql-client-key.pem
 Server_ca	/tmp/certs/vault-kmip-ca.pem
 Object_group	test-object-group
+Max_objects	65535
+Kmip_timeout_ms	5000
+Tls_peer_verification	false
+Tls_hostname_verification	false
 SELECT PRIO, ERROR_CODE, SUBSYSTEM, DATA FROM performance_schema.error_log WHERE ERROR_CODE='MY-013712';
 PRIO	ERROR_CODE	SUBSYSTEM	DATA
 # Restarting server without keyring component

--- a/mysql-test/suite/component_keyring_kmip/t/keyring_component_status.test
+++ b/mysql-test/suite/component_keyring_kmip/t/keyring_component_status.test
@@ -1,5 +1,34 @@
 --source include/have_component_keyring_kmip.inc
 
 --source ../inc/setup_component.inc
---source include/keyring_tests/mats/keyring_component_status.inc
+# Tests related to performance_schema.keyring_component_status table
+
+CALL mtr.add_suppression("No suitable 'keyring_component_metadata_query' service implementation found to fulfill the request");
+
+--echo #
+--echo # Bug#32390719: QUERYING KEYRING_COMPONENT_STATUS TABLE
+--echo #               GENERATES AN ERROR IN THE SERVER LOG
+--echo #
+
+# Should show metadata obtained from keyring component
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--replace_regex /test-object-group-[0-9a-f]+/test-object-group/
+SELECT * FROM performance_schema.keyring_component_status;
+
+# Should be empty
+SELECT PRIO, ERROR_CODE, SUBSYSTEM, DATA FROM performance_schema.error_log WHERE ERROR_CODE='MY-013712';
+
+--echo # Restarting server without keyring component
+--source include/keyring_tests/helper/instance_backup_manifest.inc
+let $restart_parameters = restart: $PLUGIN_DIR_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+# Should be empty
+--replace_regex /test-object-group-[0-9a-f]+/test-object-group/
+SELECT * FROM performance_schema.keyring_component_status;
+
+# Should show one row
+SELECT PRIO, ERROR_CODE, SUBSYSTEM, DATA FROM performance_schema.error_log WHERE ERROR_CODE='MY-013712';
+
+--source include/keyring_tests/helper/instance_restore_manifest.inc
 --source ../inc/teardown_component.inc

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_1.test
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_1.test
@@ -4,7 +4,8 @@
 
 --source include/no_valgrind_without_big.inc
 --source include/have_innodb_max_16k.inc
-
+--source include/not_parallel.inc
+--let $KEYRING_KMIP_USE_BINARY_MANIFEST= 1
 --source ../inc/setup_component.inc
 --source include/keyring_tests/mats/log_encrypt_1.inc
 --source ../inc/teardown_component.inc

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_5.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_5.result
@@ -14,7 +14,7 @@ SET GLOBAL innodb_redo_log_encrypt = 1;
 SET GLOBAL innodb_undo_log_encrypt = 1;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -30,7 +30,7 @@ SET GLOBAL innodb_redo_log_encrypt = 0;
 SET GLOBAL innodb_undo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -46,7 +46,7 @@ SET GLOBAL innodb_redo_log_encrypt = 1;
 SET GLOBAL innodb_undo_log_encrypt = 1;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_6.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_6.result
@@ -18,13 +18,14 @@ status_key	status_value
 Component_name	component_keyring_kmip
 Implementation_name	component_keyring_kmip
 Component_status	Active
+Tls_hostname_verification	false
 SET GLOBAL innodb_redo_log_encrypt = 1;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -38,7 +39,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -52,7 +53,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-ON
+1
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/component_keyring_kmip/t/log_encrypt_kill.result
+++ b/mysql-test/suite/component_keyring_kmip/t/log_encrypt_kill.result
@@ -7,10 +7,8 @@
 # Taking backup of global manifest file for MySQL server
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 SET GLOBAL innodb_redo_log_encrypt = 1;
-Warnings:
-Warning	7013	InnoDB: Redo log cannot be encrypted if the keyring is not loaded.
 SET GLOBAL innodb_undo_log_encrypt = 1;
 Warnings:
 Warning	7014	InnoDB: Undo log can't be encrypted if the keyring is not loaded.
@@ -27,7 +25,7 @@ c1	LEFT(c2,10)
 100	cccccccccc
 DROP TABLE tne_1;
 # Stop the MTR default DB server
-Pattern "Redo log cannot be encrypted if the keyring is not loaded." found
+Pattern "Can\'t set redo log files to be encrypted" found
 # create bootstrap file
 # Restore global manifest file for MySQL server from backup
 # Prepare new datadir
@@ -35,7 +33,7 @@ Pattern "Redo log cannot be encrypted if the keyring is not loaded." found
 # Starting server with keyring plugin
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 SET GLOBAL innodb_redo_log_encrypt = 1;
 SELECT @@global.innodb_undo_log_encrypt;
 @@global.innodb_undo_log_encrypt
@@ -51,10 +49,11 @@ status_key	status_value
 Component_name	component_keyring_kmip
 Implementation_name	component_keyring_kmip
 Component_status	Active
+Tls_hostname_verification	false
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-OFF
+0
 SET GLOBAL innodb_undo_log_encrypt = 0;
 SELECT @@global.innodb_undo_log_encrypt;
 @@global.innodb_undo_log_encrypt
@@ -66,6 +65,7 @@ status_key	status_value
 Component_name	component_keyring_kmip
 Implementation_name	component_keyring_kmip
 Component_status	Active
+Tls_hostname_verification	false
 DROP TABLE IF EXISTS t1;
 DROP DATABASE IF EXISTS tde_db;
 CREATE DATABASE tde_db;

--- a/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_1.test
+++ b/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_1.test
@@ -19,6 +19,7 @@
 --source include/have_debug.inc
 # Disable in valgrind because of timeout, cf. Bug#22760145
 --source include/not_valgrind.inc
+--source include/not_parallel.inc
 
 --source ../inc/setup_component.inc
 --source include/keyring_tests/mats/mysql_ts_alter_encrypt_1.inc

--- a/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_2.result
+++ b/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_2.result
@@ -228,10 +228,6 @@ DROP TABLESPACE mysql;
 ERROR 42000: InnoDB: `mysql` is a reserved tablespace name.
 ALTER TABLESPACE mysql RENAME TO xyz;
 ERROR 42000: InnoDB: `mysql` is a reserved tablespace name.
-ALTER TABLESPACE mysql ENGINE=myisam;
-ERROR HY000: Engine 'myisam' does not match stored engine 'InnoDB' for tablespace 'mysql'
-ALTER TABLESPACE mysql ENGINE=memory;
-ERROR HY000: Engine 'memory' does not match stored engine 'InnoDB' for tablespace 'mysql'
 #########################################################################
 # Restart with same keyring option
 #   - tables in mysql ts should be accessible

--- a/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_2.test
+++ b/mysql-test/suite/component_keyring_kmip/t/mysql_ts_alter_encrypt_2.test
@@ -21,6 +21,7 @@
 
 --source include/big_test.inc
 --source include/have_debug.inc
+--source include/not_parallel.inc
 # Disable in valgrind because of timeout, cf. Bug#22760145
 --source include/not_valgrind.inc
 

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_2.test
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_2.test
@@ -2,6 +2,7 @@
 # InnoDB transparent tablespace data encryption
 # This test case will test basic encryption support features.
 
+--source include/not_parallel.inc
 --source include/no_valgrind_without_big.inc
 
 --source ../inc/setup_component.inc

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_3.result
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_3.result
@@ -824,7 +824,7 @@ CREATE PROCEDURE tde_db.rotate_master_key()
 begin
 declare i int default 1;
 declare has_error int default 0;
-while (i <= 500) DO
+while (i <= 100) DO
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 set i = i + 1;
 end while;

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_3.test
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_3.test
@@ -2,6 +2,7 @@
 # InnoDB transparent tablespace data encryption
 # This test case will test basic encryption support features.
 
+--source include/not_parallel.inc
 --source include/no_valgrind_without_big.inc
 --source include/have_innodb_max_16k.inc
 

--- a/mysql-test/suite/component_keyring_kmip/t/table_encrypt_4.test
+++ b/mysql-test/suite/component_keyring_kmip/t/table_encrypt_4.test
@@ -4,6 +4,7 @@
 
 --source include/no_valgrind_without_big.inc
 --source include/have_debug.inc
+--source include/not_parallel.inc
 
 --source ../inc/setup_component.inc
 --source include/keyring_tests/innodb/table_encrypt_4.inc

--- a/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_10.result
+++ b/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_10.result
@@ -41,7 +41,7 @@ ERROR HY000: Can't find master key from keyring, please check in the server log 
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 2 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 2 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -75,7 +75,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 4 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 4 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -87,7 +87,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 6 : WITHOUT KEYRING PLUGIN
+# RESTART 6 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -103,6 +104,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 2 -------------------------------------#
 # RESTART 7 : WITH KEYRING
 ########################################################################
@@ -112,7 +114,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 8 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 8 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -146,7 +148,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 10 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 10 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after flushing page 0 at the end
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -158,7 +160,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 12 : WITHOUT KEYRING PLUGIN
+# RESTART 12 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -174,6 +177,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 3 -------------------------------------#
 # RESTART 13 : WITH KEYRING
 ########################################################################
@@ -183,7 +187,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 14 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 14 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before resetting_progress on page 0
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -217,7 +221,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 16 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 16 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before resetting_progress on page 0
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -229,7 +233,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 18 : WITHOUT KEYRING PLUGIN
+# RESTART 18 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -245,6 +250,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 4 -------------------------------------#
 # RESTART 19 : WITH KEYRING
 # Encrypt the tablespace.
@@ -259,7 +265,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 20 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 20 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before updating flags
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -271,7 +277,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 22 : WITHOUT KEYRING PLUGIN
+# RESTART 22 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -287,6 +294,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 5 -------------------------------------#
 # RESTART 23 : WITH KEYRING
 ########################################################################
@@ -296,7 +304,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 24 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 24 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before encryption processing is started
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -330,7 +338,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 26 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 26 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just before encryption processing is started
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -342,7 +350,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 28 : WITHOUT KEYRING PLUGIN
+# RESTART 28 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -358,6 +367,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 6 -------------------------------------#
 # RESTART 29 : WITH KEYRING
 ########################################################################
@@ -367,7 +377,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 30 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 30 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after encryption processing is finished
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -401,7 +411,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 32 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 32 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after encryption processing is finished
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -413,7 +423,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 34 : WITHOUT KEYRING PLUGIN
+# RESTART 34 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -429,6 +440,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 #-------------------------- TEST 7 -------------------------------------#
 # RESTART 35 : WITH KEYRING
 ########################################################################
@@ -438,7 +450,7 @@ SOME VALUES
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 # Encrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
-# RESTART 36 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 36 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after inserting DDL Log Entry
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -472,7 +484,7 @@ NAME	ENCRYPTION
 encrypt_ts	Y
 # Unencrypt the tablespace. It will cause crash.
 ALTER TABLESPACE encrypt_ts ENCRYPTION='N';
-# RESTART 38 : WITH KEYRING PLUGIN after crash and cause resume operation
+# RESTART 38 : WITH KEYRING COMPONENT after crash and cause resume operation
 #              to crash just after inserting DDL Log Entry
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 Got one of the listed errors
@@ -484,7 +496,8 @@ Pattern "Finished DECRYPTION for tablespace encrypt_ts" not found
 # Search the pattern in error log
 Pattern "Resuming DECRYPTION for tablespace encrypt_ts" found
 Pattern "Finished DECRYPTION for tablespace encrypt_ts" found
-# RESTART 40 : WITHOUT KEYRING PLUGIN
+# RESTART 40 : WITHOUT KEYRING COMPONENT
+# Taking backup of local manifest file for MySQL server instance
 SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='encrypt_ts';
 NAME	ENCRYPTION
 encrypt_ts	N
@@ -500,6 +513,7 @@ SOME VALUES
 SOME VALUES
 SOME VALUES
 SOME VALUES
+# Restore local manifest file for MySQL server instance from backup
 ###########
 # Cleanup #
 ###########

--- a/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_10.test
+++ b/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_10.test
@@ -1,6 +1,7 @@
 --source include/have_component_keyring_kmip.inc
 --source include/have_debug.inc
 --source include/big_test.inc
+--source include/not_parallel.inc
 --source include/no_valgrind_without_big.inc
 # Disable in valgrind because of timeout, cf. Bug#22760145
 --source include/not_valgrind.inc

--- a/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_11.test
+++ b/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_11.test
@@ -4,6 +4,7 @@
 --source include/no_valgrind_without_big.inc
 # Disable in valgrind because of timeout, cf. Bug#22760145
 --source include/not_valgrind.inc
+--source include/not_parallel.inc
 
 --source ../inc/setup_component.inc
 --source include/keyring_tests/innodb/tablespace_encrypt_11.inc

--- a/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_3.test
+++ b/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_3.test
@@ -1,6 +1,7 @@
 --source include/have_component_keyring_kmip.inc
 --source include/no_valgrind_without_big.inc
 --source include/have_debug.inc
+--source include/not_parallel.inc
 
 --source ../inc/setup_component.inc
 --source include/keyring_tests/innodb/tablespace_encrypt_3.inc

--- a/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_7.test
+++ b/mysql-test/suite/component_keyring_kmip/t/tablespace_encrypt_7.test
@@ -1,6 +1,7 @@
 --source include/have_component_keyring_kmip.inc
 --source include/big_test.inc
 --source include/have_debug.inc
+--source include/not_parallel.inc
 # --source include/no_valgrind_without_big.inc
 # Disable in valgrind because of timeout, cf. Bug#22760145
 --source include/not_valgrind.inc


### PR DESCRIPTION
This PR contains 2 commits: First fixes crashed in the situation when a KMIP server inaccessible; Second commit fixes tests suite for  component_keyring_kmip