### PR TITLE
PS-11273 [8.4] Signal 6 on Invalid Variable Value

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -75,7 +75,7 @@ SERVICE_TYPE(log_builtins_string) *log_bs = nullptr;
 namespace audit_log_filter {
 namespace {
 
-std::unique_ptr<AuditLogFilter> audit_log_filter;
+AuditLogFilter* audit_log_filter{nullptr};
 
 class EventsConsumer {
  public:
@@ -191,7 +191,7 @@ bool is_stored_program_statement(MYSQL_THD thd) {
 }  // namespace
 
 AuditLogFilter *get_audit_log_filter_instance() noexcept {
-  return audit_log_filter.get();
+  return audit_log_filter;
 }
 
 /*
@@ -388,7 +388,9 @@ mysql_service_status_t audit_log_filter_init() try {
   // Disarm the scope guard only after all potentially-throwing operations
   // succeeded, so that SysVars cleanup still runs on exception.
   comp_registry_srv = nullptr;
-  audit_log_filter = std::move(local_audit_log_filter);
+  if (audit_log_filter != nullptr)
+    delete audit_log_filter;
+  audit_log_filter = local_audit_log_filter.release();
   return 0;
 } catch (const std::exception &e) {
   LogComponentErr(ERROR_LEVEL, ER_AUDIT_INIT_EXCEPTION, e.what());
@@ -421,7 +423,10 @@ mysql_service_status_t audit_log_filter_deinit() try {
   SysVars::deinit();
   SysVars::release_comp_registry_srv();
 
-  audit_log_filter.reset();
+  if (audit_log_filter != nullptr) {
+    delete audit_log_filter;
+    audit_log_filter = nullptr;
+  }
 
   return 0;
 } catch (const std::exception &e) {

--- a/mysql-test/suite/component_audit_log_filter/r/initialization.result
+++ b/mysql-test/suite/component_audit_log_filter/r/initialization.result
@@ -1,0 +1,8 @@
+CALL mtr.add_suppression("Option --authentication-policy is set to an invalid value");
+### Shutdown
+### Start with invalid option
+# restart_abort: --authentication-policy=mysql_native_password --mysql_native_password=OFF
+### Waiting for the error message to occur
+include/wait_for_pattern_in_file.inc [authentication-policy is set to an invalid value]
+### Start again
+# restart:

--- a/mysql-test/suite/component_audit_log_filter/t/initialization.test
+++ b/mysql-test/suite/component_audit_log_filter/t/initialization.test
@@ -1,0 +1,25 @@
+--source include/have_component_audit_log.inc
+--source include/have_debug.inc
+--source ../inc/audit_tables_init.inc
+--source ../inc/audit_comp_install.inc
+
+CALL mtr.add_suppression("Option --authentication-policy is set to an invalid value");
+
+--echo ### Shutdown
+--source include/shutdown_mysqld.inc
+
+--echo ### Start with invalid option
+--let $restart_parameters=--authentication-policy=mysql_native_password --mysql_native_password=OFF
+--source include/start_mysqld_expecting_crash.inc
+
+--echo ### Waiting for the error message to occur
+--let $grep_pattern=authentication-policy is set to an invalid value
+--let $grep_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--source include/wait_for_pattern_in_file.inc
+
+--echo ### Start again
+--let $restart_parameters=restart:
+--source include/start_mysqld.inc
+
+--source ../inc/audit_comp_uninstall.inc
+--source ../inc/audit_tables_cleanup.inc


### PR DESCRIPTION
Problem:
In case of premature termination of the server (e.g. because of incorrect configuration), audit log filter component crashed on destructing a global object (of type str::unique_ptr) which in turn destructed AuditLogFilter. AuditLogFilter destructor crashes on rotating log file as it uses a local static variable which was destroyed prior the global variable. It is because the server doesn't call component's deinit function where the

Fix:
Global uniuque_ptr replaced by raw pointer to avoid non-trivially constructed/destructed objects.