### PR TITLE
PS-11143-[9.7] Fix compilation errors in acl_table_user.cc - proper p…

### DIFF
--- a/sql/auth/acl_table_user.cc
+++ b/sql/auth/acl_table_user.cc
@@ -1630,56 +1630,6 @@ bool Acl_table_user_reader::read_plugin_info(
     user.plugin.length = strlen(user.plugin.str);
 
     /*
-      In case we are working with 5.6 db layout we need to make server
-      aware of Password field and that the plugin column can be null.
-      In case when plugin column is null we use native password plugin
-      if we can.
-    */
-    if (is_old_db_layout && (user.plugin.length == 0 ||
-                             Cached_authentication_plugins::compare_plugin(
-                                 PLUGIN_MYSQL_NATIVE_PASSWORD, user.plugin))) {
-      char *password = get_field(
-          &m_mem_root, m_table->field[m_table_schema->password_idx()]);
-
-      // We do not support pre 4.1 hashes
-      plugin_ref native_plugin =
-          g_cached_authentication_plugins->get_cached_plugin_ref(
-              PLUGIN_MYSQL_NATIVE_PASSWORD);
-      if (native_plugin) {
-        const uint password_len = password ? strlen(password) : 0;
-        st_mysql_auth *auth = (st_mysql_auth *)plugin_decl(native_plugin)->info;
-        Auth_plugin_operation_guard op_guard;
-        if (!op_guard) {
-          LogErr(WARNING_LEVEL, ER_AUTHCACHE_USER_IGNORED_INVALID_PASSWORD,
-                 user.user ? user.user : "",
-                 user.host.get_host() ? user.host.get_host() : "");
-          return true;
-        }
-        if (auth->validate_authentication_string(password, password_len) == 0) {
-          // auth_string takes precedence over password
-          if (user.credentials[PRIMARY_CRED].m_auth_string.length == 0) {
-            user.credentials[PRIMARY_CRED].m_auth_string.str = password;
-            user.credentials[PRIMARY_CRED].m_auth_string.length = password_len;
-          }
-          if (user.plugin.length == 0) {
-            user.plugin.str = Cached_authentication_plugins::get_plugin_name(
-                PLUGIN_MYSQL_NATIVE_PASSWORD);
-            user.plugin.length = strlen(user.plugin.str);
-          }
-        } else {
-          if ((user.access & SUPER_ACL) && !super_users_with_empty_plugin &&
-              (user.plugin.length == 0))
-            super_users_with_empty_plugin = true;
-
-          LogErr(WARNING_LEVEL, ER_AUTHCACHE_USER_IGNORED_DEPRECATED_PASSWORD,
-                 user.user ? user.user : "",
-                 user.host.get_host() ? user.host.get_host() : "");
-          return true;
-        }
-      }
-    }
-
-    /*
       Check if the plugin string is blank or null.
       If it is, the user will be skipped.
     */


### PR DESCRIPTION
…ort from 8.4

Remove native password handling code that references PLUGIN_MYSQL_NATIVE_PASSWORD and PLUGIN_SHA256_PASSWORD constants which are not available in 9.7+.

This code block was ported from 8.4 branch during cherrypick but the referenced constants and native password plugin were removed in 9.7 architecture. The code was handling legacy 5.6 database layout upgrades, which is no longer needed or supported in 9.7+.

Fixes compilation errors:
- 'is_old_db_layout' was not declared in this scope
- 'PLUGIN_MYSQL_NATIVE_PASSWORD' was not declared in this scope; did you mean 'PLUGIN_SHA256_PASSWORD'?

The cherrypick properly removed the parameter from function signatures in 9.7, but this code block that used it was incorrectly left behind.

Please squash it later with prev PS-11143-[9.7]