### PR TITLE
PS-10595 [trunk]: Change the default of innodb_buffer_pool_populate to ON

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_populate_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_populate_basic.result
@@ -1,28 +1,28 @@
 SET @start_global_value = @@global.innodb_buffer_pool_populate;
 SELECT @start_global_value;
 @start_global_value
-0
+1
 Valid values are 'ON' and 'OFF'
 select @@global.innodb_buffer_pool_populate in (0, 1);
 @@global.innodb_buffer_pool_populate in (0, 1)
 1
 select @@global.innodb_buffer_pool_populate;
 @@global.innodb_buffer_pool_populate
-0
+1
 select @@session.innodb_buffer_pool_populate;
 ERROR HY000: Variable 'innodb_buffer_pool_populate' is a GLOBAL variable
 show global variables like 'innodb_buffer_pool_populate';
 Variable_name	Value
-innodb_buffer_pool_populate	OFF
+innodb_buffer_pool_populate	ON
 show session variables like 'innodb_buffer_pool_populate';
 Variable_name	Value
-innodb_buffer_pool_populate	OFF
+innodb_buffer_pool_populate	ON
 select * from performance_schema.global_variables where variable_name='innodb_buffer_pool_populate';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_buffer_pool_populate	OFF
+innodb_buffer_pool_populate	ON
 select * from performance_schema.session_variables where variable_name='innodb_buffer_pool_populate';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_buffer_pool_populate	OFF
+innodb_buffer_pool_populate	ON
 set global innodb_buffer_pool_populate='ON';
 select @@global.innodb_buffer_pool_populate;
 @@global.innodb_buffer_pool_populate
@@ -59,4 +59,4 @@ ERROR 42000: Variable 'innodb_buffer_pool_populate' can't be set to the value of
 SET @@global.innodb_buffer_pool_populate = @start_global_value;
 SELECT @@global.innodb_buffer_pool_populate;
 @@global.innodb_buffer_pool_populate
-0
+1

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -24184,11 +24184,12 @@ static MYSQL_SYSVAR_BOOL(
 static MYSQL_SYSVAR_BOOL(
     buffer_pool_populate, srv_buf_pool_populate, PLUGIN_VAR_NOCMDARG,
     "Enforce page faults for InnoDB buffer pool allocations at allocation time"
-    " (pre-populate pages). When OFF (default), the pre-population is skipped"
-    " to reduce startup time and page-faults happen on first page accesses."
+    " (pre-populate pages). When ON (default), pre-population happens at"
+    " allocation time. When OFF, the pre-population is skipped to reduce"
+    " startup time and page-faults happen on first page accesses."
     " Note: it is recommended to turn on this variable when using large pages"
     " on systems with multiple NUMA nodes.",
-    nullptr, nullptr, false);
+    nullptr, nullptr, true);
 
 static MYSQL_SYSVAR_BOOL(
     api_enable_binlog, ib_binlog_enabled,

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -231,7 +231,7 @@ bool srv_buf_pool_lazy_latch_init = false;
 /** Whether buffer pool allocations (huge and regular pages) are pre-populated
 (MAP_POPULATE and the explicit prefault step) at allocation time. Exposed as the
 innodb_buffer_pool_populate system variable. */
-bool srv_buf_pool_populate = false;
+bool srv_buf_pool_populate = true;
 
 #ifdef UNIV_DEBUG
 /** Force all user tables to use page compression. */


### PR DESCRIPTION
Post-push fix for PS-10595.

innodb_buffer_pool_populate defaulted to OFF, deferring buffer pool page faults to first access at runtime. Testing showed this default causes a measurable performance regression as pages get faulted in on demand during normal operation instead of being pre-populated at startup.

Flip the default to ON so pre-population happens automatically on startup, avoiding the regression without requiring users to set the variable explicitly.

https://perconadev.atlassian.net/browse/PS-10595