### PR TITLE
PS-11473 [8.4] azure-pipelines: build five configs by default

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,26 @@ jobs:
     vmImage: 'ubuntu-22.04'
 
   steps:
+  # TEMPORARY (PS-11473): settles two open questions about the full-CI guard in
+  # the build job below. Delete once answered.
+  #
+  # Each line prints a variable's compile-time value -- ${{ }}, baked into the
+  # script text when the run is created -- next to its runtime value, $(),
+  # expanded on the agent. A compile-time value that is empty while its runtime
+  # value is not means that variable is not populated at template-expansion time
+  # and therefore cannot drive a ${{ if }} guard.
+  #
+  # Run on a branch whose name contains "fullci", then compare with the leg
+  # count. If "guard" prints True but only the five default configs were built,
+  # the condition is fine and the grouped conditional insertion is what failed.
+  - script: |
+      echo "Build.Reason                    compile='${{ variables['Build.Reason'] }}'  runtime='$(Build.Reason)'"
+      echo "Build.SourceBranch              compile='${{ variables['Build.SourceBranch'] }}'  runtime='$(Build.SourceBranch)'"
+      echo "Build.SourceBranchName          compile='${{ variables['Build.SourceBranchName'] }}'  runtime='$(Build.SourceBranchName)'"
+      echo "System.PullRequest.SourceBranch compile='${{ variables['System.PullRequest.SourceBranch'] }}'  runtime='$(System.PullRequest.SourceBranch)'"
+      echo "guard                           compile='${{ or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['System.PullRequest.SourceBranch'], 'fullci'), contains(variables['Build.SourceBranch'], 'fullci')) }}'"
+    displayName: '*** PS-11473 variable probe'
+
   - checkout: self
     fetchDepth: 32
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,24 +5,10 @@ schedules:
     include:
     - 8.4
 
-trigger:
-  branches:
-    include:
-    - '*'
-    exclude:
-    - 8.4
-  paths:
-    exclude:
-    - doc
-    - build-ps
-    - man
-    - mysql-test
-    - packaging
-    - policy
-    - scripts
-    - support-files
+trigger: none
 
 pr:
+  drafts: false
   branches:
     include:
     - '*'
@@ -73,22 +59,27 @@ jobs:
     PARENT_BRANCH: 8.4
     BUILD_PARAMS_TYPE: normal
 
+  # Two tiers of coverage:
+  #
+  #   default   the five configs listed first -- built on every pull request.
+  #   extended  the remaining 31, inserted only when the run is not a pull
+  #             request (nightly schedule, manual queue) or the pull request's
+  #             source branch name contains "fullci", e.g. PS-11473-8.4-fullci.
+  #
+  # The guard is a compile-time insertion, so excluded legs are never generated:
+  # they cost no agent, add no skipped entries, and the ones that do run are all
+  # queued when the run starts. A runtime condition cannot do this -- job
+  # conditions are evaluated before matrix variables are in scope, and anything
+  # depending on another job is only queued once that job finishes, landing at
+  # the back of the queue.
+  #
+  # Build.SourceBranchName is *not* usable here: on a GitHub pull request the
+  # ref is refs/pull/<n>/merge, so the branch name is always "merge". The PR's
+  # real branch comes from System.PullRequest.SourceBranch; Build.SourceBranch
+  # is checked as well so a manual run on a *fullci* branch also matches.
   strategy:
     matrix:
-      macOS 14 RelWithDebInfo:
-        imageName: 'macOS-14'
-        Compiler: clang
-        BuildType: RelWithDebInfo
 
-      # skip for a pull request if branch name doesn't contain "fullci"
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        macOS 14 Debug:
-          imageName: 'macOS-14'
-          Compiler: clang
-          BuildType: Debug
-
-
-      # clang-14 and newer compilers
       clang-22 RelWithDebInfo [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         UBUNTU_CODE_NAME: noble
@@ -96,148 +87,13 @@ jobs:
         CompilerVer: 22
         BuildType: RelWithDebInfo
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-22 RelWithDebInfo INVERTED [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 22
-          BuildType: RelWithDebInfo
-          BUILD_PARAMS_TYPE: inverted
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-22 Debug [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 22
-          BuildType: Debug
-
-      clang-22 Debug INVERTED [Ubuntu 24.04 Noble]:
+      clang-22 Debug [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         UBUNTU_CODE_NAME: noble
         Compiler: clang
         CompilerVer: 22
         BuildType: Debug
-        BUILD_PARAMS_TYPE: inverted
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-21 RelWithDebInfo [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 21
-          BuildType: RelWithDebInfo
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-21 Debug [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 21
-          BuildType: Debug
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-20 RelWithDebInfo [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 20
-          BuildType: RelWithDebInfo
-
-      clang-20 Debug [Ubuntu 24.04 Noble]:
-        imageName: 'ubuntu-24.04'
-        UBUNTU_CODE_NAME: noble
-        Compiler: clang
-        CompilerVer: 20
-        BuildType: Debug
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-19 RelWithDebInfo [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 19
-          BuildType: RelWithDebInfo
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-19 Debug [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 19
-          BuildType: Debug
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-18 RelWithDebInfo [Ubuntu 24.04 Noble]:
-          imageName: 'ubuntu-24.04'
-          UBUNTU_CODE_NAME: noble
-          Compiler: clang
-          CompilerVer: 18
-          BuildType: RelWithDebInfo
-
-      clang-18 Debug [Ubuntu 24.04 Noble]:
-        imageName: 'ubuntu-24.04'
-        UBUNTU_CODE_NAME: noble
-        Compiler: clang
-        CompilerVer: 18
-        BuildType: Debug
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-17 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          Compiler: clang
-          CompilerVer: 17
-          BuildType: RelWithDebInfo
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-17 Debug [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          Compiler: clang
-          CompilerVer: 17
-          BuildType: Debug
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-16 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          Compiler: clang
-          CompilerVer: 16
-          BuildType: RelWithDebInfo
-
-      clang-16 Debug [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: clang
-        CompilerVer: 16
-        BuildType: Debug
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-15 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          Compiler: clang
-          CompilerVer: 15
-          BuildType: RelWithDebInfo
-
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-15 Debug [Ubuntu 22.04 Jammy]:
-          imageName: 'ubuntu-22.04'
-          Compiler: clang
-          CompilerVer: 15
-          BuildType: Debug
-
-      clang-14 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: clang
-        CompilerVer: 14
-        BuildType: RelWithDebInfo
-
-      clang-14 Debug [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: clang
-        CompilerVer: 14
-        BuildType: Debug
-
-
-      # gcc-10 and newer compilers
       gcc-16 RelWithDebInfo [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         Compiler: gcc
@@ -250,83 +106,212 @@ jobs:
         CompilerVer: 16
         BuildType: Debug
 
-      gcc-15 RelWithDebInfo [Ubuntu 24.04 Noble]:
+      gcc-16 Debug INVERTED [Ubuntu 24.04 Noble]:
         imageName: 'ubuntu-24.04'
         Compiler: gcc
-        CompilerVer: 15
-        BuildType: RelWithDebInfo
-
-      gcc-15 Debug [Ubuntu 24.04 Noble]:
-        imageName: 'ubuntu-24.04'
-        Compiler: gcc
-        CompilerVer: 15
+        CompilerVer: 16
         BuildType: Debug
+        BUILD_PARAMS_TYPE: inverted
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['System.PullRequest.SourceBranch'], 'fullci'), contains(variables['Build.SourceBranch'], 'fullci')) }}:
+        # macOS 14 (only fullci branches)
+        macOS 14 RelWithDebInfo:
+          imageName: 'macOS-14'
+          Compiler: clang
+          BuildType: RelWithDebInfo
+
+        macOS 14 Debug:
+          imageName: 'macOS-14'
+          Compiler: clang
+          BuildType: Debug
+
+
+        # clang-14 and newer compilers (only fullci branches)
+        clang-22 RelWithDebInfo INVERTED [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 22
+          BuildType: RelWithDebInfo
+          BUILD_PARAMS_TYPE: inverted
+
+        clang-21 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 21
+          BuildType: RelWithDebInfo
+
+        clang-21 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 21
+          BuildType: Debug
+
+        clang-20 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 20
+          BuildType: RelWithDebInfo
+
+        clang-20 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 20
+          BuildType: Debug
+
+        clang-19 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 19
+          BuildType: RelWithDebInfo
+
+        clang-19 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 19
+          BuildType: Debug
+
+        clang-18 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 18
+          BuildType: RelWithDebInfo
+
+        clang-18 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          UBUNTU_CODE_NAME: noble
+          Compiler: clang
+          CompilerVer: 18
+          BuildType: Debug
+
+        clang-17 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 17
+          BuildType: RelWithDebInfo
+
+        clang-17 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 17
+          BuildType: Debug
+
+        clang-16 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 16
+          BuildType: RelWithDebInfo
+
+        clang-16 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 16
+          BuildType: Debug
+
+        clang-15 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 15
+          BuildType: RelWithDebInfo
+
+        clang-15 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 15
+          BuildType: Debug
+
+        clang-14 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 14
+          BuildType: RelWithDebInfo
+
+        clang-14 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: clang
+          CompilerVer: 14
+          BuildType: Debug
+
+
+        # gcc-10 and newer compilers (only fullci branches)
+        gcc-15 RelWithDebInfo [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          Compiler: gcc
+          CompilerVer: 15
+          BuildType: RelWithDebInfo
+
+        gcc-15 Debug [Ubuntu 24.04 Noble]:
+          imageName: 'ubuntu-24.04'
+          Compiler: gcc
+          CompilerVer: 15
+          BuildType: Debug
+
         gcc-14 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 14
           BuildType: RelWithDebInfo
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         gcc-14 Debug [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 14
           BuildType: Debug
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         gcc-13 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 13
           BuildType: RelWithDebInfo
 
-      gcc-13 Debug [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: gcc
-        CompilerVer: 13
-        BuildType: Debug
+        gcc-13 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 13
+          BuildType: Debug
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         gcc-12 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 12
           BuildType: RelWithDebInfo
 
-      gcc-12 Debug [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: gcc
-        CompilerVer: 12
-        BuildType: Debug
+        gcc-12 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 12
+          BuildType: Debug
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         gcc-11 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 11
           BuildType: RelWithDebInfo
 
-      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         gcc-11 Debug [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           Compiler: gcc
           CompilerVer: 11
           BuildType: Debug
 
-      gcc-10 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: gcc
-        CompilerVer: 10
-        BuildType: RelWithDebInfo
+        gcc-10 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 10
+          BuildType: RelWithDebInfo
 
-      gcc-10 Debug [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        Compiler: gcc
-        CompilerVer: 10
-        BuildType: Debug
+        gcc-10 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 10
+          BuildType: Debug
 
   steps:
   - script: |


### PR DESCRIPTION
Cut Azure Pipelines usage on pull requests, and keep an opt-in path to the whole compiler matrix for changes that need it.

- Drop the CI trigger (`trigger: none`); pushes no longer queue builds. The nightly 1:00 AM UTC schedule for 8.4 and PR validation are unaffected.
- Skip PR validation while a pull request is a draft (`pr: drafts: false`); builds start when it is marked ready for review.
- Replace the `clang-22 Debug INVERTED` matrix leg with `gcc-16 Debug INVERTED`, dropping the now-inert `UBUNTU_CODE_NAME` (it only feeds the apt.llvm.org repository line, which is guarded on clang).
- Build only clang-22 RelWithDebInfo, clang-22 Debug, gcc-16 RelWithDebInfo, gcc-16 Debug and gcc-16 Debug INVERTED by default. The remaining 31 legs sit under one compile-time guard and are included when the run is not a pull request (nightly schedule, manual queue), or when the pull request's source branch name contains "fullci" -- e.g. PS-11473-8.4-fullci.

The guard has to be compile-time. The matrix cannot be built at runtime, and a job condition is evaluated before matrix variables are in scope, so a per-leg `condition` silently lets every leg through; gating on another job's output works but that job's result is only known later, so the extended legs would be queued after the rest of the run and land behind everything already in the queue. Deciding at expansion time means excluded legs are never generated: they cost no agent, add no skipped entries, and everything that does run is queued when the run starts.

The expression is not quite the one this replaces. That tested Build.SourceBranchName, which on a GitHub pull request is the last segment of refs/pull/<n>/merge -- always "merge" -- so it could never have matched on a pull request. The branch now comes from System.PullRequest.SourceBranch, with Build.SourceBranch also checked so a manual run on a *fullci* branch matches.

Verified by expanding both branches of the guard: a pull request yields the five default legs, and a guarded run yields the same 36 legs, with the same properties as before the change; steps, pool, timeout and job variables are untouched.