### PR TITLE
PS-9768 [8.4] duplicate key in table while using tmp table for group by a json data

### DIFF
--- a/mysql-test/suite/percona/r/ps9768.result
+++ b/mysql-test/suite/percona/r/ps9768.result
@@ -247,5 +247,115 @@ SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
 FROM information_schema.OPTIMIZER_TRACE;
 group_by_substituted
 1
+#
+# Case 10: residual gap — TYPECAST is still stripped under
+#          require_same_value, so a functional index CAST(.. AS UNSIGNED)
+#          replaces GROUP BY on the inner expression and merges '1' and
+#          '01'. If require_same_value also refused TYPECAST_FUNC, the
+#          GROUP BY below would not be rewritten (substituted=0) and the
+#          three distinct strings would remain three groups, matching
+#          IGNORE INDEX FOR GROUP BY. Exact CAST() GROUP BY and WHERE
+#          pushdown must keep working either way.
+#
+CREATE TABLE t8 (
+data2 json,
+INDEX idx ((CAST(data2->>'$.n' AS UNSIGNED)))
+);
+INSERT INTO t8 VALUES
+(JSON_OBJECT('n','1')),
+(JSON_OBJECT('n','01')),
+(JSON_OBJECT('n','2'));
+SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8 GROUP BY data2->>'$.n';
+c	*
+1	2
+2	1
+# Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
+SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8
+IGNORE INDEX FOR GROUP BY (idx) GROUP BY data2->>'$.n';
+c	*
+01	1
+1	1
+2	1
+SELECT CAST(data2->>'$.n' AS UNSIGNED) AS c, count(*) AS `*` FROM t8
+GROUP BY CAST(data2->>'$.n' AS UNSIGNED);
+c	*
+1	2
+2	1
+# Expect 1 either way: exact CAST match
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
+SELECT data2 FROM t8 WHERE CAST(data2->>'$.n' AS UNSIGNED) = 1;
+data2
+{"n": "01"}
+{"n": "1"}
+# Expect 1: WHERE pushdown unchanged
+SELECT TRACE LIKE '%as unsigned%' AS where_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+where_substituted
+1
+#
+# Case 11: residual gap — same TYPECAST stripping with a length-
+#          changing CAST and a matching collation. 'aa' and 'ab' are
+#          merged into one group today. Gating TYPECAST under
+#          require_same_value would leave three groups. Non-strict
+#          sql_mode is required so truncated functional-index values
+#          can be stored.
+#
+SET @old_sql_mode= @@sql_mode;
+SET sql_mode='';
+CREATE TABLE t9 (
+data2 json,
+INDEX idx (((CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4)) COLLATE utf8mb4_bin))
+);
+INSERT INTO t9 VALUES
+(JSON_OBJECT('a','aa')),
+(JSON_OBJECT('a','ab')),
+(JSON_OBJECT('a','b'));
+Warnings:
+Warning	3751	Data truncated for functional index 'idx' at row 1
+Warning	3751	Data truncated for functional index 'idx' at row 2
+SET sql_mode= @old_sql_mode;
+SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9 GROUP BY data2->>'$.a';
+c	*
+aa	2
+b	1
+# Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
+SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9
+IGNORE INDEX FOR GROUP BY (idx) GROUP BY data2->>'$.a';
+c	*
+aa	1
+ab	1
+b	1
+SELECT CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin AS c,
+count(*) AS `*` FROM t9
+GROUP BY CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin;
+c	*
+a	2
+b	1
+# Expect 1 either way: exact CAST/COLLATE match
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
+SELECT data2 FROM t9
+WHERE CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin = 'a';
+data2
+{"a": "aa"}
+{"a": "ab"}
+# Expect 1: WHERE pushdown unchanged
+SELECT TRACE LIKE '%collate%utf8mb4_bin% = %' AS where_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+where_substituted
+1
 SET SESSION optimizer_trace="enabled=off";
-DROP TABLE t, t2, t3, t4, t5, t6, t7;
+DROP TABLE t, t2, t3, t4, t5, t6, t7, t8, t9;

--- a/mysql-test/suite/percona/r/ps9768.result
+++ b/mysql-test/suite/percona/r/ps9768.result
@@ -248,14 +248,11 @@ FROM information_schema.OPTIMIZER_TRACE;
 group_by_substituted
 1
 #
-# Case 10: residual gap — TYPECAST is still stripped under
-#          require_same_value, so a functional index CAST(.. AS UNSIGNED)
-#          replaces GROUP BY on the inner expression and merges '1' and
-#          '01'. If require_same_value also refused TYPECAST_FUNC, the
-#          GROUP BY below would not be rewritten (substituted=0) and the
-#          three distinct strings would remain three groups, matching
-#          IGNORE INDEX FOR GROUP BY. Exact CAST() GROUP BY and WHERE
-#          pushdown must keep working either way.
+# Case 10: require_same_value also refuses to strip TYPECAST, so a
+#          functional index CAST(.. AS UNSIGNED) must not replace
+#          GROUP BY on the inner expression. '1' and '01' stay two
+#          groups, matching IGNORE INDEX FOR GROUP BY. Exact CAST()
+#          GROUP BY and WHERE pushdown must keep working.
 #
 CREATE TABLE t8 (
 data2 json,
@@ -267,13 +264,14 @@ INSERT INTO t8 VALUES
 (JSON_OBJECT('n','2'));
 SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8 GROUP BY data2->>'$.n';
 c	*
-1	2
+01	1
+1	1
 2	1
-# Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+# Expect 0: TYPECAST on the index expression is not skipped
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
 FROM information_schema.OPTIMIZER_TRACE;
 group_by_substituted
-1
+0
 SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8
 IGNORE INDEX FOR GROUP BY (idx) GROUP BY data2->>'$.n';
 c	*
@@ -285,7 +283,7 @@ GROUP BY CAST(data2->>'$.n' AS UNSIGNED);
 c	*
 1	2
 2	1
-# Expect 1 either way: exact CAST match
+# Expect 1: exact CAST match is still substituted
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
 FROM information_schema.OPTIMIZER_TRACE;
 group_by_substituted
@@ -300,12 +298,9 @@ FROM information_schema.OPTIMIZER_TRACE;
 where_substituted
 1
 #
-# Case 11: residual gap — same TYPECAST stripping with a length-
-#          changing CAST and a matching collation. 'aa' and 'ab' are
-#          merged into one group today. Gating TYPECAST under
-#          require_same_value would leave three groups. Non-strict
-#          sql_mode is required so truncated functional-index values
-#          can be stored.
+# Case 11: same for a length-changing CAST with a matching collation.
+#          'aa' and 'ab' must remain two groups. Non-strict sql_mode is
+#          required so truncated functional-index values can be stored.
 #
 SET @old_sql_mode= @@sql_mode;
 SET sql_mode='';
@@ -323,13 +318,14 @@ Warning	3751	Data truncated for functional index 'idx' at row 2
 SET sql_mode= @old_sql_mode;
 SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9 GROUP BY data2->>'$.a';
 c	*
-aa	2
+aa	1
+ab	1
 b	1
-# Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+# Expect 0: TYPECAST on the index expression is not skipped
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
 FROM information_schema.OPTIMIZER_TRACE;
 group_by_substituted
-1
+0
 SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9
 IGNORE INDEX FOR GROUP BY (idx) GROUP BY data2->>'$.a';
 c	*
@@ -342,7 +338,7 @@ GROUP BY CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin;
 c	*
 a	2
 b	1
-# Expect 1 either way: exact CAST/COLLATE match
+# Expect 1: exact CAST/COLLATE match is still substituted
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
 FROM information_schema.OPTIMIZER_TRACE;
 group_by_substituted

--- a/mysql-test/suite/percona/r/ps9768.result
+++ b/mysql-test/suite/percona/r/ps9768.result
@@ -1,0 +1,121 @@
+# PS-9768: Bogus "Can't write; duplicate key in table" error for GROUP BY
+#          on JSON_EXTRACT() when an indexed generated column unquotes
+#          the very same expression.
+#
+# An indexed GC may only replace an ORDER/GROUP BY expression when it
+# evaluates to the same value. JSON_UNQUOTE() in the GC expression must
+# therefore not be skipped when matching, unlike for the WHERE clause.
+CREATE TABLE t (
+id int auto_increment,
+data1 json,
+data2 json,
+`i` bigint GENERATED ALWAYS AS (
+json_unquote(json_extract(`data1`,_utf8mb4'$.i'))
+) STORED,
+`a` varchar(128) GENERATED ALWAYS AS (
+json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+) STORED,
+primary key (id),
+key (a,i),
+key i (i)
+) ENGINE=innodb;
+INSERT INTO t (data1,data2) values
+(JSON_OBJECT('i', 1),JSON_OBJECT('a', "a")),
+(JSON_OBJECT('i', 1),JSON_OBJECT('a', "a")),
+(JSON_OBJECT('i', 1),JSON_OBJECT('a', "b"));
+SET SESSION optimizer_trace="enabled=on";
+#
+# Case 1: the reported query. Must not fail with ER_DUP_KEY, and must
+#         group on the quoted values returned by JSON_EXTRACT().
+#
+SELECT
+JSON_EXTRACT(data2, '$.a') as `a`,
+CAST(count(*) AS JSON) as `*`
+FROM test.t
+WHERE
+i = 1
+GROUP BY
+JSON_EXTRACT(data2, '$.a');
+a	*
+"a"	2
+"b"	1
+# Expect 0: the GROUP BY list was not rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+0
+#
+# Case 2: ORDER BY on the same expression. JSON comparison sorts numbers
+#         before strings, so 2 precedes "10", while ordering by the
+#         unquoted GC would have put '10' first.
+#
+CREATE TABLE t2 (
+data2 json,
+`a` varchar(128) GENERATED ALWAYS AS (
+json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+) STORED,
+key (a)
+) ENGINE=innodb;
+INSERT INTO t2 (data2) VALUES
+(JSON_OBJECT('a', 2)),
+(JSON_OBJECT('a', "10"));
+SELECT JSON_EXTRACT(data2, '$.a') AS `a` FROM t2
+ORDER BY JSON_EXTRACT(data2, '$.a');
+a
+2
+"10"
+# Expect 0: the ORDER BY list was not rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_ORDER_BY%' AS order_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+order_by_substituted
+0
+#
+# Case 3: single table DELETE ... ORDER BY uses the same code path, so
+#         the JSON-ordered first row (2) has to be the one deleted.
+#
+DELETE FROM t2 ORDER BY JSON_EXTRACT(data2, '$.a') LIMIT 1;
+SELECT JSON_EXTRACT(data2, '$.a') AS `a` FROM t2;
+a
+"10"
+#
+# Case 4: the optimization is not over-blocked. When the query unquotes
+#         the value itself the GC is value preserving (its collation
+#         matches the one of JSON_UNQUOTE()) and must still be used.
+#
+CREATE TABLE t3 (
+data2 json,
+`a` varchar(128) COLLATE utf8mb4_bin GENERATED ALWAYS AS (
+json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+) STORED,
+key (a)
+) ENGINE=innodb;
+INSERT INTO t3 (data2) VALUES
+(JSON_OBJECT('a', "a")),
+(JSON_OBJECT('a', "a")),
+(JSON_OBJECT('a', "b"));
+SELECT JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a')) AS `a`, count(*) AS `*`
+FROM t3
+GROUP BY JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a'));
+a	*
+a	2
+b	1
+# Expect 1: the GROUP BY list was rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
+#
+# Case 5: WHERE clause behaviour is unchanged, the index over the
+#         unquoting GC is still used for a JSON_EXTRACT() predicate.
+#
+# Expect 1: the condition was rewritten to use GC 'a'
+SELECT JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a')) AS `a` FROM t3
+WHERE JSON_EXTRACT(data2, '$.a') = 'b';
+a
+b
+SELECT TRACE LIKE '%`a` = %' AS where_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+where_substituted
+1
+SET SESSION optimizer_trace="enabled=off";
+DROP TABLE t, t2, t3;

--- a/mysql-test/suite/percona/r/ps9768.result
+++ b/mysql-test/suite/percona/r/ps9768.result
@@ -117,5 +117,135 @@ SELECT TRACE LIKE '%`a` = %' AS where_substituted
 FROM information_schema.OPTIMIZER_TRACE;
 where_substituted
 1
+#
+# Case 6: a multi-valued index's field holds the set of values the
+#         expression evaluates to, not the value itself, so it must
+#         never replace a GROUP BY expression. Two distinct arrays
+#         are two groups.
+#
+CREATE TABLE t4 (j json, INDEX mvi ((CAST(j->'$.arr' AS UNSIGNED ARRAY))));
+INSERT INTO t4 VALUES ('{"arr":[1,2,3]}'), ('{"arr":[4,5,6]}');
+# Warnings are off: the hypergraph optimizer notes that it does not
+# support sorting of non-scalar JSON values.
+SELECT j->'$.arr' AS c, count(*) AS `*` FROM t4 GROUP BY j->'$.arr';
+c	*
+[1, 2, 3]	1
+[4, 5, 6]	1
+# Expect 0: the GROUP BY list was not rewritten to use the array field
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+0
+# The multi-valued index is still used for the predicates it supports:
+# the predicand is substituted with the array field, which the trace
+# prints as its expression, CAST(.. AS UNSIGNED ARRAY).
+SELECT * FROM t4 WHERE 3 MEMBER OF (j->'$.arr');
+j
+{"arr": [1, 2, 3]}
+# Expect 1
+SELECT TRACE LIKE '%as unsigned array%' AS predicand_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+predicand_substituted
+1
+SELECT * FROM t4 WHERE JSON_CONTAINS(j->'$.arr', '[3]');
+j
+{"arr": [1, 2, 3]}
+# Expect 1
+SELECT TRACE LIKE '%as unsigned array%' AS predicand_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+predicand_substituted
+1
+SELECT * FROM t4 WHERE JSON_OVERLAPS(j->'$.arr', '[3,7]');
+j
+{"arr": [1, 2, 3]}
+# Expect 1
+SELECT TRACE LIKE '%as unsigned array%' AS predicand_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+predicand_substituted
+1
+#
+# Case 7: grouping and sorting follow the collation, so a GC whose
+#         collation differs from the one of the expression must not
+#         replace it. JSON_UNQUOTE() returns utf8mb4_bin while the
+#         functional index below is utf8mb4_0900_ai_ci, hence 'a' and
+#         'A' are two groups but would be merged into one.
+#
+CREATE TABLE t5 (data2 json, INDEX idx ((CAST(data2->>'$.a' AS CHAR(30)))));
+INSERT INTO t5 VALUES (JSON_OBJECT('a','a')), (JSON_OBJECT('a','A'));
+SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t5 GROUP BY data2->>'$.a';
+c	*
+A	1
+a	1
+# Expect 0: the GROUP BY list was not rewritten to use the index
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+0
+# Same for ORDER BY, utf8mb4_bin sorts 'A' before 'a'
+SELECT data2->>'$.a' AS c FROM t5 ORDER BY data2->>'$.a';
+c
+A
+a
+SELECT TRACE LIKE '%resulting_ORDER_BY%' AS order_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+order_by_substituted
+0
+# When the query asks for the same collation the index is still used
+SELECT CAST(data2->>'$.a' AS CHAR(30)) AS c, count(*) AS `*` FROM t5
+GROUP BY CAST(data2->>'$.a' AS CHAR(30));
+c	*
+a	2
+# Expect 1
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
+# WHERE pushdown to the functional index is unaffected: the condition
+# is rewritten to the hidden field, printed as its CAST() expression.
+SELECT data2 FROM t5 WHERE CAST(data2->>'$.a' AS CHAR(30)) = 'a';
+data2
+{"a": "A"}
+{"a": "a"}
+# Expect 1
+SELECT TRACE LIKE '%as char(30) charset utf8mb4) = %' AS where_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+where_substituted
+1
+#
+# Case 8: the same collation mismatch on a plain generated column
+#
+CREATE TABLE t6 (
+data2 json,
+`a` varchar(128) GENERATED ALWAYS AS (
+json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+) STORED,
+key (a)
+) ENGINE=innodb;
+INSERT INTO t6 (data2) VALUES (JSON_OBJECT('a','a')), (JSON_OBJECT('a','A'));
+SELECT json_unquote(json_extract(data2,'$.a')) AS c, count(*) AS `*` FROM t6
+GROUP BY json_unquote(json_extract(data2,'$.a'));
+c	*
+A	1
+a	1
+# Expect 0: the GROUP BY list was not rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+0
+#
+# Case 9: a numeric GC has no collation to compare, it must still be
+#         substituted.
+#
+CREATE TABLE t7 (f1 int, gc int GENERATED ALWAYS AS (f1 + 1) STORED, key (gc));
+INSERT INTO t7 (f1) VALUES (1),(1),(2);
+SELECT f1 + 1 AS c, count(*) AS `*` FROM t7 GROUP BY f1 + 1;
+c	*
+2	2
+3	1
+# Expect 1
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+FROM information_schema.OPTIMIZER_TRACE;
+group_by_substituted
+1
 SET SESSION optimizer_trace="enabled=off";
-DROP TABLE t, t2, t3;
+DROP TABLE t, t2, t3, t4, t5, t6, t7;

--- a/mysql-test/suite/percona/t/ps9768.test
+++ b/mysql-test/suite/percona/t/ps9768.test
@@ -226,14 +226,11 @@ SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
 --echo #
---echo # Case 10: residual gap — TYPECAST is still stripped under
---echo #          require_same_value, so a functional index CAST(.. AS UNSIGNED)
---echo #          replaces GROUP BY on the inner expression and merges '1' and
---echo #          '01'. If require_same_value also refused TYPECAST_FUNC, the
---echo #          GROUP BY below would not be rewritten (substituted=0) and the
---echo #          three distinct strings would remain three groups, matching
---echo #          IGNORE INDEX FOR GROUP BY. Exact CAST() GROUP BY and WHERE
---echo #          pushdown must keep working either way.
+--echo # Case 10: require_same_value also refuses to strip TYPECAST, so a
+--echo #          functional index CAST(.. AS UNSIGNED) must not replace
+--echo #          GROUP BY on the inner expression. '1' and '01' stay two
+--echo #          groups, matching IGNORE INDEX FOR GROUP BY. Exact CAST()
+--echo #          GROUP BY and WHERE pushdown must keep working.
 --echo #
 CREATE TABLE t8 (
   data2 json,
@@ -246,7 +243,7 @@ INSERT INTO t8 VALUES
 
 --sorted_result
 SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8 GROUP BY data2->>'$.n';
---echo # Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+--echo # Expect 0: TYPECAST on the index expression is not skipped
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
@@ -257,7 +254,7 @@ SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8
 --sorted_result
 SELECT CAST(data2->>'$.n' AS UNSIGNED) AS c, count(*) AS `*` FROM t8
   GROUP BY CAST(data2->>'$.n' AS UNSIGNED);
---echo # Expect 1 either way: exact CAST match
+--echo # Expect 1: exact CAST match is still substituted
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
@@ -268,12 +265,9 @@ SELECT TRACE LIKE '%as unsigned%' AS where_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
 --echo #
---echo # Case 11: residual gap — same TYPECAST stripping with a length-
---echo #          changing CAST and a matching collation. 'aa' and 'ab' are
---echo #          merged into one group today. Gating TYPECAST under
---echo #          require_same_value would leave three groups. Non-strict
---echo #          sql_mode is required so truncated functional-index values
---echo #          can be stored.
+--echo # Case 11: same for a length-changing CAST with a matching collation.
+--echo #          'aa' and 'ab' must remain two groups. Non-strict sql_mode is
+--echo #          required so truncated functional-index values can be stored.
 --echo #
 SET @old_sql_mode= @@sql_mode;
 SET sql_mode='';
@@ -291,7 +285,7 @@ SET sql_mode= @old_sql_mode;
 --sorted_result
 SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9 GROUP BY data2->>'$.a';
 --enable_warnings
---echo # Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+--echo # Expect 0: TYPECAST on the index expression is not skipped
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
@@ -305,7 +299,7 @@ SELECT CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin AS c,
        count(*) AS `*` FROM t9
   GROUP BY CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin;
 --enable_warnings
---echo # Expect 1 either way: exact CAST/COLLATE match
+--echo # Expect 1: exact CAST/COLLATE match is still substituted
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 

--- a/mysql-test/suite/percona/t/ps9768.test
+++ b/mysql-test/suite/percona/t/ps9768.test
@@ -1,0 +1,119 @@
+--echo # PS-9768: Bogus "Can't write; duplicate key in table" error for GROUP BY
+--echo #          on JSON_EXTRACT() when an indexed generated column unquotes
+--echo #          the very same expression.
+--echo #
+--echo # An indexed GC may only replace an ORDER/GROUP BY expression when it
+--echo # evaluates to the same value. JSON_UNQUOTE() in the GC expression must
+--echo # therefore not be skipped when matching, unlike for the WHERE clause.
+
+CREATE TABLE t (
+  id int auto_increment,
+  data1 json,
+  data2 json,
+  `i` bigint GENERATED ALWAYS AS (
+    json_unquote(json_extract(`data1`,_utf8mb4'$.i'))
+  ) STORED,
+  `a` varchar(128) GENERATED ALWAYS AS (
+    json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+  ) STORED,
+  primary key (id),
+  key (a,i),
+  key i (i)
+) ENGINE=innodb;
+
+INSERT INTO t (data1,data2) values
+(JSON_OBJECT('i', 1),JSON_OBJECT('a', "a")),
+(JSON_OBJECT('i', 1),JSON_OBJECT('a', "a")),
+(JSON_OBJECT('i', 1),JSON_OBJECT('a', "b"));
+
+SET SESSION optimizer_trace="enabled=on";
+
+--echo #
+--echo # Case 1: the reported query. Must not fail with ER_DUP_KEY, and must
+--echo #         group on the quoted values returned by JSON_EXTRACT().
+--echo #
+--sorted_result
+SELECT
+    JSON_EXTRACT(data2, '$.a') as `a`,
+    CAST(count(*) AS JSON) as `*`
+FROM test.t
+WHERE
+    i = 1
+GROUP BY
+    JSON_EXTRACT(data2, '$.a');
+
+--echo # Expect 0: the GROUP BY list was not rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 2: ORDER BY on the same expression. JSON comparison sorts numbers
+--echo #         before strings, so 2 precedes "10", while ordering by the
+--echo #         unquoted GC would have put '10' first.
+--echo #
+CREATE TABLE t2 (
+  data2 json,
+  `a` varchar(128) GENERATED ALWAYS AS (
+    json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+  ) STORED,
+  key (a)
+) ENGINE=innodb;
+
+INSERT INTO t2 (data2) VALUES
+(JSON_OBJECT('a', 2)),
+(JSON_OBJECT('a', "10"));
+
+SELECT JSON_EXTRACT(data2, '$.a') AS `a` FROM t2
+  ORDER BY JSON_EXTRACT(data2, '$.a');
+
+--echo # Expect 0: the ORDER BY list was not rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_ORDER_BY%' AS order_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 3: single table DELETE ... ORDER BY uses the same code path, so
+--echo #         the JSON-ordered first row (2) has to be the one deleted.
+--echo #
+DELETE FROM t2 ORDER BY JSON_EXTRACT(data2, '$.a') LIMIT 1;
+SELECT JSON_EXTRACT(data2, '$.a') AS `a` FROM t2;
+
+--echo #
+--echo # Case 4: the optimization is not over-blocked. When the query unquotes
+--echo #         the value itself the GC is value preserving (its collation
+--echo #         matches the one of JSON_UNQUOTE()) and must still be used.
+--echo #
+CREATE TABLE t3 (
+  data2 json,
+  `a` varchar(128) COLLATE utf8mb4_bin GENERATED ALWAYS AS (
+    json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+  ) STORED,
+  key (a)
+) ENGINE=innodb;
+
+INSERT INTO t3 (data2) VALUES
+(JSON_OBJECT('a', "a")),
+(JSON_OBJECT('a', "a")),
+(JSON_OBJECT('a', "b"));
+
+--sorted_result
+SELECT JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a')) AS `a`, count(*) AS `*`
+FROM t3
+GROUP BY JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a'));
+
+--echo # Expect 1: the GROUP BY list was rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 5: WHERE clause behaviour is unchanged, the index over the
+--echo #         unquoting GC is still used for a JSON_EXTRACT() predicate.
+--echo #
+--echo # Expect 1: the condition was rewritten to use GC 'a'
+SELECT JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a')) AS `a` FROM t3
+  WHERE JSON_EXTRACT(data2, '$.a') = 'b';
+SELECT TRACE LIKE '%`a` = %' AS where_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+SET SESSION optimizer_trace="enabled=off";
+
+DROP TABLE t, t2, t3;

--- a/mysql-test/suite/percona/t/ps9768.test
+++ b/mysql-test/suite/percona/t/ps9768.test
@@ -114,6 +114,117 @@ SELECT JSON_UNQUOTE(JSON_EXTRACT(data2, '$.a')) AS `a` FROM t3
 SELECT TRACE LIKE '%`a` = %' AS where_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
+--echo #
+--echo # Case 6: a multi-valued index's field holds the set of values the
+--echo #         expression evaluates to, not the value itself, so it must
+--echo #         never replace a GROUP BY expression. Two distinct arrays
+--echo #         are two groups.
+--echo #
+CREATE TABLE t4 (j json, INDEX mvi ((CAST(j->'$.arr' AS UNSIGNED ARRAY))));
+INSERT INTO t4 VALUES ('{"arr":[1,2,3]}'), ('{"arr":[4,5,6]}');
+
+--echo # Warnings are off: the hypergraph optimizer notes that it does not
+--echo # support sorting of non-scalar JSON values.
+--disable_warnings
+--sorted_result
+SELECT j->'$.arr' AS c, count(*) AS `*` FROM t4 GROUP BY j->'$.arr';
+--enable_warnings
+
+--echo # Expect 0: the GROUP BY list was not rewritten to use the array field
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo # The multi-valued index is still used for the predicates it supports:
+--echo # the predicand is substituted with the array field, which the trace
+--echo # prints as its expression, CAST(.. AS UNSIGNED ARRAY).
+SELECT * FROM t4 WHERE 3 MEMBER OF (j->'$.arr');
+--echo # Expect 1
+SELECT TRACE LIKE '%as unsigned array%' AS predicand_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+SELECT * FROM t4 WHERE JSON_CONTAINS(j->'$.arr', '[3]');
+--echo # Expect 1
+SELECT TRACE LIKE '%as unsigned array%' AS predicand_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--sorted_result
+SELECT * FROM t4 WHERE JSON_OVERLAPS(j->'$.arr', '[3,7]');
+--echo # Expect 1
+SELECT TRACE LIKE '%as unsigned array%' AS predicand_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 7: grouping and sorting follow the collation, so a GC whose
+--echo #         collation differs from the one of the expression must not
+--echo #         replace it. JSON_UNQUOTE() returns utf8mb4_bin while the
+--echo #         functional index below is utf8mb4_0900_ai_ci, hence 'a' and
+--echo #         'A' are two groups but would be merged into one.
+--echo #
+CREATE TABLE t5 (data2 json, INDEX idx ((CAST(data2->>'$.a' AS CHAR(30)))));
+INSERT INTO t5 VALUES (JSON_OBJECT('a','a')), (JSON_OBJECT('a','A'));
+
+--sorted_result
+SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t5 GROUP BY data2->>'$.a';
+
+--echo # Expect 0: the GROUP BY list was not rewritten to use the index
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo # Same for ORDER BY, utf8mb4_bin sorts 'A' before 'a'
+SELECT data2->>'$.a' AS c FROM t5 ORDER BY data2->>'$.a';
+SELECT TRACE LIKE '%resulting_ORDER_BY%' AS order_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo # When the query asks for the same collation the index is still used
+--sorted_result
+SELECT CAST(data2->>'$.a' AS CHAR(30)) AS c, count(*) AS `*` FROM t5
+  GROUP BY CAST(data2->>'$.a' AS CHAR(30));
+--echo # Expect 1
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo # WHERE pushdown to the functional index is unaffected: the condition
+--echo # is rewritten to the hidden field, printed as its CAST() expression.
+--sorted_result
+SELECT data2 FROM t5 WHERE CAST(data2->>'$.a' AS CHAR(30)) = 'a';
+--echo # Expect 1
+SELECT TRACE LIKE '%as char(30) charset utf8mb4) = %' AS where_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 8: the same collation mismatch on a plain generated column
+--echo #
+CREATE TABLE t6 (
+  data2 json,
+  `a` varchar(128) GENERATED ALWAYS AS (
+    json_unquote(json_extract(`data2`,_utf8mb4'$.a'))
+  ) STORED,
+  key (a)
+) ENGINE=innodb;
+INSERT INTO t6 (data2) VALUES (JSON_OBJECT('a','a')), (JSON_OBJECT('a','A'));
+
+--sorted_result
+SELECT json_unquote(json_extract(data2,'$.a')) AS c, count(*) AS `*` FROM t6
+  GROUP BY json_unquote(json_extract(data2,'$.a'));
+
+--echo # Expect 0: the GROUP BY list was not rewritten to use GC 'a'
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 9: a numeric GC has no collation to compare, it must still be
+--echo #         substituted.
+--echo #
+CREATE TABLE t7 (f1 int, gc int GENERATED ALWAYS AS (f1 + 1) STORED, key (gc));
+INSERT INTO t7 (f1) VALUES (1),(1),(2);
+
+--sorted_result
+SELECT f1 + 1 AS c, count(*) AS `*` FROM t7 GROUP BY f1 + 1;
+
+--echo # Expect 1
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
 SET SESSION optimizer_trace="enabled=off";
 
-DROP TABLE t, t2, t3;
+DROP TABLE t, t2, t3, t4, t5, t6, t7;

--- a/mysql-test/suite/percona/t/ps9768.test
+++ b/mysql-test/suite/percona/t/ps9768.test
@@ -225,6 +225,99 @@ SELECT f1 + 1 AS c, count(*) AS `*` FROM t7 GROUP BY f1 + 1;
 SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
   FROM information_schema.OPTIMIZER_TRACE;
 
+--echo #
+--echo # Case 10: residual gap — TYPECAST is still stripped under
+--echo #          require_same_value, so a functional index CAST(.. AS UNSIGNED)
+--echo #          replaces GROUP BY on the inner expression and merges '1' and
+--echo #          '01'. If require_same_value also refused TYPECAST_FUNC, the
+--echo #          GROUP BY below would not be rewritten (substituted=0) and the
+--echo #          three distinct strings would remain three groups, matching
+--echo #          IGNORE INDEX FOR GROUP BY. Exact CAST() GROUP BY and WHERE
+--echo #          pushdown must keep working either way.
+--echo #
+CREATE TABLE t8 (
+  data2 json,
+  INDEX idx ((CAST(data2->>'$.n' AS UNSIGNED)))
+);
+INSERT INTO t8 VALUES
+  (JSON_OBJECT('n','1')),
+  (JSON_OBJECT('n','01')),
+  (JSON_OBJECT('n','2'));
+
+--sorted_result
+SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8 GROUP BY data2->>'$.n';
+--echo # Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--sorted_result
+SELECT data2->>'$.n' AS c, count(*) AS `*` FROM t8
+  IGNORE INDEX FOR GROUP BY (idx) GROUP BY data2->>'$.n';
+
+--sorted_result
+SELECT CAST(data2->>'$.n' AS UNSIGNED) AS c, count(*) AS `*` FROM t8
+  GROUP BY CAST(data2->>'$.n' AS UNSIGNED);
+--echo # Expect 1 either way: exact CAST match
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--sorted_result
+SELECT data2 FROM t8 WHERE CAST(data2->>'$.n' AS UNSIGNED) = 1;
+--echo # Expect 1: WHERE pushdown unchanged
+SELECT TRACE LIKE '%as unsigned%' AS where_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--echo #
+--echo # Case 11: residual gap — same TYPECAST stripping with a length-
+--echo #          changing CAST and a matching collation. 'aa' and 'ab' are
+--echo #          merged into one group today. Gating TYPECAST under
+--echo #          require_same_value would leave three groups. Non-strict
+--echo #          sql_mode is required so truncated functional-index values
+--echo #          can be stored.
+--echo #
+SET @old_sql_mode= @@sql_mode;
+SET sql_mode='';
+CREATE TABLE t9 (
+  data2 json,
+  INDEX idx (((CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4)) COLLATE utf8mb4_bin))
+);
+INSERT INTO t9 VALUES
+  (JSON_OBJECT('a','aa')),
+  (JSON_OBJECT('a','ab')),
+  (JSON_OBJECT('a','b'));
+SET sql_mode= @old_sql_mode;
+
+--disable_warnings
+--sorted_result
+SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9 GROUP BY data2->>'$.a';
+--enable_warnings
+--echo # Expect 1 today (TYPECAST stripped). Would be 0 if TYPECAST were gated.
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--sorted_result
+SELECT data2->>'$.a' AS c, count(*) AS `*` FROM t9
+  IGNORE INDEX FOR GROUP BY (idx) GROUP BY data2->>'$.a';
+
+--disable_warnings
+--sorted_result
+SELECT CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin AS c,
+       count(*) AS `*` FROM t9
+  GROUP BY CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin;
+--enable_warnings
+--echo # Expect 1 either way: exact CAST/COLLATE match
+SELECT TRACE LIKE '%resulting_GROUP_BY%' AS group_by_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
+--disable_warnings
+--sorted_result
+SELECT data2 FROM t9
+  WHERE CAST(data2->>'$.a' AS CHAR(1) CHARSET utf8mb4) COLLATE utf8mb4_bin = 'a';
+--enable_warnings
+--echo # Expect 1: WHERE pushdown unchanged
+SELECT TRACE LIKE '%collate%utf8mb4_bin% = %' AS where_substituted
+  FROM information_schema.OPTIMIZER_TRACE;
+
 SET SESSION optimizer_trace="enabled=off";
 
-DROP TABLE t, t2, t3, t4, t5, t6, t7;
+DROP TABLE t, t2, t3, t4, t5, t6, t7, t8, t9;

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1124,6 +1124,31 @@ Item_field *get_gc_for_expr(const Item *func, Field *fld, Item_result type,
       evaluated through an index lookup. When the value of the expression
       itself is consumed, as in GROUP BY/ORDER BY, such substitution changes
       the query result (PS-9768).
+
+      TYPECAST and COLLATE are still stripped even when require_same_value is
+      true. That is an intentional residual gap, not a claim that every CAST is
+      value-preserving:
+
+      - COLLATE mismatches for ORDER/GROUP BY are rejected separately in
+        substitute_gc() by comparing the expression's collation to the GC
+        field's charset.
+      - Multi-valued CAST(.. AS .. ARRAY) fields are excluded from the
+        ORDER/GROUP BY candidate list in substitute_gc().
+      - A scalar CAST can still change the value while keeping a matching
+        collation or a non-string result type when the analysed expression
+        is itself a function (bare fields are not candidates for ORDER/GROUP
+        BY substitution; @see Item::can_be_substituted_for_gc()), e.g.
+          INDEX ((CAST(j->>'$.n' AS UNSIGNED))) + GROUP BY j->>'$.n'
+          INDEX (((CAST(j->>'$.a' AS CHAR(1) CHARSET utf8mb4))
+                  COLLATE utf8mb4_bin)) + GROUP BY j->>'$.a'
+        Refusing to strip TYPECAST_FUNC when require_same_value is set would
+        close that (GROUP BY on the exact CAST() expression would keep
+        matching, because the wrapper is only skipped when the analysed
+        expression lacks it). The known PS-9768 wrong-results cases are
+        covered without that change, so TYPECAST stripping is left as-is
+        for now rather than widening the behavioural delta further.
+        Regression coverage for the residual behaviour is in percona.ps9768
+        cases 10 and 11.
     */
     if (require_same_value && functype == Item_func::JSON_UNQUOTE_FUNC)
       continue;

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1072,6 +1072,8 @@ bool contains_function_of_type(Item *item, Item_func::Functype type) {
                         when the value of the expression itself is consumed
                         (GROUP BY/ORDER BY), as opposed to the expression only
                         being used for an index lookup inside a predicate.
+                        When set, JSON_UNQUOTE() and CAST() wrappers on the
+                        GC expression are not skipped while matching.
 
   @returns
     item new Item_field for matched GC
@@ -1116,41 +1118,29 @@ Item_field *get_gc_for_expr(const Item *func, Field *fld, Item_result type,
        {Item_func::COLLATE_FUNC, Item_func::TYPECAST_FUNC,
         Item_func::JSON_UNQUOTE_FUNC}) {
     /*
-      Unlike the other functions skipped here, JSON_UNQUOTE() changes the value
-      and not only its representation for comparison purposes:
-      JSON_EXTRACT(j,'$.a') evaluates to '"a"' whereas
-      JSON_UNQUOTE(JSON_EXTRACT(j,'$.a')) evaluates to 'a'. Skipping it is only
-      sound when the GC replaces the expression inside a predicate which is
-      evaluated through an index lookup. When the value of the expression
-      itself is consumed, as in GROUP BY/ORDER BY, such substitution changes
-      the query result (PS-9768).
+      JSON_UNQUOTE() and CAST() can change the value of the expression, not
+      only its representation for comparison purposes:
+      - JSON_EXTRACT(j,'$.a') evaluates to '"a"' whereas
+        JSON_UNQUOTE(JSON_EXTRACT(j,'$.a')) evaluates to 'a'.
+      - CAST(j->>'$.n' AS UNSIGNED) turns the distinct strings '1' and '01'
+        into the same integer; CAST(.. AS CHAR(n)) can truncate.
 
-      TYPECAST and COLLATE are still stripped even when require_same_value is
-      true. That is an intentional residual gap, not a claim that every CAST is
-      value-preserving:
+      Skipping those wrappers is only sound when the GC replaces the
+      expression inside a predicate evaluated through an index lookup. When
+      the value of the expression itself is consumed, as in GROUP BY/ORDER
+      BY, such substitution changes the query result (PS-9768).
 
-      - COLLATE mismatches for ORDER/GROUP BY are rejected separately in
-        substitute_gc() by comparing the expression's collation to the GC
-        field's charset.
-      - Multi-valued CAST(.. AS .. ARRAY) fields are excluded from the
-        ORDER/GROUP BY candidate list in substitute_gc().
-      - A scalar CAST can still change the value while keeping a matching
-        collation or a non-string result type when the analysed expression
-        is itself a function (bare fields are not candidates for ORDER/GROUP
-        BY substitution; @see Item::can_be_substituted_for_gc()), e.g.
-          INDEX ((CAST(j->>'$.n' AS UNSIGNED))) + GROUP BY j->>'$.n'
-          INDEX (((CAST(j->>'$.a' AS CHAR(1) CHARSET utf8mb4))
-                  COLLATE utf8mb4_bin)) + GROUP BY j->>'$.a'
-        Refusing to strip TYPECAST_FUNC when require_same_value is set would
-        close that (GROUP BY on the exact CAST() expression would keep
-        matching, because the wrapper is only skipped when the analysed
-        expression lacks it). The known PS-9768 wrong-results cases are
-        covered without that change, so TYPECAST stripping is left as-is
-        for now rather than widening the behavioural delta further.
-        Regression coverage for the residual behaviour is in percona.ps9768
-        cases 10 and 11.
+      COLLATE is still stripped when require_same_value is true: it does not
+      change the value bytes, and ORDER/GROUP BY collation mismatches are
+      rejected separately in substitute_gc() by comparing the expression's
+      collation to the GC field's charset. Multi-valued CAST(.. AS .. ARRAY)
+      fields are excluded from the ORDER/GROUP BY candidate list there as
+      well. Exact GROUP BY/ORDER BY on the CAST() expression keeps matching,
+      because the wrapper is only skipped when the analysed expression lacks
+      it.
     */
-    if (require_same_value && functype == Item_func::JSON_UNQUOTE_FUNC)
+    if (require_same_value && (functype == Item_func::JSON_UNQUOTE_FUNC ||
+                               functype == Item_func::TYPECAST_FUNC))
       continue;
     if (is_function_of_type(expr, functype) &&
         !is_function_of_type(func, functype)) {

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1066,6 +1066,12 @@ bool contains_function_of_type(Item *item, Item_func::Functype type) {
   @param fld            GCs field
   @param type           Result type to match with Field
   @param[out] found     If given, just return found field, without Item_field
+  @param require_same_value
+                        If true, the GC is only considered a match when it
+                        evaluates to the same value as @p func. Must be used
+                        when the value of the expression itself is consumed
+                        (GROUP BY/ORDER BY), as opposed to the expression only
+                        being used for an index lookup inside a predicate.
 
   @returns
     item new Item_field for matched GC
@@ -1073,7 +1079,7 @@ bool contains_function_of_type(Item *item, Item_func::Functype type) {
 */
 
 Item_field *get_gc_for_expr(const Item *func, Field *fld, Item_result type,
-                            Field **found) {
+                            Field **found, bool require_same_value) {
   func = func->real_item();
   Item *expr = fld->gcol_info->expr_item;
 
@@ -1109,6 +1115,18 @@ Item_field *get_gc_for_expr(const Item *func, Field *fld, Item_result type,
   for (Item_func::Functype functype :
        {Item_func::COLLATE_FUNC, Item_func::TYPECAST_FUNC,
         Item_func::JSON_UNQUOTE_FUNC}) {
+    /*
+      Unlike the other functions skipped here, JSON_UNQUOTE() changes the value
+      and not only its representation for comparison purposes:
+      JSON_EXTRACT(j,'$.a') evaluates to '"a"' whereas
+      JSON_UNQUOTE(JSON_EXTRACT(j,'$.a')) evaluates to 'a'. Skipping it is only
+      sound when the GC replaces the expression inside a predicate which is
+      evaluated through an index lookup. When the value of the expression
+      itself is consumed, as in GROUP BY/ORDER BY, such substitution changes
+      the query result (PS-9768).
+    */
+    if (require_same_value && functype == Item_func::JSON_UNQUOTE_FUNC)
+      continue;
     if (is_function_of_type(expr, functype) &&
         !is_function_of_type(func, functype)) {
       expr = down_cast<Item_func *>(expr)->get_arg(0);

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -4068,7 +4068,8 @@ double my_double_round(double value, longlong dec, bool dec_unsigned,
                        bool truncate);
 bool eval_const_cond(THD *thd, Item *cond, bool *value);
 Item_field *get_gc_for_expr(const Item *func, Field *fld, Item_result type,
-                            Field **found = nullptr);
+                            Field **found = nullptr,
+                            bool require_same_value = false);
 
 void retrieve_tablespace_statistics(THD *thd, Item **args, bool *null_value);
 

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -1286,6 +1286,15 @@ bool substitute_gc(THD *thd, Query_block *query_block, Item *where_cond,
   List_iterator<Field> li(indexed_gc);
 
   while ((gc = li++)) {
+    /*
+      A multi-valued index's field holds the set of values the expression
+      evaluates to, and not the value itself, so it can never replace an
+      ORDER/GROUP BY expression.
+    */
+    if (gc->is_array()) {
+      li.remove();
+      continue;
+    }
     Key_map tkm = gc->part_of_key;
     tkm.intersect(group_list ? gc->table->keys_in_use_for_group_by
                              : gc->table->keys_in_use_for_order_by);
@@ -1300,6 +1309,20 @@ bool substitute_gc(THD *thd, Query_block *query_block, Item *where_cond,
     li.rewind();
     if (!(*ord->item)->can_be_substituted_for_gc()) continue;
     while ((gc = li++)) {
+      /*
+        Grouping and sorting are performed according to the collation, so a GC
+        whose collation differs from the one of the expression does not order
+        or group the rows the same way: e.g. a case insensitive GC merges
+        values which the expression keeps apart. Unlike for the WHERE
+        condition, where this only matters for functional indexes
+        (@see substitute_gc_expression()), the value of an ORDER/GROUP BY
+        expression is consumed by the executor, so require the collations to
+        match for every string GC.
+      */
+      if (gc->result_type() == STRING_RESULT &&
+          gc->match_collation_to_optimize_range() &&
+          (*ord->item)->collation.collation != gc->charset())
+        continue;
       Item_field *const field =
           get_gc_for_expr(*ord->item, gc, gc->result_type(),
                           /*found=*/nullptr, /*require_same_value=*/true);

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -1227,10 +1227,12 @@ bool JOIN::push_to_engines() {
     list. When a match is found, the expression is replaced with a new
     Item_field for the matched GC field. Also, this new field is added to
     the hidden part of all_fields list.
-    Unlike for the WHERE condition, only substitutions which preserve the
-    value of the expression are performed here, since the value of an
-    ORDER/GROUP BY expression is consumed by the executor and not merely
-    used to look up rows in an index. @see get_gc_for_expr()
+    Unlike for the WHERE condition, substitutions here must preserve the
+    value of the expression, since that value is consumed by the executor
+    and not merely used to look up rows in an index. JSON_UNQUOTE() and
+    multi-valued indexes are therefore excluded, and string GCs must match
+    the expression's collation. Scalar CAST() wrappers are still eligible;
+    see get_gc_for_expr() for the residual gap and the rationale.
 
   @param thd         thread handle
   @param query_block  the current select
@@ -1318,6 +1320,11 @@ bool substitute_gc(THD *thd, Query_block *query_block, Item *where_cond,
         (@see substitute_gc_expression()), the value of an ORDER/GROUP BY
         expression is consumed by the executor, so require the collations to
         match for every string GC.
+
+        This does not cover value changes from a scalar CAST on the GC
+        (truncation or numeric conversion) when collations still match; that
+        residual gap is documented in get_gc_for_expr() and covered by
+        percona.ps9768 cases 10 and 11.
       */
       if (gc->result_type() == STRING_RESULT &&
           gc->match_collation_to_optimize_range() &&

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -1229,10 +1229,9 @@ bool JOIN::push_to_engines() {
     the hidden part of all_fields list.
     Unlike for the WHERE condition, substitutions here must preserve the
     value of the expression, since that value is consumed by the executor
-    and not merely used to look up rows in an index. JSON_UNQUOTE() and
-    multi-valued indexes are therefore excluded, and string GCs must match
-    the expression's collation. Scalar CAST() wrappers are still eligible;
-    see get_gc_for_expr() for the residual gap and the rationale.
+    and not merely used to look up rows in an index. JSON_UNQUOTE(),
+    CAST(), and multi-valued indexes are therefore excluded, and string
+    GCs must match the expression's collation. @see get_gc_for_expr()
 
   @param thd         thread handle
   @param query_block  the current select
@@ -1320,11 +1319,6 @@ bool substitute_gc(THD *thd, Query_block *query_block, Item *where_cond,
         (@see substitute_gc_expression()), the value of an ORDER/GROUP BY
         expression is consumed by the executor, so require the collations to
         match for every string GC.
-
-        This does not cover value changes from a scalar CAST on the GC
-        (truncation or numeric conversion) when collations still match; that
-        residual gap is documented in get_gc_for_expr() and covered by
-        percona.ps9768 cases 10 and 11.
       */
       if (gc->result_type() == STRING_RESULT &&
           gc->match_collation_to_optimize_range() &&

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -1227,6 +1227,10 @@ bool JOIN::push_to_engines() {
     list. When a match is found, the expression is replaced with a new
     Item_field for the matched GC field. Also, this new field is added to
     the hidden part of all_fields list.
+    Unlike for the WHERE condition, only substitutions which preserve the
+    value of the expression are performed here, since the value of an
+    ORDER/GROUP BY expression is consumed by the executor and not merely
+    used to look up rows in an index. @see get_gc_for_expr()
 
   @param thd         thread handle
   @param query_block  the current select
@@ -1297,7 +1301,8 @@ bool substitute_gc(THD *thd, Query_block *query_block, Item *where_cond,
     if (!(*ord->item)->can_be_substituted_for_gc()) continue;
     while ((gc = li++)) {
       Item_field *const field =
-          get_gc_for_expr(*ord->item, gc, gc->result_type());
+          get_gc_for_expr(*ord->item, gc, gc->result_type(),
+                          /*found=*/nullptr, /*require_same_value=*/true);
       if (field != nullptr) {
         changed = true;
         /* Add new field to field list. */


### PR DESCRIPTION
duplicate key in table while using tmp table for group by a json data