### PR TITLE
PS-11423 [8.4]: Free XCom connections in xcom_get_synode_app_data()

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_proxy.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_proxy.cc
@@ -790,21 +790,28 @@ bool Gcs_xcom_proxy_base::xcom_get_synode_app_data(
       xcom_instance.get_member_id().get_member_id());
   connection_descriptor *con = xcom_client_open_connection(
       xcom_address.get_member_ip(), xcom_address.get_member_port());
-  bool const connected_to_xcom = (con != nullptr);
+  /*
+    xcom_client_open_connection() always hands back an allocated descriptor: a
+    failed connection is reported through fd == -1, in which case the socket and
+    the SSL object have already been released by the network provider. The
+    descriptor itself must be freed in every case.
+  */
+  bool const connected_to_xcom = (con != nullptr && con->fd != -1);
   if (!connected_to_xcom) goto end;
 
   successful = convert_synode_set_to_synode_array(synodes, synode_set);
-  if (!successful) goto end;
-
-  /* Request the data decided at synodes.
-   * synodes is passed with moved semantics, so no need to free afterwards. */
-  successful =
-      xcom_client_get_synode_app_data(con, group_id_hash, synodes, reply);
+  if (successful) {
+    /* Request the data decided at synodes.
+     * synodes is passed with moved semantics, so no need to free afterwards. */
+    successful =
+        xcom_client_get_synode_app_data(con, group_id_hash, synodes, reply);
+  }
 
   /* Close the connection to XCom. */
   xcom_client_close_connection(con);
 
 end:
+  free_connection(con);
   return successful;
 }
 

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_communication_interface-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_communication_interface-t.cc
@@ -541,8 +541,13 @@ bool mock_xcom_client_get_synode_app_data(connection_descriptor *, uint32_t,
   return true;
 }
 
-int mock_xcom_client_close_connection(connection_descriptor *con) {
-  ::free(con);
+int mock_xcom_client_close_connection(connection_descriptor *con
+                                      [[maybe_unused]]) {
+  /*
+    Mimic Gcs_xcom_proxy_impl::xcom_client_close_connection(), which releases
+    the socket and the SSL object but does not own the descriptor itself: the
+    caller frees it with free_connection().
+  */
   return 1;
 }
 


### PR DESCRIPTION
== Gcs_xcom_proxy_base::xcom_get_synode_app_data() ==

Three defects in one function:

* The connection descriptor was never released.  It is heap allocated by new_connection() (node_connection.h:61) inside Network_provider_manager::open_xcom_connection(), and xcom_client_close_connection() only drives the provider's close_connection() - it does not own the descriptor.  Nothing in the function called free_connection(), so every call leaked it, successful or not.

* On the "convert_synode_set_to_synode_array() failed" exit the function jumped straight to the end label, skipping xcom_client_close_connection() and therefore leaking the socket and the SSL object as well.

* The connectedness test was wrong:

    bool const connected_to_xcom = (con != nullptr);

  open_xcom_connection() (network_provider_manager.cc:231) always returns an allocated descriptor and reports failure through fd == -1, so the test was always true and the function went on to talk over a dead handle.  Gcs_xcom_control::connect_to_peer() checks fd == -1; this now does the same.

  A failed connect needs no close: every failure exit of Xcom_network_provider::open_connection() already releases the socket, and the TLS exits pass has_error = true so ssl_free_con() runs.  Only the descriptor is left over, and that is now freed unconditionally at the end label.

== Unit test mock ==

mock_xcom_client_close_connection() in
gcs_xcom_communication_interface-t.cc did ::free(con), which masked the descriptor leak in the two synod-recovery tests and would now double free.  The real Gcs_xcom_proxy_impl::xcom_client_close_connection() does not free the descriptor, so the mock no longer does either.

== Testing ==

  gcs_xcom_communication_interface-t   8/8 passed

(Debug build, gcc 16.)  The group_replication suite should be re-run under Valgrind to confirm the remaining "definitely lost" blocks from Build 816 are gone.

== Note ==

All of this is unmodified upstream code (blame: Tiago Vale 2018, Tiago Jorge 2023); PS is affected identically and the defects are worth reporting to Oracle.