### PR TITLE
PS-11479 Add vault_namespace support to component_keyring_vault

### DIFF
--- a/components/keyrings/keyring_vault/README
+++ b/components/keyrings/keyring_vault/README
@@ -9,6 +9,7 @@ MTR_VAULT_ADDRESS=<vault_url> \
 MTR_VAULT_CA=<ca_path> \
 MTR_VAULT_ADMIN_TOKEN=<admin_token> \
 MTR_VAULT_PLUGIN_TOKEN=<plugin_token> \
+[MTR_VAULT_NAMESPACE=<vault_namespace>] \
 ./mysql-test/mtr ... --suite=keyring_vault
 
 '<vault_version>' - the version of the secret engine used in Vault Server
@@ -29,3 +30,7 @@ MTR_VAULT_PLUGIN_TOKEN=<plugin_token> \
 '<plugin_token>'  - Vault Server token that will be used to run the tests,
                     will be translated into 'token' parameter in the component
                     configuration file
+'<vault_namespace>' - (optional) Vault namespace, will be sent as the
+                    'X-Vault-Namespace' HTTP header on every request and
+                    translated into 'vault_namespace' in the component
+                    configuration file (e.g. 'myorg/myteam')

--- a/components/keyrings/keyring_vault/backend/vault_curl.cc
+++ b/components/keyrings/keyring_vault/backend/vault_curl.cc
@@ -203,10 +203,15 @@ bool Keyring_vault_curl::setup_curl_session(CURL *curl) {
   }
 
   pfs_string token_header = "X-Vault-Token:" + m_config->token;
+  pfs_string ns_header;
+  if (!m_config->vault_namespace.empty())
+    ns_header = "X-Vault-Namespace:" + m_config->vault_namespace;
 
   if ((m_list = curl_slist_append(m_list, token_header.c_str())) == nullptr ||
       (m_list = curl_slist_append(m_list, "Content-Type: application/json")) ==
           nullptr ||
+      (!ns_header.empty() &&
+       (m_list = curl_slist_append(m_list, ns_header.c_str())) == nullptr) ||
       (curl_res = curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, m_curl_errbuf)) !=
           CURLE_OK ||
       (curl_res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION,

--- a/components/keyrings/keyring_vault/config/config.cc
+++ b/components/keyrings/keyring_vault/config/config.cc
@@ -57,9 +57,9 @@ static const char *s_component_metadata[][2] = {
 
 /* Config names */
 static const std::string config_options[] = {
-    "read_local_config",         "timeout",  "vault_url",
-    "secret_mount_point",        "vault_ca", "token",
-    "secret_mount_point_version"};
+    "read_local_config",          "timeout",        "vault_url",
+    "secret_mount_point",         "vault_ca",       "token",
+    "secret_mount_point_version", "vault_namespace"};
 
 namespace {
 
@@ -284,6 +284,20 @@ bool find_and_read_config_file(std::unique_ptr<Config_pod> &config_pod) {
     }
   }
 
+  if (!config_reader->has_element(config_options[7])) {
+    // Not mandatory field
+    if (config_reader->is_string(config_options[7])) {
+      return true;
+    }
+
+    if (!config_reader->get_element<std::string>(config_options[7],
+                                                 fetched_conf_value)) {
+      boost::algorithm::trim(fetched_conf_value);
+      config_pod_tmp->vault_namespace = {fetched_conf_value.c_str(),
+                                         fetched_conf_value.length()};
+    }
+  }
+
   if (!check_config_valid(config_pod_tmp.get())) {
     return true;
   }
@@ -365,6 +379,15 @@ bool create_config(
 
   metadata->push_back(
       std::make_pair("secret_mount_point_version", mount_point_version_str));
+
+  metadata->push_back(std::make_pair(
+      "vault_namespace",
+      ((global_config_available)
+           ? ((config_pod.vault_namespace.length() == 0)
+                  ? "<NONE>"
+                  : std::string{config_pod.vault_namespace.c_str(),
+                                config_pod.vault_namespace.length()})
+           : "<NOT APPLICABLE>")));
 
   return false;
 }

--- a/components/keyrings/keyring_vault/config/config.h
+++ b/components/keyrings/keyring_vault/config/config.h
@@ -54,6 +54,7 @@ class Config_pod {
   pfs_string vault_ca;
   pfs_string token;
   Vault_version_type secret_mount_point_version = Vault_version_unknown;
+  pfs_string vault_namespace;
 };
 
 /**

--- a/mysql-test/suite/component_keyring_vault/inc/generate_comp_config_content.inc
+++ b/mysql-test/suite/component_keyring_vault/inc/generate_comp_config_content.inc
@@ -62,3 +62,17 @@ if ($vault_conf_mount_point_version)
 {
   --let $config_content = `SELECT CONCAT('$config_content', ', \"secret_mount_point_version\": \"', '$vault_conf_mount_point_version', '\"')`
 }
+
+--let $vault_namespace =
+if ($vault_conf_namespace)
+{
+  --let $vault_namespace = $vault_conf_namespace
+}
+if (!$vault_namespace)
+{
+  --let $vault_namespace = $MTR_VAULT_NAMESPACE
+}
+if ($vault_namespace)
+{
+  --let $config_content = `SELECT CONCAT('$config_content', ', \"vault_namespace\": \"', '$vault_namespace', '\"')`
+}

--- a/unittest/gunit/components/keyring_vault/vault_config-t.cc
+++ b/unittest/gunit/components/keyring_vault/vault_config-t.cc
@@ -542,4 +542,40 @@ TEST_F(Vault_config_test, ParseFileWithValuesWithSpacesInIt) {
   EXPECT_STREQ(config_pod->vault_ca.c_str(), "/some/  path");
 }
 
+TEST_F(Vault_config_test, ParseFileWithVaultNamespace) {
+  std::ofstream my_file;
+  create_empty_credentials_file(my_file);
+  my_file << "{" << std::endl;
+  my_file << "  \"timeout\": 10," << std::endl;
+  my_file << "  \"vault_url\": \"http://127.0.0.1:8200\"," << std::endl;
+  my_file << "  \"secret_mount_point\": \"secret\"," << std::endl;
+  my_file << "  \"token\": \"123-123-123\"," << std::endl;
+  my_file << "  \"vault_namespace\": \"  myorg/myteam  \"" << std::endl;
+  my_file << "}" << std::endl;
+  my_file.close();
+
+  auto config_pod = std::make_unique<Config_pod>();
+  EXPECT_FALSE(find_and_read_config_file(config_pod));
+
+  EXPECT_STREQ(config_pod->vault_namespace.c_str(), "myorg/myteam");
+}
+
+TEST_F(Vault_config_test, ParseFileWithVaultNamespaceBeingNumeric) {
+  std::ofstream my_file;
+  create_empty_credentials_file(my_file);
+  my_file << "{" << std::endl;
+  my_file << "  \"timeout\": 10," << std::endl;
+  my_file << "  \"vault_url\": \"http://127.0.0.1:8200\"," << std::endl;
+  my_file << "  \"secret_mount_point\": \"secret\"," << std::endl;
+  my_file << "  \"token\": \"123-123-123\"," << std::endl;
+  my_file << "  \"vault_namespace\": 1" << std::endl;
+  my_file << "}" << std::endl;
+  my_file.close();
+
+  auto config_pod = std::make_unique<Config_pod>();
+  EXPECT_TRUE(find_and_read_config_file(config_pod));
+
+  EXPECT_TRUE(config_pod->vault_namespace.empty());
+}
+
 }  // namespace keyring_vault_config_unittest


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11479

Add optional vault_namespace configuration parameter to component_keyring_vault. When set, sends the X-Vault-Namespace HTTP header on every Vault API request, enabling use with HashiCorp Vault Enterprise and OpenBao deployments that enforce namespaces. The field is optional and backward-compatible — omitting it preserves existing behavior.

This feature is already available in https://github.com/percona/pg_tde for Postgres.

Changed files:
- config/config.h: added vault_namespace field to Config_pod
- config/config.cc: parse optional vault_namespace key (trimmed), show in status output
- backend/vault_curl.cc: conditionally append X-Vault-Namespace header in setup_curl_session()
- unittest/gunit/.../vault_config-t.cc: two new unit tests for valid and invalid namespace values
- mysql-test/suite/.../generate_comp_config_content.inc: MTR support via vault_conf_namespace/$MTR_VAULT_NAMESPACE
- README: document the new optional parameter