### PR TITLE
PS-11266: Basic HNSW class (phase 1 - basic modification and read operations support).

### DIFF
--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -435,6 +435,18 @@ MYSQL_ADD_EXECUTABLE(vector_distance_benchmark-t vector_distance_benchmark-t.cc
   SKIP_INSTALL
 )
 
+# HNSW recall / memory / throughput benchmark over a synthetic vector set.
+# Deliberately NOT in the TESTS list above: that list is merged into
+# merge_small_tests-t, which ctest runs, and this builds a 20k-node index.
+# See the file header for how to build and run it.
+MYSQL_ADD_EXECUTABLE(hnsw_bench-t hnsw_bench-t.cc
+  COMPILE_DEFINITIONS ${DISABLE_PSI_DEFINITIONS}
+  ENABLE_EXPORTS
+  EXCLUDE_FROM_ALL
+  LINK_LIBRARIES sqlgunitlib gunit_small extra::boost
+  SKIP_INSTALL
+)
+
 # Disable by default, since it dumps a stack trace.
 # We don't want ppl to think there was a segfault or something.
 # See also the mtr test main.print_stacktrace

--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -119,6 +119,7 @@ SET(TESTS
   filesort_buffer
   filesort_compare
   filesort_mergechunk
+  hnsw
   inplace_vector
   integer_digits
   intrusive_list_iterator

--- a/unittest/gunit/hnsw-t.cc
+++ b/unittest/gunit/hnsw-t.cc
@@ -1,0 +1,302 @@
+/* Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "my_alloc.h"
+#include "vector-common/hnsw.h"
+
+namespace hnsw_unittest {
+
+/**
+  Arena allocator backed by MEM_ROOT for HNSW unit tests.
+  All blocks are freed when the allocator (and its MEM_ROOT) is destroyed.
+*/
+class ArenaAllocator {
+ public:
+  ArenaAllocator() : m_mem_root(PSI_NOT_INSTRUMENTED, 4096) {}
+
+  void *allocate(size_t size) { return m_mem_root.Alloc(size); }
+
+ private:
+  MEM_ROOT m_mem_root;
+};
+
+using TestHnsw = HNSW<ArenaAllocator>;
+
+static double euclidean(const char *a_raw, const char *b_raw, uint32_t dims) {
+  const float *a = reinterpret_cast<const float *>(a_raw);
+  const float *b = reinterpret_cast<const float *>(b_raw);
+  double sum = 0.0;
+  for (uint32_t i = 0; i < dims; ++i) {
+    const double d = static_cast<double>(a[i]) - static_cast<double>(b[i]);
+    sum += d * d;
+  }
+  return std::sqrt(sum);
+}
+
+static std::vector<float> make_vec(std::initializer_list<float> values) {
+  return std::vector<float>(values);
+}
+
+static const char *as_bytes(const std::vector<float> &v) {
+  return reinterpret_cast<const char *>(v.data());
+}
+
+class HnswTest : public ::testing::Test {
+ protected:
+  static constexpr size_t kDims = 2;
+  static constexpr size_t kM = 4;
+  static constexpr size_t kEfConstruction = 16;
+};
+
+TEST_F(HnswTest, SearchEmptyIndex) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  const auto query = make_vec({0.0f, 0.0f});
+  const auto result = index.k_nn_search(as_bytes(query), 3, 16);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(HnswTest, InsertSingleAndSearchExact) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  const auto v0 = make_vec({1.0f, 2.0f});
+  index.insert(42, 1001, as_bytes(v0));
+
+  const auto result = index.k_nn_search(as_bytes(v0), 1, 8);
+  ASSERT_EQ(1U, result.size());
+  EXPECT_EQ(1001U, result[0]);
+}
+
+TEST_F(HnswTest, InsertMultipleSearchNearest) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  const auto v0 = make_vec({0.0f, 0.0f});
+  const auto v1 = make_vec({10.0f, 0.0f});
+  const auto v2 = make_vec({0.0f, 10.0f});
+  const auto v3 = make_vec({10.0f, 10.0f});
+  index.insert(100, 2000, as_bytes(v0));
+  index.insert(101, 2001, as_bytes(v1));
+  index.insert(102, 2002, as_bytes(v2));
+  index.insert(103, 2003, as_bytes(v3));
+
+  const auto query = make_vec({9.5f, 9.5f});
+  const auto result = index.k_nn_search(as_bytes(query), 1, 16);
+  ASSERT_EQ(1U, result.size());
+  EXPECT_EQ(2003U, result[0]);
+}
+
+TEST_F(HnswTest, SearchReturnsKResults) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  const auto v0 = make_vec({0.0f, 0.0f});
+  const auto v1 = make_vec({1.0f, 0.0f});
+  const auto v2 = make_vec({2.0f, 0.0f});
+  const auto v3 = make_vec({3.0f, 0.0f});
+  const auto v4 = make_vec({4.0f, 0.0f});
+  index.insert(10, 3010, as_bytes(v0));
+  index.insert(11, 3011, as_bytes(v1));
+  index.insert(12, 3012, as_bytes(v2));
+  index.insert(13, 3013, as_bytes(v3));
+  index.insert(14, 3014, as_bytes(v4));
+
+  const auto query = make_vec({0.1f, 0.0f});
+  const auto result = index.k_nn_search(as_bytes(query), 3, 16);
+  ASSERT_EQ(3U, result.size());
+
+  std::unordered_set<uint64_t> base_pks(result.begin(), result.end());
+  // Closest three to (0.1, 0) should be base_pks 3010, 3011, 3012.
+  EXPECT_EQ(1U, base_pks.count(3010));
+  EXPECT_EQ(1U, base_pks.count(3011));
+  EXPECT_EQ(1U, base_pks.count(3012));
+}
+
+TEST_F(HnswTest, SearchKLargerThanIndexSize) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  const auto v0 = make_vec({0.0f, 0.0f});
+  const auto v1 = make_vec({1.0f, 0.0f});
+  index.insert(1, 4001, as_bytes(v0));
+  index.insert(2, 4002, as_bytes(v1));
+
+  const auto query = make_vec({0.0f, 0.0f});
+  const auto result = index.k_nn_search(as_bytes(query), 10, 16);
+  EXPECT_EQ(2U, result.size());
+}
+
+TEST_F(HnswTest, SearchResultsOrderedByDistance) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  const auto v0 = make_vec({0.0f, 0.0f});
+  const auto v1 = make_vec({5.0f, 0.0f});
+  const auto v2 = make_vec({1.0f, 0.0f});
+  index.insert(20, 5020, as_bytes(v0));
+  index.insert(21, 5021, as_bytes(v1));
+  index.insert(22, 5022, as_bytes(v2));
+
+  const auto query = make_vec({0.0f, 0.0f});
+  const auto result = index.k_nn_search(as_bytes(query), 3, 16);
+  ASSERT_EQ(3U, result.size());
+  EXPECT_EQ(5020U, result[0]);
+  EXPECT_EQ(5022U, result[1]);
+  EXPECT_EQ(5021U, result[2]);
+}
+
+TEST_F(HnswTest, ExactMatchIsFirstResult) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  std::vector<std::vector<float>> points = {
+      make_vec({0.0f, 0.0f}),  make_vec({1.0f, 1.0f}), make_vec({2.0f, -1.0f}),
+      make_vec({-3.0f, 4.0f}), make_vec({5.0f, 5.0f}), make_vec({-1.0f, -1.0f}),
+      make_vec({8.0f, 0.0f}),  make_vec({0.0f, 8.0f}),
+  };
+  for (size_t i = 0; i < points.size(); ++i) {
+    index.insert(1000 + i, 5000 + i, as_bytes(points[i]));
+  }
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    const auto result = index.k_nn_search(as_bytes(points[i]), 1, 32);
+    ASSERT_EQ(1U, result.size()) << "i=" << i;
+    EXPECT_EQ(5000 + i, result[0]) << "i=" << i;
+  }
+}
+
+TEST_F(HnswTest, BruteForceRecall) {
+  constexpr size_t kRecallDims = 16;
+  constexpr size_t kM = 5;
+  constexpr size_t kNumPoints = 2000;
+  constexpr size_t kNumQueries = 20;
+  constexpr size_t kK = 10;
+  constexpr size_t kEfSearch = 50;
+  // HNSW is approximate; require strong average recall@k on this seeded set.
+  constexpr double kMinAvgRecall = 0.9;
+
+  TestHnsw index(kRecallDims, euclidean, kM, kEfConstruction);
+
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> coord(-1.0f, 1.0f);
+
+  std::vector<std::vector<float>> points(kNumPoints);
+  for (size_t i = 0; i < kNumPoints; ++i) {
+    points[i].resize(kRecallDims);
+    for (size_t d = 0; d < kRecallDims; ++d) {
+      points[i][d] = coord(rng);
+    }
+    index.insert(i, /*base_pk=*/i, as_bytes(points[i]));
+  }
+
+  double recall_sum = 0.0;
+  for (size_t q = 0; q < kNumQueries; ++q) {
+    std::vector<float> query(kRecallDims);
+    for (size_t d = 0; d < kRecallDims; ++d) {
+      query[d] = coord(rng);
+    }
+
+    std::vector<std::pair<double, uint64_t>> exact;
+    exact.reserve(kNumPoints);
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      exact.emplace_back(euclidean(as_bytes(query), as_bytes(points[i]),
+                                   static_cast<uint32_t>(kRecallDims)),
+                         i);
+    }
+    std::partial_sort(exact.begin(), exact.begin() + kK, exact.end());
+    std::unordered_set<uint64_t> exact_ids;
+    for (size_t i = 0; i < kK; ++i) {
+      exact_ids.insert(exact[i].second);
+    }
+
+    const auto approx = index.k_nn_search(as_bytes(query), kK, kEfSearch);
+    ASSERT_EQ(kK, approx.size()) << "q=" << q;
+
+    size_t hits = 0;
+    for (uint64_t pk : approx) {
+      hits += exact_ids.count(pk);
+    }
+    recall_sum += static_cast<double>(hits) / static_cast<double>(kK);
+  }
+
+  const double avg_recall = recall_sum / static_cast<double>(kNumQueries);
+  EXPECT_GE(avg_recall, kMinAvgRecall) << "avg recall@10=" << avg_recall;
+}
+
+TEST_F(HnswTest, SearchEfZeroStillReturnsK) {
+  // ef is clamped with max(ef_search, k), so ef=0 must still work.
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  index.insert(1, 100, as_bytes(make_vec({0.0f, 0.0f})));
+  index.insert(2, 101, as_bytes(make_vec({1.0f, 0.0f})));
+
+  const auto query = make_vec({0.0f, 0.0f});
+  const auto result =
+      index.k_nn_search(as_bytes(query), /*k=*/1, /*ef_search=*/0);
+  ASSERT_EQ(1U, result.size());
+  EXPECT_EQ(100U, result[0]);
+}
+
+TEST_F(HnswTest, DuplicateBasePkAllowed) {
+  // Same base_pk, different graph ids (e.g. vector update).
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  index.insert(1, /*base_pk=*/42, as_bytes(make_vec({0.0f, 0.0f})));
+  index.insert(2, /*base_pk=*/42, as_bytes(make_vec({10.0f, 0.0f})));
+
+  const auto result =
+      index.k_nn_search(as_bytes(make_vec({0.0f, 0.0f})), 2, 16);
+  ASSERT_EQ(2U, result.size());
+  EXPECT_EQ(42U, result[0]);
+  EXPECT_EQ(42U, result[1]);
+}
+
+#ifndef NDEBUG
+TEST_F(HnswTest, GraphInvariants) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  EXPECT_TRUE(index.validate());
+
+  for (uint64_t i = 0; i < 50; ++i) {
+    const auto v = make_vec({static_cast<float>(i), static_cast<float>(i % 7)});
+    index.insert(i, 1000 + i, as_bytes(v));
+    EXPECT_TRUE(index.validate()) << "after insert i=" << i;
+  }
+}
+
+TEST(HnswDeathTest, SearchKZeroAsserts) {
+  TestHnsw index(2, euclidean, 4, 16);
+  const auto v = make_vec({0.0f, 0.0f});
+  index.insert(1, 100, as_bytes(v));
+  EXPECT_DEATH_IF_SUPPORTED(index.k_nn_search(as_bytes(v), /*k=*/0, 16), "");
+}
+
+TEST(HnswDeathTest, DuplicateIdAsserts) {
+  TestHnsw index(2, euclidean, 4, 16);
+  const auto v = make_vec({1.0f, 2.0f});
+  index.insert(7, 100, as_bytes(v));
+  EXPECT_DEATH_IF_SUPPORTED(index.insert(7, 101, as_bytes(v)), "");
+}
+
+TEST(HnswDeathTest, ZeroDimensionsAsserts) {
+  EXPECT_DEATH_IF_SUPPORTED(TestHnsw(0, euclidean, 4, 16), "");
+}
+
+TEST(HnswDeathTest, MTooSmallAsserts) {
+  EXPECT_DEATH_IF_SUPPORTED(TestHnsw(2, euclidean, 1, 16), "");
+}
+#endif  // NDEBUG
+
+}  // namespace hnsw_unittest

--- a/unittest/gunit/hnsw-t.cc
+++ b/unittest/gunit/hnsw-t.cc
@@ -23,68 +23,10 @@
 #include <utility>
 #include <vector>
 
-#include "my_alloc.h"
+#include "unittest/gunit/hnsw_test_utils.h"
 #include "vector-common/hnsw.h"
 
 namespace hnsw_unittest {
-
-/**
-  Arena allocator backed by MEM_ROOT for HNSW unit tests.
-  All blocks are freed when the allocator (and its MEM_ROOT) is destroyed.
-*/
-class ArenaAllocator {
- public:
-  ArenaAllocator() : m_mem_root(PSI_NOT_INSTRUMENTED, 4096) {}
-
-  void *allocate(size_t size) { return m_mem_root.Alloc(size); }
-
- private:
-  MEM_ROOT m_mem_root;
-};
-
-using TestHnsw = HNSW<ArenaAllocator>;
-
-static double euclidean(const char *a_raw, const char *b_raw, uint32_t dims) {
-  const float *a = reinterpret_cast<const float *>(a_raw);
-  const float *b = reinterpret_cast<const float *>(b_raw);
-  double sum = 0.0;
-  for (uint32_t i = 0; i < dims; ++i) {
-    const double d = static_cast<double>(a[i]) - static_cast<double>(b[i]);
-    sum += d * d;
-  }
-  return std::sqrt(sum);
-}
-
-static std::vector<float> make_vec(std::initializer_list<float> values) {
-  return std::vector<float>(values);
-}
-
-static const char *as_bytes(const std::vector<float> &v) {
-  return reinterpret_cast<const char *>(v.data());
-}
-
-/**
-  Deterministic pseudo-random coordinate in [-1, 1).
-
-  Used instead of std::mt19937 / std::uniform_real_distribution so point
-  clouds are identical across standard libraries.
-*/
-static float pseudo_coord(uint64_t *state) {
-  *state = *state * 6364136223846793005ULL + 1442695040888963407ULL;
-  return static_cast<float>((*state >> 40) & 0xFFFF) / 32768.0f - 1.0f;
-}
-
-static std::vector<std::vector<float>> make_pseudo_random_points(
-    size_t count, size_t dims, uint64_t *state) {
-  std::vector<std::vector<float>> points(count);
-  for (size_t i = 0; i < count; ++i) {
-    points[i].resize(dims);
-    for (size_t d = 0; d < dims; ++d) {
-      points[i][d] = pseudo_coord(state);
-    }
-  }
-  return points;
-}
 
 class HnswTest : public ::testing::Test {
  protected:
@@ -280,23 +222,6 @@ TEST_F(HnswTest, DuplicateBasePkAllowed) {
   ASSERT_EQ(2U, result.size());
   EXPECT_EQ(42U, result[0]);
   EXPECT_EQ(42U, result[1]);
-}
-
-static std::vector<uint64_t> drain_stream(const TestHnsw &index,
-                                          const char *query, size_t batch_size,
-                                          size_t ef_search,
-                                          size_t max_results = 1000) {
-  TestHnsw::NNSearchContext ctx;
-  index.nn_search_start(&ctx, query, batch_size, ef_search);
-  std::vector<uint64_t> out;
-  for (size_t i = 0; i < max_results; ++i) {
-    const std::pair<bool, uint64_t> step = index.nn_search_next(&ctx);
-    if (!step.first) {
-      break;
-    }
-    out.push_back(step.second);
-  }
-  return out;
 }
 
 TEST_F(HnswTest, StreamEmptyIndex) {

--- a/unittest/gunit/hnsw-t.cc
+++ b/unittest/gunit/hnsw-t.cc
@@ -18,7 +18,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <random>
+#include <limits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -61,6 +61,29 @@ static std::vector<float> make_vec(std::initializer_list<float> values) {
 
 static const char *as_bytes(const std::vector<float> &v) {
   return reinterpret_cast<const char *>(v.data());
+}
+
+/**
+  Deterministic pseudo-random coordinate in [-1, 1).
+
+  Used instead of std::mt19937 / std::uniform_real_distribution so point
+  clouds are identical across standard libraries.
+*/
+static float pseudo_coord(uint64_t *state) {
+  *state = *state * 6364136223846793005ULL + 1442695040888963407ULL;
+  return static_cast<float>((*state >> 40) & 0xFFFF) / 32768.0f - 1.0f;
+}
+
+static std::vector<std::vector<float>> make_pseudo_random_points(
+    size_t count, size_t dims, uint64_t *state) {
+  std::vector<std::vector<float>> points(count);
+  for (size_t i = 0; i < count; ++i) {
+    points[i].resize(dims);
+    for (size_t d = 0; d < dims; ++d) {
+      points[i][d] = pseudo_coord(state);
+    }
+  }
+  return points;
 }
 
 class HnswTest : public ::testing::Test {
@@ -188,28 +211,23 @@ TEST_F(HnswTest, BruteForceRecall) {
   constexpr size_t kK = 10;
   constexpr size_t kEfSearch = 50;
   // HNSW is approximate; require strong average recall@k on this seeded set.
-  constexpr double kMinAvgRecall = 0.9;
+  constexpr double kMinAvgRecall = 0.95;
 
   TestHnsw index(kRecallDims, euclidean, kM, kEfConstruction);
 
-  std::mt19937 rng(42);
-  std::uniform_real_distribution<float> coord(-1.0f, 1.0f);
-
-  std::vector<std::vector<float>> points(kNumPoints);
+  uint64_t state = 42;
+  const auto points =
+      make_pseudo_random_points(kNumPoints, kRecallDims, &state);
   for (size_t i = 0; i < kNumPoints; ++i) {
-    points[i].resize(kRecallDims);
-    for (size_t d = 0; d < kRecallDims; ++d) {
-      points[i][d] = coord(rng);
-    }
     index.insert(i, /*base_pk=*/i, as_bytes(points[i]));
   }
 
+  const auto queries =
+      make_pseudo_random_points(kNumQueries, kRecallDims, &state);
+
   double recall_sum = 0.0;
   for (size_t q = 0; q < kNumQueries; ++q) {
-    std::vector<float> query(kRecallDims);
-    for (size_t d = 0; d < kRecallDims; ++d) {
-      query[d] = coord(rng);
-    }
+    const std::vector<float> &query = queries[q];
 
     std::vector<std::pair<double, uint64_t>> exact;
     exact.reserve(kNumPoints);
@@ -262,6 +280,305 @@ TEST_F(HnswTest, DuplicateBasePkAllowed) {
   ASSERT_EQ(2U, result.size());
   EXPECT_EQ(42U, result[0]);
   EXPECT_EQ(42U, result[1]);
+}
+
+static std::vector<uint64_t> drain_stream(const TestHnsw &index,
+                                          const char *query, size_t batch_size,
+                                          size_t ef_search,
+                                          size_t max_results = 1000) {
+  TestHnsw::NNSearchContext ctx;
+  index.nn_search_start(&ctx, query, batch_size, ef_search);
+  std::vector<uint64_t> out;
+  for (size_t i = 0; i < max_results; ++i) {
+    const std::pair<bool, uint64_t> step = index.nn_search_next(&ctx);
+    if (!step.first) {
+      break;
+    }
+    out.push_back(step.second);
+  }
+  return out;
+}
+
+TEST_F(HnswTest, StreamEmptyIndex) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  TestHnsw::NNSearchContext ctx;
+  const auto query = make_vec({0.0f, 0.0f});
+  index.nn_search_start(&ctx, as_bytes(query), /*batch_size=*/8,
+                        /*ef_search=*/16);
+  EXPECT_FALSE(index.nn_search_next(&ctx).first);
+}
+
+TEST_F(HnswTest, StreamMatchesKnnFirstBatch) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  index.insert(10, 3010, as_bytes(make_vec({0.0f, 0.0f})));
+  index.insert(11, 3011, as_bytes(make_vec({1.0f, 0.0f})));
+  index.insert(12, 3012, as_bytes(make_vec({2.0f, 0.0f})));
+  index.insert(13, 3013, as_bytes(make_vec({3.0f, 0.0f})));
+  index.insert(14, 3014, as_bytes(make_vec({4.0f, 0.0f})));
+
+  const auto query = make_vec({0.1f, 0.0f});
+  constexpr size_t kEf = 3;
+  const auto knn = index.k_nn_search(as_bytes(query), kEf, kEf);
+  const auto streamed = drain_stream(index, as_bytes(query), /*batch_size=*/kEf,
+                                     /*ef_search=*/kEf);
+
+  ASSERT_GE(streamed.size(), knn.size());
+  for (size_t i = 0; i < knn.size(); ++i) {
+    EXPECT_EQ(knn[i], streamed[i]) << "i=" << i;
+  }
+}
+
+TEST_F(HnswTest, StreamMultipleBatchesNoDuplicates) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  for (uint64_t i = 0; i < 30; ++i) {
+    const auto v = make_vec({static_cast<float>(i), 0.0f});
+    index.insert(i, 1000 + i, as_bytes(v));
+  }
+  const auto query = make_vec({0.0f, 0.0f});
+  // Small batch/ef forces continuation refills across batches.
+  const auto streamed = drain_stream(index, as_bytes(query), /*batch_size=*/3,
+                                     /*ef_search=*/8);
+
+  EXPECT_GE(streamed.size(), 3U);
+  std::unordered_set<uint64_t> seen(streamed.begin(), streamed.end());
+  EXPECT_EQ(seen.size(), streamed.size());
+}
+
+TEST_F(HnswTest, StreamDistancesNonDecreasingAcrossBatches) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  std::vector<std::vector<float>> points;
+  for (uint64_t i = 0; i < 40; ++i) {
+    points.push_back(make_vec({static_cast<float>(i), 0.0f}));
+    index.insert(i, /*base_pk=*/i, as_bytes(points.back()));
+  }
+
+  const auto query = make_vec({0.0f, 0.0f});
+  // batch_size < ef_search forces refills while still returning many hits.
+  const auto streamed = drain_stream(index, as_bytes(query), /*batch_size=*/3,
+                                     /*ef_search=*/10, /*max_results=*/30);
+
+  ASSERT_GT(streamed.size(), 3U);  // more than one batch worth
+
+  double prev_dist = -std::numeric_limits<double>::infinity();
+  for (size_t i = 0; i < streamed.size(); ++i) {
+    const uint64_t pk = streamed[i];
+    ASSERT_LT(pk, points.size());
+    const double d = euclidean(as_bytes(query), as_bytes(points[pk]),
+                               static_cast<uint32_t>(kDims));
+    EXPECT_GE(d, prev_dist) << "i=" << i << " pk=" << pk;
+    prev_dist = d;
+  }
+}
+
+TEST_F(HnswTest, StreamDrainsEntireGraph) {
+  constexpr size_t kNumPoints = 25;
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  for (uint64_t i = 0; i < kNumPoints; ++i) {
+    const auto v = make_vec({static_cast<float>(i), 0.0f});
+    index.insert(i, /*base_pk=*/1000 + i, as_bytes(v));
+  }
+
+  const auto query = make_vec({0.0f, 0.0f});
+  // Small batches, wide search; max_results above graph size so we can finish.
+  const auto streamed =
+      drain_stream(index, as_bytes(query), /*batch_size=*/4,
+                   /*ef_search=*/32, /*max_results=*/kNumPoints + 10);
+
+  ASSERT_EQ(kNumPoints, streamed.size());
+
+  std::unordered_set<uint64_t> seen(streamed.begin(), streamed.end());
+  EXPECT_EQ(kNumPoints, seen.size());
+  for (uint64_t i = 0; i < kNumPoints; ++i) {
+    EXPECT_EQ(1U, seen.count(1000 + i)) << "missing base_pk=" << (1000 + i);
+  }
+}
+
+TEST_F(HnswTest, StreamDrainsEntireGraphWithEfSmallerThanGraph) {
+  constexpr size_t kNumPoints = 100;
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+
+  for (uint64_t i = 0; i < kNumPoints; ++i) {
+    const auto v = make_vec({static_cast<float>(i), 0.0f});
+    index.insert(i, /*base_pk=*/1000 + i, as_bytes(v));
+  }
+
+  const auto query = make_vec({0.0f, 0.0f});
+  const auto streamed =
+      drain_stream(index, as_bytes(query), /*batch_size=*/4,
+                   /*ef_search=*/8, /*max_results=*/kNumPoints + 10);
+
+  const std::unordered_set<uint64_t> seen(streamed.begin(), streamed.end());
+  EXPECT_EQ(streamed.size(), seen.size()) << "stream returned duplicate rows";
+  EXPECT_EQ(kNumPoints, seen.size()) << "stream ended after " << seen.size()
+                                     << " of " << kNumPoints << " rows";
+}
+
+TEST_F(HnswTest, StreamNoDuplicatesInMultiDimensionalGraph) {
+  constexpr size_t kStreamDims = 8;
+  constexpr size_t kStreamM = 4;
+  constexpr size_t kNumPoints = 100;
+  constexpr size_t kNumQueries = 4;
+  constexpr size_t kBatchSize = 4;
+  constexpr size_t kEfSearch = 8;
+
+  TestHnsw index(kStreamDims, euclidean, kStreamM, kEfConstruction);
+
+  uint64_t state = 12345;
+  const auto points =
+      make_pseudo_random_points(kNumPoints, kStreamDims, &state);
+  for (size_t i = 0; i < kNumPoints; ++i) {
+    index.insert(i, /*base_pk=*/i, as_bytes(points[i]));
+  }
+
+  const auto queries =
+      make_pseudo_random_points(kNumQueries, kStreamDims, &state);
+  for (size_t q = 0; q < kNumQueries; ++q) {
+    const auto streamed =
+        drain_stream(index, as_bytes(queries[q]), kBatchSize, kEfSearch,
+                     /*max_results=*/kNumPoints * 2);
+    const std::unordered_set<uint64_t> seen(streamed.begin(), streamed.end());
+    EXPECT_EQ(streamed.size(), seen.size())
+        << "q=" << q << ": stream yielded " << (streamed.size() - seen.size())
+        << " duplicate rows out of " << streamed.size();
+  }
+}
+
+TEST_F(HnswTest, StreamYieldsEachNodeAtMostOnce) {
+  constexpr size_t kStreamM = 2;
+  constexpr size_t kStreamEfConstruction = 2;
+  constexpr uint32_t kStreamSeed = 157;
+  constexpr size_t kBatchSize = 1;
+  constexpr size_t kEfSearch = 4;
+
+  TestHnsw index(kDims, euclidean, kStreamM, kStreamEfConstruction,
+                 kStreamSeed);
+
+  for (uint64_t i = 0; i < 5; ++i) {
+    index.insert(
+        i, i,
+        as_bytes(make_vec({100.0f + 0.5f * static_cast<float>(i), 0.0f})));
+  }
+  for (uint64_t i = 5; i < 10; ++i) {
+    index.insert(
+        i, i,
+        as_bytes(make_vec({100.0f + 0.5f * static_cast<float>(i - 5), 1.0f})));
+  }
+  for (uint64_t i = 10; i < 15; ++i) {
+    index.insert(
+        i, i,
+        as_bytes(make_vec({100.0f + 0.5f * static_cast<float>(i - 10), 2.0f})));
+  }
+  for (uint64_t i = 100; i < 105; ++i) {
+    index.insert(
+        i, i, as_bytes(make_vec({0.5f * static_cast<float>(i - 100), 0.0f})));
+  }
+  for (uint64_t i = 105; i < 110; ++i) {
+    index.insert(
+        i, i, as_bytes(make_vec({0.5f * static_cast<float>(i - 105), 1.0f})));
+  }
+  for (uint64_t i = 110; i < 115; ++i) {
+    index.insert(
+        i, i, as_bytes(make_vec({0.5f * static_cast<float>(i - 110), 2.0f})));
+  }
+
+  const auto query = make_vec({0.0f, 0.0f});
+  const auto streamed = drain_stream(index, as_bytes(query), kBatchSize,
+                                     kEfSearch, /*max_results=*/30);
+  std::unordered_set<uint64_t> seen(streamed.begin(), streamed.end());
+  EXPECT_EQ(seen.size(), streamed.size())
+      << "stream must not yield the same base_pk twice";
+}
+
+TEST_F(HnswTest, StreamExhaustThenNextStaysDone) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  index.insert(1, 100, as_bytes(make_vec({0.0f, 0.0f})));
+  TestHnsw::NNSearchContext ctx;
+  index.nn_search_start(&ctx, as_bytes(make_vec({0.0f, 0.0f})),
+                        /*batch_size=*/8, /*ef_search=*/16);
+  ASSERT_TRUE(index.nn_search_next(&ctx).first);
+  EXPECT_FALSE(index.nn_search_next(&ctx).first);
+  EXPECT_FALSE(index.nn_search_next(&ctx).first);
+}
+
+TEST_F(HnswTest, StreamRestartContext) {
+  TestHnsw index(kDims, euclidean, kM, kEfConstruction);
+  index.insert(1, 100, as_bytes(make_vec({0.0f, 0.0f})));
+  index.insert(2, 200, as_bytes(make_vec({5.0f, 0.0f})));
+
+  TestHnsw::NNSearchContext ctx;
+  const auto q = make_vec({0.0f, 0.0f});
+  index.nn_search_start(&ctx, as_bytes(q), /*batch_size=*/8, /*ef_search=*/16);
+  ASSERT_EQ(100U, index.nn_search_next(&ctx).second);
+
+  // Re-start on same context must work after reset.
+  ctx.reset();
+
+  index.nn_search_start(&ctx, as_bytes(q), /*batch_size=*/8, /*ef_search=*/16);
+  const std::pair<bool, uint64_t> step = index.nn_search_next(&ctx);
+  ASSERT_TRUE(step.first);
+  EXPECT_EQ(100U, step.second);
+}
+
+TEST_F(HnswTest, StreamBruteForceRecall) {
+  constexpr size_t kRecallDims = 16;
+  constexpr size_t kM = 5;
+  constexpr size_t kNumPoints = 2000;
+  constexpr size_t kNumQueries = 20;
+  constexpr size_t kK = 125;
+  // Batch size smaller than kK, so we have multiple batches.
+  constexpr size_t kBatchSize = 10;
+  // Ef_search is big enough to get good recall, but still smaller than kK.
+  // So we have more than one candidate set refills.
+  constexpr size_t kEfSearch = 50;
+  // Multi-batch streaming is more approximate, hence worse recall.
+  constexpr double kMinAvgRecall = 0.9;
+
+  TestHnsw index(kRecallDims, euclidean, kM, kEfConstruction);
+
+  uint64_t state = 42;
+  const auto points =
+      make_pseudo_random_points(kNumPoints, kRecallDims, &state);
+  for (size_t i = 0; i < kNumPoints; ++i) {
+    index.insert(i, /*base_pk=*/i, as_bytes(points[i]));
+  }
+
+  const auto queries =
+      make_pseudo_random_points(kNumQueries, kRecallDims, &state);
+
+  double recall_sum = 0.0;
+  for (size_t q = 0; q < kNumQueries; ++q) {
+    const std::vector<float> &query = queries[q];
+
+    std::vector<std::pair<double, uint64_t>> exact;
+    exact.reserve(kNumPoints);
+    for (size_t i = 0; i < kNumPoints; ++i) {
+      exact.emplace_back(euclidean(as_bytes(query), as_bytes(points[i]),
+                                   static_cast<uint32_t>(kRecallDims)),
+                         i);
+    }
+    std::partial_sort(exact.begin(), exact.begin() + kK, exact.end());
+    std::unordered_set<uint64_t> exact_ids;
+    for (size_t i = 0; i < kK; ++i) {
+      exact_ids.insert(exact[i].second);
+    }
+
+    const auto streamed =
+        drain_stream(index, as_bytes(query), kBatchSize, kEfSearch,
+                     /*max_results=*/kK);
+    ASSERT_EQ(kK, streamed.size()) << "q=" << q;
+
+    size_t hits = 0;
+    for (uint64_t pk : streamed) {
+      hits += exact_ids.count(pk);
+    }
+    recall_sum += static_cast<double>(hits) / static_cast<double>(kK);
+  }
+
+  const double avg_recall = recall_sum / static_cast<double>(kNumQueries);
+  EXPECT_GE(avg_recall, kMinAvgRecall)
+      << "avg stream recall@125=" << avg_recall;
 }
 
 #ifndef NDEBUG

--- a/unittest/gunit/hnsw_bench-t.cc
+++ b/unittest/gunit/hnsw_bench-t.cc
@@ -1,0 +1,520 @@
+/* Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+/**
+  @file
+
+  Recall / memory / throughput benchmark for the in-memory HNSW index.
+
+  This target is defined but NOT built by default and is never run by ctest;
+  it builds a large index and is meant to be run deliberately. Build and run
+  it with:
+
+    ninja hnsw_bench-t          # or: make hnsw_bench-t
+    ./runtime_output_directory/hnsw_bench-t
+
+  Timing benchmarks only (they are skipped in debug builds):
+
+    ./runtime_output_directory/hnsw_bench-t --gtest_filter='Microbenchmarks*'
+
+  The data set is sized by environment variables, so the whole curve can be
+  re-measured at a different scale without rebuilding:
+
+    HNSW_BENCH_POINTS  number of indexed vectors
+    HNSW_BENCH_DIMS    dimensions per vector
+    HNSW_BENCH_QUERIES number of query vectors
+    HNSW_BENCH_M       max out-degree above layer 0
+    HNSW_BENCH_EFC     ef_construction
+    HNSW_BENCH_K       k for recall@k
+
+  Unlike the correctness tests in hnsw-t.cc, this file asserts almost nothing.
+  Recall depends on the data distribution, so absolute thresholds are a
+  flakiness generator; the assertions that do exist are either structural
+  (no duplicate rows) or scale-free (recall must improve with ef_search).
+  The numbers are printed for a human to read.
+*/
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "unittest/gunit/benchmark.h"
+#include "unittest/gunit/hnsw_test_utils.h"
+#include "vector-common/vector_distance.h"
+
+namespace hnsw_bench {
+
+using hnsw_unittest::ArenaHandover;
+using hnsw_unittest::as_bytes;
+using hnsw_unittest::BorrowedHnsw;
+using hnsw_unittest::drain_stream;
+using hnsw_unittest::make_clustered_points;
+using hnsw_unittest::make_pseudo_random_points;
+
+// Keeps the optimizer from discarding search results.
+static volatile uint64_t bench_sink = 0;
+
+#ifdef NDEBUG
+constexpr size_t kDefaultPoints = 20000;
+constexpr size_t kDefaultDims = 64;
+constexpr size_t kDefaultQueries = 50;
+constexpr size_t kDefaultM = 16;
+constexpr size_t kDefaultEfConstruction = 200;
+#else
+// A 20000 x 64 build at -O0 with the hot-path asserts live runs into minutes,
+// so debug builds measure a small index just to keep the code exercised.
+constexpr size_t kDefaultPoints = 2000;
+constexpr size_t kDefaultDims = 16;
+constexpr size_t kDefaultQueries = 10;
+constexpr size_t kDefaultM = 8;
+constexpr size_t kDefaultEfConstruction = 32;
+#endif
+
+constexpr size_t kDefaultK = 10;
+
+/** ef_search values swept by RecallVsEfSearch. */
+constexpr size_t kEfSearchGrid[] = {10, 16, 32, 64, 128, 256};
+
+/**
+  Results fetched per streaming batch.
+
+  Must stay well below k: with batch_size >= k the first batch already
+  satisfies the request, the stream never refills, and it would return exactly
+  what k_nn_search returns -- making the comparison between the two paths
+  vacuous.
+*/
+constexpr size_t kStreamBatchSize = 3;
+
+/**
+  Clusters in the synthetic data set, and how tight they are.
+
+  The spread is tuned so recall is graded across the whole ef_search grid
+  rather than saturating early: at this setting clusters overlap substantially
+  but structure remains, and recall runs from roughly 0.79 at ef_search=10 to
+  roughly 0.998 at 256. Tighter clusters (spread <= 1.5) put every true
+  neighbor in an easily-found pocket and pin recall at 1.0 from ef_search=32
+  up, which measures nothing.
+*/
+constexpr size_t kNumClusters = 100;
+constexpr float kClusterSpread = 3.00f;
+
+/**
+  MEM_ROOT block size for the index arena.
+
+  Deliberately far larger than the 4096 used by the correctness tests: a
+  64-dimension node is ~536 bytes, so at 4096 only seven nodes fit per block
+  and the reported footprint would be dominated by abandoned block tails
+  rather than by the index itself.
+*/
+constexpr size_t kArenaBlockSize = 1024 * 1024;
+
+static size_t read_size_env(const char *name, size_t default_value) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return default_value;
+  }
+  char *end = nullptr;
+  const unsigned long long parsed = std::strtoull(value, &end, 10);
+  if (end == value || *end != '\0' || parsed == 0) {
+    std::cerr << "hnsw_bench: ignoring invalid " << name << "='" << value
+              << "', using " << default_value << "\n";
+    return default_value;
+  }
+  return static_cast<size_t>(parsed);
+}
+
+static double seconds_since(
+    const std::chrono::steady_clock::time_point &start) {
+  return std::chrono::duration<double>(std::chrono::steady_clock::now() - start)
+      .count();
+}
+
+/**
+  Data set, index and brute-force ground truth, built once for the whole
+  binary.
+
+  Building is by far the most expensive thing here, and the microbenchmark
+  harness calls each benchmark body twice (a calibration pass and the timed
+  run), so sharing this is what keeps the run to seconds rather than minutes.
+*/
+class BenchFixture {
+ public:
+  BenchFixture()
+      : m_num_points(read_size_env("HNSW_BENCH_POINTS", kDefaultPoints)),
+        m_dims(read_size_env("HNSW_BENCH_DIMS", kDefaultDims)),
+        m_num_queries(read_size_env("HNSW_BENCH_QUERIES", kDefaultQueries)),
+        m_M(read_size_env("HNSW_BENCH_M", kDefaultM)),
+        m_ef_construction(
+            read_size_env("HNSW_BENCH_EFC", kDefaultEfConstruction)),
+        m_k(read_size_env("HNSW_BENCH_K", kDefaultK)),
+        m_arena(kArenaBlockSize) {
+    // The index and the ground truth must rank with the same function, and
+    // this is the SIMD-dispatched kernel the server itself uses. Squaring
+    // does not change the ordering, so recall is the same as it would be for
+    // true L2.
+    init_vector_distance_functions();
+
+    uint64_t state = 42;
+    const std::vector<std::vector<float>> centers =
+        make_pseudo_random_points(kNumClusters, m_dims, &state);
+    m_points =
+        make_clustered_points(centers, m_num_points, kClusterSpread, &state);
+    // Queries are drawn from the same centers -- otherwise they land in empty
+    // space between clusters and the run measures out-of-distribution
+    // behavior -- but from fresh draws, so no query is an exact copy of an
+    // indexed point (a self-match would take one of the k slots for free).
+    m_queries =
+        make_clustered_points(centers, m_num_queries, kClusterSpread, &state);
+
+    const auto build_start = std::chrono::steady_clock::now();
+    {
+      ArenaHandover handover(&m_arena);
+      m_index.emplace(m_dims, vector_distance_euclidean_squared, m_M,
+                      m_ef_construction);
+    }
+    for (size_t i = 0; i < m_num_points; ++i) {
+      m_index->insert(i, /*base_pk=*/i, as_bytes(m_points[i]));
+    }
+    m_build_seconds = seconds_since(build_start);
+
+    const auto truth_start = std::chrono::steady_clock::now();
+    m_ground_truth.resize(m_num_queries);
+    std::vector<std::pair<double, uint64_t>> scratch;
+    scratch.reserve(m_num_points);
+    const size_t truth_k = std::min(m_k, m_num_points);
+    for (size_t q = 0; q < m_num_queries; ++q) {
+      scratch.clear();
+      for (size_t i = 0; i < m_num_points; ++i) {
+        scratch.emplace_back(vector_distance_euclidean_squared(
+                                 as_bytes(m_queries[q]), as_bytes(m_points[i]),
+                                 static_cast<uint32_t>(m_dims)),
+                             i);
+      }
+      std::partial_sort(scratch.begin(), scratch.begin() + truth_k,
+                        scratch.end());
+      for (size_t i = 0; i < truth_k; ++i) {
+        m_ground_truth[q].insert(scratch[i].second);
+      }
+    }
+    m_ground_truth_seconds = seconds_since(truth_start);
+  }
+
+  BenchFixture(const BenchFixture &) = delete;
+  BenchFixture &operator=(const BenchFixture &) = delete;
+
+  size_t num_points() const { return m_num_points; }
+  size_t dims() const { return m_dims; }
+  size_t num_queries() const { return m_num_queries; }
+  size_t M() const { return m_M; }
+  size_t ef_construction() const { return m_ef_construction; }
+  size_t k() const { return m_k; }
+  double build_seconds() const { return m_build_seconds; }
+  double ground_truth_seconds() const { return m_ground_truth_seconds; }
+  size_t arena_allocated_bytes() const {
+    return m_arena.mem_root.allocated_size();
+  }
+  size_t arena_requested_bytes() const { return m_arena.bytes_requested; }
+  size_t arena_requests() const { return m_arena.requests_number; }
+
+  const BorrowedHnsw &index() const { return *m_index; }
+  const std::vector<float> &query(size_t q) const { return m_queries[q]; }
+  const std::unordered_set<uint64_t> &ground_truth(size_t q) const {
+    return m_ground_truth[q];
+  }
+
+  /** Fraction of the true top-k present in @p found (duplicates ignored). */
+  double recall_of(const std::vector<uint64_t> &found, size_t q) const {
+    const std::unordered_set<uint64_t> distinct(found.begin(), found.end());
+    size_t hits = 0;
+    for (uint64_t base_pk : distinct) {
+      hits += m_ground_truth[q].count(base_pk);
+    }
+    return static_cast<double>(hits) /
+           static_cast<double>(m_ground_truth[q].size());
+  }
+
+  void print_config() const {
+    std::printf(
+        "\nHNSW benchmark: %zu points x %zu dims, %zu queries, M=%zu, "
+        "ef_construction=%zu, recall@%zu\n"
+        "  data: %zu clusters, spread %.2f    build: %.2fs    "
+        "ground truth: %.2fs\n\n",
+        m_num_points, m_dims, m_num_queries, m_M, m_ef_construction, m_k,
+        kNumClusters, static_cast<double>(kClusterSpread), m_build_seconds,
+        m_ground_truth_seconds);
+  }
+
+ private:
+  const size_t m_num_points;
+  const size_t m_dims;
+  const size_t m_num_queries;
+  const size_t m_M;
+  const size_t m_ef_construction;
+  const size_t m_k;
+
+  std::vector<std::vector<float>> m_points;
+  std::vector<std::vector<float>> m_queries;
+  std::vector<std::unordered_set<uint64_t>> m_ground_truth;
+
+  // Declared before the index: nodes point into this arena, so it has to
+  // outlive them. Owned here rather than inside the index so that its size is
+  // observable from outside.
+  hnsw_unittest::ArenaStats m_arena;
+  std::optional<BorrowedHnsw> m_index;
+
+  double m_build_seconds = 0.0;
+  double m_ground_truth_seconds = 0.0;
+};
+
+/** Built on first use, so a --gtest_filter run only pays for what it selects.
+ */
+static const BenchFixture &fixture() {
+  static const BenchFixture instance;
+  return instance;
+}
+
+/** Recall of k_nn_search() at @p ef_search, averaged over all queries. */
+struct RecallStats {
+  double average = 0.0;
+  double worst = 1.0;
+};
+
+static RecallStats measure_knn_recall(const BenchFixture &f, size_t ef_search) {
+  RecallStats stats;
+  for (size_t q = 0; q < f.num_queries(); ++q) {
+    const std::vector<uint64_t> found =
+        f.index().k_nn_search(as_bytes(f.query(q)), f.k(), ef_search);
+    const double recall = f.recall_of(found, q);
+    stats.average += recall;
+    stats.worst = std::min(stats.worst, recall);
+  }
+  stats.average /= static_cast<double>(f.num_queries());
+  return stats;
+}
+
+static RecallStats measure_stream_recall(const BenchFixture &f,
+                                         size_t ef_search) {
+  RecallStats stats;
+  for (size_t q = 0; q < f.num_queries(); ++q) {
+    const std::vector<uint64_t> found =
+        drain_stream(f.index(), as_bytes(f.query(q)),
+                     std::min(kStreamBatchSize, f.k()), ef_search,
+                     /*max_results=*/f.k());
+    const double recall = f.recall_of(found, q);
+    stats.average += recall;
+    stats.worst = std::min(stats.worst, recall);
+  }
+  stats.average /= static_cast<double>(f.num_queries());
+  return stats;
+}
+
+TEST(HnswBenchmark, RecallVsEfSearch) {
+  const BenchFixture &f = fixture();
+  f.print_config();
+
+  std::printf("  %9s | %9s %9s | %9s %9s | %8s\n", "ef_search", "knn_avg",
+              "knn_worst", "str_avg", "str_worst", "delta");
+  std::printf("  %9s-+-%9s-%9s-+-%9s-%9s-+-%8s\n", "---------", "---------",
+              "---------", "---------", "---------", "--------");
+
+  RecallStats first_knn;
+  RecallStats first_stream;
+  RecallStats last_knn;
+  RecallStats last_stream;
+  bool first = true;
+
+  for (size_t ef_search : kEfSearchGrid) {
+    const RecallStats knn = measure_knn_recall(f, ef_search);
+    const RecallStats stream = measure_stream_recall(f, ef_search);
+
+    std::printf("  %9zu | %9.4f %9.4f | %9.4f %9.4f | %+8.4f\n", ef_search,
+                knn.average, knn.worst, stream.average, stream.worst,
+                stream.average - knn.average);
+
+    if (first) {
+      first_knn = knn;
+      first_stream = stream;
+      first = false;
+    }
+    last_knn = knn;
+    last_stream = stream;
+  }
+  std::printf("\n");
+
+  // Scale-free and distribution-independent: whatever the data looks like,
+  // a wider search must not find fewer of the true neighbors. This is the
+  // assertion that actually catches a regression.
+  EXPECT_GE(last_knn.average, first_knn.average)
+      << "k_nn_search recall did not improve with ef_search";
+  EXPECT_GE(last_stream.average, first_stream.average)
+      << "streaming recall did not improve with ef_search";
+
+  // Deliberately wide floors, calibrated from a real run rather than guessed:
+  // both paths measure ~0.998 at the widest ef_search on this data set, so
+  // these leave room for compiler, libm and data-layout drift while still
+  // catching a collapse. They are separate because the streaming path drops
+  // any row closer than the last one it yielded (hnsw.h, m_seen_distance) and
+  // so is not guaranteed to track k_nn_search.
+  EXPECT_GE(last_knn.average, 0.85) << "k_nn_search recall collapsed";
+  EXPECT_GE(last_stream.average, 0.80) << "streaming recall collapsed";
+}
+
+TEST(HnswBenchmark, StreamFullDrainQuality) {
+  const BenchFixture &f = fixture();
+
+  // A full drain costs O(N * Mmax) distance evaluations, so sample a few
+  // queries rather than the whole set.
+  const size_t num_drains = std::min<size_t>(3, f.num_queries());
+  constexpr size_t kDrainEfSearch = 64;
+
+  std::printf("  full drain (ef_search=%zu, batch=%zu), %zu queries:\n",
+              kDrainEfSearch, kStreamBatchSize, num_drains);
+
+  for (size_t q = 0; q < num_drains; ++q) {
+    // max_results has to exceed the graph size, or the drain is truncated and
+    // the completeness ratio below would be meaningless.
+    const std::vector<uint64_t> streamed = drain_stream(
+        f.index(), as_bytes(f.query(q)), kStreamBatchSize, kDrainEfSearch,
+        /*max_results=*/f.num_points() + 1);
+
+    const std::unordered_set<uint64_t> distinct(streamed.begin(),
+                                                streamed.end());
+    const size_t duplicates = streamed.size() - distinct.size();
+    const double completeness = static_cast<double>(distinct.size()) /
+                                static_cast<double>(f.num_points());
+
+    std::printf(
+        "    q=%zu  rows %6zu  distinct %6zu  duplicates %4zu  "
+        "completeness %6.2f%%\n",
+        q, streamed.size(), distinct.size(), duplicates, 100.0 * completeness);
+
+    // Structural invariant, and the one the first version of the streaming
+    // code violated. This test builds a 1:1 id <-> base_pk mapping, so a
+    // repeated base_pk really is the same graph node twice; HNSW itself
+    // permits distinct nodes to share a base_pk.
+    EXPECT_EQ(0U, duplicates) << "q=" << q << ": stream yielded the same row "
+                              << duplicates << " time(s) over";
+  }
+
+  // Completeness is reported, never asserted to be 100%: rows are legitimately
+  // dropped by the documented m_seen_distance skip in nn_search_next(), and
+  // some nodes may be unreachable through the layer-0 graph.
+  std::printf("\n");
+}
+
+TEST(HnswBenchmark, IndexMemoryAndBuildCost) {
+  const BenchFixture &f = fixture();
+
+  const size_t nodes = f.num_points();
+  const size_t requested = f.arena_requested_bytes();
+  const size_t allocated = f.arena_allocated_bytes();
+  const size_t raw_vectors = nodes * f.dims() * sizeof(float);
+  const double bytes_per_node =
+      static_cast<double>(requested) / static_cast<double>(nodes);
+
+  // m_nodes is a std::unordered_map allocated from the global allocator, not
+  // from the arena, so it is invisible to allocated_size(). Estimate it:
+  // one hash node (next pointer + key + value) plus one bucket slot per entry.
+  const size_t map_estimate = nodes * (sizeof(void *) + sizeof(uint64_t) +
+                                       sizeof(void *) + sizeof(void *));
+
+  std::printf("  index memory and build cost:\n");
+  std::printf("    nodes                 %12zu\n", nodes);
+  std::printf("    build time            %12.2f s   (%.1f us/insert)\n",
+              f.build_seconds(),
+              1e6 * f.build_seconds() / static_cast<double>(nodes));
+  std::printf("    node bytes requested  %12zu bytes  (%.2f MB, %zu allocs)\n",
+              requested, requested / (1024.0 * 1024.0), f.arena_requests());
+  std::printf("    bytes per node        %12.1f\n", bytes_per_node);
+  std::printf("    raw vector bytes      %12zu bytes  (%.2f MB)\n", raw_vectors,
+              raw_vectors / (1024.0 * 1024.0));
+  std::printf(
+      "    graph / raw vectors   %12.2fx\n",
+      static_cast<double>(requested) / static_cast<double>(raw_vectors));
+  std::printf(
+      "    arena resident        %12zu bytes  (%.2f MB, %.1f%% slack)\n",
+      allocated, allocated / (1024.0 * 1024.0),
+      100.0 *
+          (static_cast<double>(allocated) - static_cast<double>(requested)) /
+          static_cast<double>(allocated));
+  std::printf(
+      "    m_nodes map (est.)    %12zu bytes  (%.2f MB, outside arena)\n",
+      map_estimate, map_estimate / (1024.0 * 1024.0));
+  std::printf("\n");
+
+  // A node stores its vector plus at least 2*M neighbor slots on layer 0, so
+  // anything at or below the raw vector size means the layout changed under us.
+  EXPECT_GT(bytes_per_node, static_cast<double>(f.dims() * sizeof(float)))
+      << "a node cannot be smaller than the vector it stores";
+  const double slots_per_node =
+      static_cast<double>(2 * f.M() + 2) * sizeof(void *);
+  EXPECT_LT(bytes_per_node,
+            2.0 * (f.dims() * sizeof(float) + slots_per_node) + 512.0)
+      << "per-node footprint far above the expected layout";
+}
+
+static void BM_HnswKnnSearch(size_t num_iterations) {
+#ifndef NDEBUG
+  // Timings from a -O0 build with hot-path asserts live are not informative.
+  GTEST_SKIP() << "Benchmarks skipped in debug builds "
+                  "(configure with -DWITH_DEBUG=OFF for meaningful results)";
+#endif
+  StopBenchmarkTiming();
+  const BenchFixture &f = fixture();
+  constexpr size_t kEfSearch = 64;
+
+  StartBenchmarkTiming();
+  for (size_t i = 0; i < num_iterations; ++i) {
+    // Rotate the query: repeating one query would measure a fully warmed path.
+    const std::vector<uint64_t> found = f.index().k_nn_search(
+        as_bytes(f.query(i % f.num_queries())), f.k(), kEfSearch);
+    bench_sink = bench_sink + (found.empty() ? 0 : found[0]);
+  }
+  StopBenchmarkTiming();
+}
+BENCHMARK(BM_HnswKnnSearch)
+
+static void BM_HnswStreamSearch(size_t num_iterations) {
+#ifndef NDEBUG
+  GTEST_SKIP() << "Benchmarks skipped in debug builds "
+                  "(configure with -DWITH_DEBUG=OFF for meaningful results)";
+#endif
+  StopBenchmarkTiming();
+  const BenchFixture &f = fixture();
+  constexpr size_t kEfSearch = 64;
+
+  StartBenchmarkTiming();
+  for (size_t i = 0; i < num_iterations; ++i) {
+    // Same k as BM_HnswKnnSearch so the two are directly comparable, and
+    // bounded because the harness calibrates with 100 unconditional
+    // iterations -- a full drain here would cost minutes before it noticed.
+    const std::vector<uint64_t> found = drain_stream(
+        f.index(), as_bytes(f.query(i % f.num_queries())),
+        std::min(kStreamBatchSize, f.k()), kEfSearch, /*max_results=*/f.k());
+    bench_sink = bench_sink + (found.empty() ? 0 : found[0]);
+  }
+  StopBenchmarkTiming();
+}
+BENCHMARK(BM_HnswStreamSearch)
+
+}  // namespace hnsw_bench

--- a/unittest/gunit/hnsw_test_utils.h
+++ b/unittest/gunit/hnsw_test_utils.h
@@ -1,0 +1,218 @@
+/* Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef HNSW_TEST_UTILS_INCLUDED
+#define HNSW_TEST_UTILS_INCLUDED
+
+/**
+  @file
+
+  Helpers shared by the HNSW unit tests (hnsw-t.cc) and the HNSW benchmark
+  (hnsw_bench-t.cc). Everything here is inline rather than static: hnsw-t.cc is
+  compiled into merge_small_tests-t, and a static helper that one including
+  translation unit happens not to use is a -Wunused-function error under
+  maintainer mode.
+*/
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <initializer_list>
+#include <utility>
+#include <vector>
+
+#include "my_alloc.h"
+#include "vector-common/hnsw.h"
+
+namespace hnsw_unittest {
+
+/**
+  Arena allocator backed by MEM_ROOT for HNSW unit tests.
+  All blocks are freed when the allocator (and its MEM_ROOT) is destroyed.
+*/
+class ArenaAllocator {
+ public:
+  ArenaAllocator() : m_mem_root(PSI_NOT_INSTRUMENTED, 4096) {}
+
+  void *allocate(size_t size) { return m_mem_root.Alloc(size); }
+
+ private:
+  MEM_ROOT m_mem_root;
+};
+
+using TestHnsw = HNSW<ArenaAllocator>;
+
+/**
+  Caller-owned arena plus request counters, for measuring an index's memory.
+
+  MEM_ROOT::allocated_size() reports what was taken from the OS, which includes
+  the unused tail of the last (exponentially grown) block; bytes_requested is
+  what the index actually asked for. Reporting both separates the index's own
+  footprint from the allocator's slack.
+*/
+struct ArenaStats {
+  explicit ArenaStats(size_t block_size)
+      : mem_root(PSI_NOT_INSTRUMENTED, block_size) {}
+
+  MEM_ROOT mem_root;
+  size_t bytes_requested = 0;
+  size_t requests_number = 0;
+};
+
+/**
+  Arena handed to the next HNSW constructed on this thread.
+
+  HNSW holds its allocator by value as a private member and default-constructs
+  it, so there is no way to pass an arena in. This slot lets a caller keep
+  ownership of the arena anyway, which is what makes the index's memory
+  footprint observable from outside. Set it with ArenaHandover, never directly.
+*/
+inline ArenaStats *g_pending_arena = nullptr;
+
+/**
+  Allocator that borrows a caller-owned arena instead of owning one.
+
+  The ArenaStats must outlive the index, since nodes point into its MEM_ROOT.
+*/
+class BorrowedArenaAllocator {
+ public:
+  BorrowedArenaAllocator() : m_arena(g_pending_arena) {
+    assert(m_arena != nullptr);  // no ArenaHandover in scope
+    g_pending_arena = nullptr;
+  }
+
+  void *allocate(size_t size) {
+    m_arena->bytes_requested += size;
+    ++m_arena->requests_number;
+    return m_arena->mem_root.Alloc(size);
+  }
+
+ private:
+  ArenaStats *m_arena;
+};
+
+using BorrowedHnsw = HNSW<BorrowedArenaAllocator>;
+
+/** Scoped arm of g_pending_arena; construct the index inside its scope. */
+class ArenaHandover {
+ public:
+  explicit ArenaHandover(ArenaStats *arena) { g_pending_arena = arena; }
+  ~ArenaHandover() { g_pending_arena = nullptr; }
+
+  ArenaHandover(const ArenaHandover &) = delete;
+  ArenaHandover &operator=(const ArenaHandover &) = delete;
+};
+
+inline double euclidean(const char *a_raw, const char *b_raw, uint32_t dims) {
+  const float *a = reinterpret_cast<const float *>(a_raw);
+  const float *b = reinterpret_cast<const float *>(b_raw);
+  double sum = 0.0;
+  for (uint32_t i = 0; i < dims; ++i) {
+    const double d = static_cast<double>(a[i]) - static_cast<double>(b[i]);
+    sum += d * d;
+  }
+  return std::sqrt(sum);
+}
+
+inline std::vector<float> make_vec(std::initializer_list<float> values) {
+  return std::vector<float>(values);
+}
+
+inline const char *as_bytes(const std::vector<float> &v) {
+  return reinterpret_cast<const char *>(v.data());
+}
+
+/**
+  Deterministic pseudo-random coordinate in [-1, 1).
+
+  Used instead of std::mt19937 / std::uniform_real_distribution so point
+  clouds are identical across standard libraries.
+*/
+inline float pseudo_coord(uint64_t *state) {
+  *state = *state * 6364136223846793005ULL + 1442695040888963407ULL;
+  return static_cast<float>((*state >> 40) & 0xFFFF) / 32768.0f - 1.0f;
+}
+
+inline std::vector<std::vector<float>> make_pseudo_random_points(
+    size_t count, size_t dims, uint64_t *state) {
+  std::vector<std::vector<float>> points(count);
+  for (size_t i = 0; i < count; ++i) {
+    points[i].resize(dims);
+    for (size_t d = 0; d < dims; ++d) {
+      points[i][d] = pseudo_coord(state);
+    }
+  }
+  return points;
+}
+
+/**
+  Deterministic point cloud drawn from the given cluster centers.
+
+  Uniform points in a high-dimensional cube are close to the worst case for any
+  approximate nearest-neighbor index: distances concentrate, so the "nearest"
+  neighbors are barely nearer than the rest and recall is low even for a
+  correct implementation. Real embeddings are clustered, so benchmark numbers
+  taken on clustered data are both more representative and more stable.
+
+  Members sit within @p spread of their center (sum of four draws, so roughly
+  bell-shaped). Queries must be drawn from the same centers as the indexed
+  points, or they land in empty space and the measurement says more about
+  out-of-distribution behavior than about the index.
+*/
+inline std::vector<std::vector<float>> make_clustered_points(
+    const std::vector<std::vector<float>> &centers, size_t count, float spread,
+    uint64_t *state) {
+  assert(!centers.empty());
+  const size_t dims = centers[0].size();
+
+  std::vector<std::vector<float>> points(count);
+  for (size_t i = 0; i < count; ++i) {
+    const std::vector<float> &center = centers[i % centers.size()];
+    points[i].resize(dims);
+    for (size_t d = 0; d < dims; ++d) {
+      float offset = 0.0f;
+      for (int j = 0; j < 4; ++j) {
+        offset += pseudo_coord(state);
+      }
+      points[i][d] = center[d] + spread * offset * 0.25f;
+    }
+  }
+  return points;
+}
+
+/**
+  Run a streaming search to completion (or @p max_results rows) and return the
+  base_pk values in the order the stream yielded them.
+*/
+template <typename Hnsw>
+inline std::vector<uint64_t> drain_stream(const Hnsw &index, const char *query,
+                                          size_t batch_size, size_t ef_search,
+                                          size_t max_results = 1000) {
+  typename Hnsw::NNSearchContext ctx;
+  index.nn_search_start(&ctx, query, batch_size, ef_search);
+  std::vector<uint64_t> out;
+  for (size_t i = 0; i < max_results; ++i) {
+    const std::pair<bool, uint64_t> step = index.nn_search_next(&ctx);
+    if (!step.first) {
+      break;
+    }
+    out.push_back(step.second);
+  }
+  return out;
+}
+
+}  // namespace hnsw_unittest
+
+#endif  // HNSW_TEST_UTILS_INCLUDED

--- a/vector-common/hnsw.h
+++ b/vector-common/hnsw.h
@@ -42,7 +42,7 @@ typedef double vec_dist_func_t(const char *a, const char *b, uint32_t dims);
   Approximate nearest-neighbor index over float vectors, following the
   algorithms from: https://arxiv.org/abs/1603.09320
 
-  Supports insert and k-NN search.
+  Supports insert, k-NN search, and streaming NN search.
 
   @tparam ArenaAllocator
     Arena allocator for graph nodes (and trailing vector / neighbor storage).
@@ -53,13 +53,12 @@ typedef double vec_dist_func_t(const char *a, const char *b, uint32_t dims);
     Not assumed thread-safe.
 
   @todo (not in order of priority)
-        1) Thread safety (interwined with persistence callbacks).
-        2) Streaming API.
-        3) Support for deletes (might be unnecessary).
-        4) Persistence callback API.
-        5) Support for arbitrary PKs and additional data (e.g. versioning).
-        6) Memory limits/expulsion strategy.
-        7) Performance optimizations (visited set?).
+        1) Thread safety (intertwined with persistence callbacks).
+        2) Support for deletes (might be unnecessary).
+        3) Persistence callback API.
+        4) Support for arbitrary PKs and additional data (e.g. versioning).
+        5) Memory limits/expulsion strategy.
+        6) Performance optimizations (visited set?).
 */
 template <typename ArenaAllocator>
 class HNSW {
@@ -214,6 +213,268 @@ class HNSW {
     return result;
   }
 
+ private:
+  class Node;
+
+  struct NodeDist {
+    Node *node;
+    double distance;
+  };
+
+  struct NodeDistMinCmp {
+    bool operator()(const NodeDist &a, const NodeDist &b) const {
+      return a.distance > b.distance;
+    }
+  };
+
+  struct NodeDistMaxCmp {
+    bool operator()(const NodeDist &a, const NodeDist &b) const {
+      return a.distance < b.distance;
+    }
+  };
+
+  typedef std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistMinCmp>
+      NodeDistMinQueue;
+
+ public:
+  /**
+    Mutable state for a batched streaming nearest-neighbor search.
+
+    Owned by the caller. Pass the same instance to nn_search_start() and
+    repeated nn_search_next() calls. Call reset() before starting another
+    search on the same context (asserted in debug builds). Destruction
+    also releases resources.
+
+    The HNSW index must outlive an in-progress search on this context.
+  */
+  class NNSearchContext {
+   public:
+    NNSearchContext() = default;
+    ~NNSearchContext() { reset(); }
+    NNSearchContext(const NNSearchContext &) = delete;
+    NNSearchContext &operator=(const NNSearchContext &) = delete;
+    NNSearchContext(NNSearchContext &&) = delete;
+    NNSearchContext &operator=(NNSearchContext &&) = delete;
+
+    /**
+      Release the query copy and clear search state.
+      Required before a subsequent nn_search_start() on this context.
+    */
+    void reset() {
+      free(const_cast<char *>(m_query_vec));
+      m_query_vec = nullptr;
+      m_batch_size = 0;
+      m_ef_search = 0;
+
+      m_visited = std::unordered_set<Node *>();
+      m_discarded = {};
+
+      m_results_batch.clear();
+      m_current_batch_pos = 0;
+      m_seen_distance = -std::numeric_limits<double>::infinity();
+    }
+
+   private:
+    void init(const HNSW &hnsw, const char *q, size_t batch_size,
+              size_t ef_search) {
+      char *query_vec = (char *)malloc(hnsw.m_dimensions * sizeof(float));
+      // TODO: revisit once we add memory limits.
+      if (query_vec == nullptr) throw std::bad_alloc();
+      memcpy(query_vec, q, hnsw.m_dimensions * sizeof(float));
+      assert(m_query_vec == nullptr);
+      m_query_vec = query_vec;
+      m_batch_size = batch_size;
+      m_ef_search = ef_search;
+      assert(m_visited.empty());
+      assert(m_discarded.empty());
+      assert(m_results_batch.empty());
+      assert(m_current_batch_pos == 0);
+      assert(m_seen_distance == -std::numeric_limits<double>::infinity());
+    }
+
+    // Search parameters
+    // Query vector is owned via malloc/free (not the HNSW arena):
+    // NNSearchContext outlives individual next() calls but is much
+    // shorter-lived than the index, and must be releasable on
+    // reset()/destruction independently of m_allocator.
+    const char *m_query_vec{nullptr};
+    size_t m_batch_size{0};
+    size_t m_ef_search{0};
+
+    // Search state
+    //
+    // TODO: Is it possible to use minimal seen distance + result from
+    //       previous batch as the only search state, like MariaDB does?
+    //       Our implementation is more complex, but should be more exact.
+    std::unordered_set<Node *> m_visited;
+    // Min-heap of nodes which were removed from the tentative result set
+    // and neighbors of nodes which are or were present in the result set
+    // which themselves were considered to be not good enough to be included
+    // into it while preparing the current/previous batch.
+    // We use this "ring" of nodes to prime the algorithm in order to produce
+    // the next batch.
+    NodeDistMinQueue m_discarded;
+
+    // Results
+    std::vector<NodeDist> m_results_batch;
+    size_t m_current_batch_pos{0};
+    double m_seen_distance{-std::numeric_limits<double>::infinity()};
+
+    friend class HNSW;
+  };
+
+  /**
+    Start a streaming approximate nearest-neighbor search on @p ctx.
+
+    @param ctx         Fresh or reset() context owned by the caller.
+    @param q           Query vector (copied into @p ctx).
+    @param batch_size  Results fetched per internal batch; must be > 0.
+    @param ef_search   Search width (clamped to at least batch_size).
+
+    @note This API is not intended to scan the entire or large part of the
+          index as it is approximate and likely to omit some nodes.
+          Optimizer should avoid using this API for queries which are likely
+          to do so.
+  */
+  void nn_search_start(NNSearchContext *ctx, const char *q, size_t batch_size,
+                       size_t ef_search) const {
+    assert(batch_size > 0);
+    size_t ef = std::max(batch_size, ef_search);
+    ctx->init(*this, q, batch_size, ef);
+
+    if (m_entry_point == nullptr) {
+      return;
+    }
+    const uint8_t max_layer = m_entry_point->m_layer;
+    NodeDist nearest_entry = {m_entry_point, dist(q, m_entry_point)};
+    for (int l = max_layer; l > 0; --l) {
+      nearest_entry = search_layer_ef_1(q, nearest_entry, l);
+    }
+
+    SearchLayerResult nearest{nearest_entry};
+    NodeDistMinQueue candidates;
+    candidates.push(nearest_entry);
+
+    assert(ctx->m_visited.empty());
+    ctx->m_visited.insert(nearest_entry.node);
+
+    assert(ctx->m_discarded.empty());
+
+    search_layer_core(q, &nearest, &candidates, &ctx->m_visited,
+                      &ctx->m_discarded, ef, 0);
+
+    // We can safely ignore nodes left in candidates heap. There can
+    // be only nodes in it which were part of the tentative result
+    // set in the past but were removed from it at some point.
+    // They will be present in the discarded heap as well.
+
+    // Intuitively, using the whole nearest/result set should negatively impact
+    // recall. Quick tests were not conclusive. TODO: Thoroughly investigate
+    // this.
+    while (nearest.size() > batch_size) {
+      ctx->m_discarded.push(nearest.top());
+      nearest.pop();
+    }
+
+    ctx->m_results_batch.resize(nearest.size());
+    for (size_t i = nearest.size(); i > 0; --i) {
+      ctx->m_results_batch[i - 1] = nearest.top();
+      nearest.pop();
+    }
+    assert(ctx->m_current_batch_pos == 0);
+  }
+
+  /**
+    Return the next neighbor from a streaming search, or {false, 0} when done.
+
+    Yields base_pk values in non-decreasing distance order.
+
+    @note Since underlying algorithm is not exact, it might sometimes produce
+          results out of order (then they belong to different batches).
+          We solve this problem by omitting offending nodes from the result.
+
+          Due to this and due to HNSW inherent properties this API is not
+          intended for scanning the entire index or large part of it.
+          Optimizer should avoid using this API for such cases.
+
+    @param ctx  Context previously passed to nn_search_start().
+  */
+  std::pair<bool, uint64_t> nn_search_next(NNSearchContext *ctx) const {
+    while (true) {
+      if (ctx->m_current_batch_pos >= ctx->m_results_batch.size()) {
+        if (ctx->m_current_batch_pos < ctx->m_batch_size) {
+          // The last batch was too short. This means that we have reached the
+          // end of the graph. There should be no leftover discarded nodes.
+          assert(ctx->m_discarded.empty());
+          return {false, 0};
+        } else {
+          // If there are no discarded nodes left, we have reached the end of
+          // the graph and there will be no more results.
+          if (ctx->m_discarded.empty()) {
+            return {false, 0};
+          }
+
+          SearchLayerResult nearest;
+          NodeDistMinQueue candidates;
+
+          while (nearest.size() < ctx->m_ef_search &&
+                 !ctx->m_discarded.empty()) {
+            nearest.push(ctx->m_discarded.top());
+            // Some of the nodes from the discarded heap (those which were
+            // removed from the tentative result set) might had their
+            // neighbors considered already in the past. This is OK.
+            // The visited set will filter such nodes' neighbors out.
+            // OTOH, nodes from discarded heap which were added there
+            // without entering the result set (or nodes which were
+            // removed from the result set before their neighbors were
+            // considered), do not have their neighbors inspected yet.
+            // Hence we need to add them to the candidates heap.
+            candidates.push(ctx->m_discarded.top());
+            assert(ctx->m_visited.count(ctx->m_discarded.top().node) > 0);
+            ctx->m_discarded.pop();
+          }
+
+          search_layer_core(ctx->m_query_vec, &nearest, &candidates,
+                            &ctx->m_visited, &ctx->m_discarded,
+                            ctx->m_ef_search, 0);
+
+          // Similarly to nn_search_start(), we can safely ignore nodes left
+          // in candidates heap. They will be present in the discarded heap.
+
+          // Again, the idea is that using the whole nearest/result set here
+          // should negatively impact recall. Quick tests were not conclusive.
+          // TODO: Thoroughly investigate this.
+          while (nearest.size() > ctx->m_batch_size) {
+            ctx->m_discarded.push(nearest.top());
+            nearest.pop();
+          }
+
+          // Since search_layer_core() got some candidates, there must be at
+          // least one result.
+          assert(nearest.size() > 0);
+
+          ctx->m_results_batch.resize(nearest.size());
+          for (size_t i = nearest.size(); i > 0; --i) {
+            ctx->m_results_batch[i - 1] = nearest.top();
+            nearest.pop();
+          }
+          ctx->m_current_batch_pos = 0;
+        }
+      }
+      const NodeDist &result = ctx->m_results_batch[ctx->m_current_batch_pos];
+      ctx->m_current_batch_pos++;
+
+      // The result from the new batch might be closer than the last seen
+      // result, from the previous batch. If so, we must skip it to ensure
+      // non-decreasing distance order. This is accepted trade-off/consequence
+      // of using approximate algorithm.
+      if (result.distance < ctx->m_seen_distance) continue;
+
+      ctx->m_seen_distance = result.distance;
+      return {true, result.node->m_base_pk};
+    }
+  }
+
 #ifndef NDEBUG
   /**
     Check internal graph consistency (debug builds only).
@@ -328,7 +589,10 @@ class HNSW {
       void *raw_mem =
           allocator.allocate(ALIGN_SIZE(sizeof(Node)) + ALIGN_SIZE(vec_size) +
                              ALIGN_SIZE(neighbors_size));
-      assert(raw_mem != nullptr);
+
+      // TODO: revisit once we add memory limits.
+      if (raw_mem == nullptr) throw std::bad_alloc();
+
       assert(ALIGN_SIZE(sizeof(Node)) + ALIGN_SIZE(vec_size) ==
              hnsw.m_neighbors_offset);
       Node *node = new (raw_mem) Node(id, base_pk, layer);
@@ -379,11 +643,6 @@ class HNSW {
     return ALIGN_SIZE(sizeof(Node)) + ALIGN_SIZE(dimensions * sizeof(float));
   }
 
-  struct NodeDist {
-    Node *node;
-    double distance;
-  };
-
   ArenaAllocator m_allocator;
   const size_t m_dimensions;
   vec_dist_func_t *const m_dist_func;
@@ -428,18 +687,6 @@ class HNSW {
         std::min<double>(-std::log(u) * m_layer_factor, layer_cap));
   }
 
-  struct NodeDistMinCmp {
-    bool operator()(const NodeDist &a, const NodeDist &b) const {
-      return a.distance > b.distance;
-    }
-  };
-
-  struct NodeDistMaxCmp {
-    bool operator()(const NodeDist &a, const NodeDist &b) const {
-      return a.distance < b.distance;
-    }
-  };
-
   /**
     Max-heap of (node, distance) pairs for a single-layer HNSW search.
 
@@ -449,6 +696,7 @@ class HNSW {
   */
   struct SearchLayerResult
       : std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistMaxCmp> {
+    SearchLayerResult() = default;
     explicit SearchLayerResult(const NodeDist &ep) { this->push(ep); }
 
     SearchLayerResult(const SearchLayerResult &) = delete;
@@ -530,10 +778,11 @@ class HNSW {
     std::unordered_set<Node *> visited;  // v in the paper
     // Guesstimate the number of unique nodes to visit in the layer.
     visited.reserve(ef * get_Mmax(layer));
-    // C in the paper
-    std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistMinCmp>
-        candidates;
-    // W in the paper
+    // C in the paper. Min-heap of nodes which neighbors we are going to
+    // consider for inclusion in the result set.
+    NodeDistMinQueue candidates;
+    // W in the paper. Max-heap of nodes which are already in the tentative
+    // result set (i.e. tentatively the closest ef nodes).
     SearchLayerResult result = std::move(entry_points);
 
     for (const NodeDist &entry : result) {
@@ -542,33 +791,70 @@ class HNSW {
       candidates.push(entry);
     }
 
-    while (!candidates.empty()) {
-      const NodeDist c = candidates.top();
-      candidates.pop();
+    search_layer_core(q, &result, &candidates, &visited, nullptr, ef, layer);
 
-      if (c.distance > result.top().distance) {
+    return result;
+  }
+
+  /**
+    Core of SEARCH-LAYER() algorithm from the HNSW paper used by search_layer()
+    and streaming search.
+
+    @param q           Query vector.
+    @param result      In/out result/working set max-heap (W in the paper).
+                       Must be non-empty on entry.
+    @param candidates  In/out min-heap of nodes whose neighbors to consider
+                       (C in the paper).
+    @param visited     In/out visited set (v in the paper).
+    @param discarded   Optional sink for evicted W entries and neighbors
+                       of C entries which were not admitted to W and C;
+                       nullptr to drop them.
+    @param ef          Maximum size of @p result.
+    @param layer       Layer index to search.
+*/
+  void search_layer_core(const char *q, SearchLayerResult *result,
+                         NodeDistMinQueue *candidates,
+                         std::unordered_set<Node *> *visited,
+                         NodeDistMinQueue *discarded, size_t ef,
+                         uint8_t layer) const {
+    assert(result != nullptr && !result->empty());
+    assert(candidates != nullptr && !candidates->empty());
+    // Early exit should not be possible as we populate C == W initially.
+    assert(candidates->top().distance <= result->top().distance);
+    assert(visited != nullptr);
+
+    while (!candidates->empty()) {
+      const NodeDist c = candidates->top();
+      candidates->pop();
+
+      if (c.distance > result->top().distance) {
         break;
       }
 
       for (Node *const *it = c.node->neighbors_begin(*this, layer);
            it != c.node->neighbors_end(*this, layer) && *it != nullptr; ++it) {
         Node *e = *it;
-        if (!visited.insert(e).second) {
+        if (!visited->insert(e).second) {
           continue;
         }
 
         const double e_dist = dist(q, e);
-        if (e_dist < result.top().distance || result.size() < ef) {
-          candidates.push({e, e_dist});
-          result.push({e, e_dist});
-          if (result.size() > ef) {
-            result.pop();
+        if (e_dist < result->top().distance || result->size() < ef) {
+          candidates->push({e, e_dist});
+          result->push({e, e_dist});
+          if (result->size() > ef) {
+            if (discarded != nullptr) {
+              discarded->push(result->top());
+            }
+            result->pop();
+          }
+        } else {
+          if (discarded != nullptr) {
+            discarded->push({e, e_dist});
           }
         }
       }
     }
-
-    return result;
   }
 
   /**

--- a/vector-common/hnsw.h
+++ b/vector-common/hnsw.h
@@ -1,0 +1,635 @@
+/* Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef HNSW_H_INCLUDED
+#define HNSW_H_INCLUDED
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <queue>
+#include <random>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "my_pointer_arithmetic.h"
+
+typedef double vec_dist_func_t(const char *a, const char *b, uint32_t dims);
+
+/**
+  Basic class for in-memory Hierarchical Navigable Small World (HNSW) vector
+  index.
+
+  Approximate nearest-neighbor index over float vectors, following the
+  algorithms from: https://arxiv.org/abs/1603.09320
+
+  Supports insert and k-NN search.
+
+  @tparam ArenaAllocator
+    Arena allocator for graph nodes (and trailing vector / neighbor storage).
+    Must provide void *allocate(size_t size); there is no per-block free.
+    Returned memory must stay valid for this object's lifetime; destroying
+    the allocator frees the arena. HNSW does not destroy Nodes and must not
+    outlive the allocator. allocate() may return nullptr (asserted).
+    Not assumed thread-safe.
+
+  @todo (not in order of priority)
+        1) Thread safety (interwined with persistence callbacks).
+        2) Streaming API.
+        3) Support for deletes (might be unnecessary).
+        4) Persistence callback API.
+        5) Support for arbitrary PKs and additional data (e.g. versioning).
+        6) Memory limits/expulsion strategy.
+        7) Performance optimizations (visited set?).
+*/
+template <typename ArenaAllocator>
+class HNSW {
+ public:
+  /**
+    Construct an empty in-memory HNSW index.
+
+    @param dimensions      Number of float elements per vector; must be > 0.
+    @param dist_func       Distance function over two vectors of @p dimensions.
+    @param M               Max out-degree on layers > 0 (layer 0 uses 2*M);
+                           must be >= 2.
+    @param ef_construction Size of the dynamic candidate list during INSERT;
+                           clamped to at least M.
+    @param seed            RNG seed for random layer assignment (default 42).
+  */
+  HNSW(size_t dimensions, vec_dist_func_t *dist_func, size_t M,
+       size_t ef_construction, uint32_t seed = 42)
+      : m_dimensions(dimensions),
+        m_dist_func(dist_func),
+        m_M(M),
+        m_ef_construction(std::max(ef_construction, M)),
+        m_layer_factor(1 / std::log(M)),
+        m_neighbors_offset(calc_neighbors_offset(dimensions)),
+        m_rng(seed) {
+    assert(dimensions > 0);
+    assert(M >= 2);
+  }
+  HNSW(const HNSW &) = delete;
+  HNSW &operator=(const HNSW &) = delete;
+  HNSW(HNSW &&) = delete;
+  HNSW &operator=(HNSW &&) = delete;
+
+  /**
+    Insert a vector into the HNSW graph.
+
+    Corresponds to INSERT (algorithm 1) in the HNSW paper.
+
+    @param id       Unique graph node id (must not already exist in the index).
+    @param base_pk  Primary key of the corresponding base-table row. Duplicates
+                    are allowed (e.g. after updating an indexed vector, a new
+                    graph node may share the same base_pk).
+    @param q        Vector to insert.
+  */
+  void insert(uint64_t id, uint64_t base_pk, const char *q) {
+    const uint8_t max_layer =
+        m_entry_point == nullptr ? 0 : m_entry_point->m_layer;
+    const uint8_t target_layer = random_layer(max_layer);
+
+    Node *new_node =
+        Node::create(m_allocator, *this, id, base_pk, q, target_layer);
+
+    auto inserted [[maybe_unused]] = m_nodes.emplace(id, new_node);
+    assert(inserted.second);
+
+    if (m_entry_point == nullptr) {
+      m_entry_point = new_node;
+      return;
+    }
+
+    NodeDist nearest_entry = {m_entry_point, dist(q, m_entry_point)};
+    for (int l = max_layer; l > target_layer; --l) {
+      nearest_entry = search_layer_ef_1(q, nearest_entry, l);
+      assert(nearest_entry.node != nullptr);
+    }
+
+    SearchLayerResult nearest{nearest_entry};
+
+    for (int l = std::min(max_layer, target_layer); l >= 0; --l) {
+      const size_t Mmax = get_Mmax(l);
+      nearest = search_layer(q, std::move(nearest), m_ef_construction, l);
+      // Paper and reference implementation both use M when selecting neighbors
+      // for layer 0 for newly inserted node, but it seems to be a typo.
+      // Both MariaDB and pgVector use 2 * M for layer 0, so we do too.
+      Node **new_node_neighbors = new_node->neighbors_begin(*this, l);
+      const size_t n [[maybe_unused]] =
+          select_neighbors(q, nearest, Mmax, new_node_neighbors);
+      assert(n <= Mmax);
+
+      for (Node *const *it = new_node_neighbors;
+           it != new_node->neighbors_end(*this, l) && *it != nullptr; ++it) {
+        Node *neighbor = *it;
+        Node **it2 = neighbor->neighbors_begin(*this, l);
+        while (it2 != neighbor->neighbors_end(*this, l) && *it2 != nullptr) {
+          ++it2;
+        }
+        if (it2 != neighbor->neighbors_end(*this, l)) {
+          *it2 = new_node;
+        } else {
+          std::vector<NodeDist> candidate_neighbors;
+          candidate_neighbors.reserve(Mmax + 1);
+          for (Node *const *nb = neighbor->neighbors_begin(*this, l);
+               nb != neighbor->neighbors_end(*this, l); ++nb) {
+            candidate_neighbors.push_back(
+                {*nb, dist(neighbor->get_vec(), *nb)});
+          }
+          candidate_neighbors.push_back(
+              {new_node, dist(neighbor->get_vec(), new_node)});
+
+          const size_t selected [[maybe_unused]] =
+              select_neighbors(neighbor->get_vec(), candidate_neighbors, Mmax,
+                               neighbor->neighbors_begin(*this, l));
+          assert(selected == Mmax);
+        }
+      }
+    }
+
+    if (target_layer > max_layer) {
+      m_entry_point = new_node;
+    }
+  }
+
+  /**
+    Approximate k-nearest-neighbor search.
+
+    Corresponds to K-NN-SEARCH (algorithm 5) in the HNSW paper.
+
+    @param q          Query vector.
+    @param k          Number of nearest neighbors to return; must be > 0.
+    @param ef_search  Size of the dynamic candidate list on layer 0 (clamped
+                      to at least k).
+
+    @return Up to k base_pk values for q's nearest neighbors ordered by
+            increasing distance.
+  */
+  std::vector<uint64_t> k_nn_search(const char *q, size_t k,
+                                    size_t ef_search) const {
+    assert(k > 0);
+
+    if (m_entry_point == nullptr) {
+      return {};
+    }
+    const uint8_t max_layer = m_entry_point->m_layer;
+    NodeDist nearest_entry = {m_entry_point, dist(q, m_entry_point)};
+    for (int l = max_layer; l > 0; --l) {
+      nearest_entry = search_layer_ef_1(q, nearest_entry, l);
+    }
+    // Asking for more rows than the configured search width silently
+    // widens the search.
+    SearchLayerResult nearest = search_layer(
+        q, SearchLayerResult{nearest_entry}, std::max(ef_search, k), 0);
+    // 'nearest' is a max-heap, so we need to throw away
+    // the extra elements to get the closest k elements.
+    while (nearest.size() > k) {
+      nearest.pop();
+    }
+    // Use trick to return closest k elements in correct order.
+    std::vector<uint64_t> result(nearest.size());
+    for (size_t i = nearest.size(); i > 0; --i) {
+      result[i - 1] = nearest.top().node->m_base_pk;
+      nearest.pop();
+    }
+    return result;
+  }
+
+#ifndef NDEBUG
+  /**
+    Check internal graph consistency (debug builds only).
+  */
+  bool validate() const {
+    // Empty index <=> no entry point.
+    if (m_nodes.empty()) {
+      return m_entry_point == nullptr;
+    }
+    // Non-empty index must have an entry point.
+    if (m_entry_point == nullptr) {
+      return false;
+    }
+
+    uint8_t max_layer = 0;
+    bool found_ep = false;
+    for (const auto &kv : m_nodes) {
+      const Node *node = kv.second;
+      // Map key must match node id; pointer must be non-null.
+      if (node == nullptr || node->m_id != kv.first) {
+        return false;
+      }
+      max_layer = std::max(max_layer, node->m_layer);
+      if (node == m_entry_point) {
+        found_ep = true;
+      }
+    }
+    // Entry point must be in the map and sit on the highest layer.
+    if (!found_ep || m_entry_point->m_layer != max_layer) {
+      return false;
+    }
+
+    for (const auto &kv : m_nodes) {
+      const Node *node = kv.second;
+      for (uint8_t lc = 0; lc <= node->m_layer; ++lc) {
+        const size_t Mmax = get_Mmax(lc);
+        Node *const *begin = node->neighbors_begin(*this, lc);
+        Node *const *end = node->neighbors_end(*this, lc);
+
+        // Neighbor slot span must equal Mmax for this layer.
+        if (static_cast<size_t>(end - begin) != Mmax) {
+          return false;
+        }
+
+        size_t degree = 0;
+        bool seen_null = false;
+        std::unordered_set<const Node *> seen_neighbors;
+        for (Node *const *it = begin; it != end; ++it) {
+          if (*it == nullptr) {
+            seen_null = true;
+            continue;
+          }
+          // No holes: non-null after a null slot.
+          if (seen_null) {
+            return false;
+          }
+          const Node *nb = *it;
+          // No self-loops.
+          if (nb == node) {
+            return false;
+          }
+          // No duplicate neighbors on the same layer.
+          if (!seen_neighbors.insert(nb).second) {
+            return false;
+          }
+          // Neighbor must still be present in m_nodes under its id.
+          const auto nit = m_nodes.find(nb->m_id);
+          if (nit == m_nodes.end() || nit->second != nb) {
+            return false;
+          }
+          // Neighbor must exist on this layer (its top layer >= lc).
+          if (nb->m_layer < lc) {
+            return false;
+          }
+          ++degree;
+        }
+        // Degree cannot exceed Mmax (also implied by packed slots).
+        if (degree > Mmax) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+#endif  // NDEBUG
+
+ private:
+  /**
+    Graph node allocated as one arena block:
+
+      [ Node | float vector | neighbor slots ]
+
+    Each region is ALIGN_SIZE-aligned. The vector holds m_dimensions floats.
+    Neighbor storage is (m_layer + 2) * M Node* slots (layer 0 needs 2*M,
+    layers 1..m_layer need M each). Within that array, layers are packed
+    high-to-low: layer L starts at offset (m_layer - L) * M and spans
+    get_Mmax(L) slots; unused slots are nullptr. Neighbor array starts at
+    byte offset HNSW::m_neighbors_offset from Node. Arena-owned: do not delete.
+  */
+  class Node {
+   public:
+    /**
+      Allocate and initialize a node in @p allocator (see class layout).
+    */
+    static Node *create(ArenaAllocator &allocator, const HNSW &hnsw,
+                        uint64_t id, uint64_t base_pk, const char *vec,
+                        uint8_t layer) {
+      // TODO: Needs to be adjusted to support quantization.
+      const size_t vec_size = hnsw.m_dimensions * sizeof(float);
+      const size_t neighbors_size =
+          (static_cast<size_t>(layer) + 2) * hnsw.m_M * sizeof(Node *);
+      void *raw_mem =
+          allocator.allocate(ALIGN_SIZE(sizeof(Node)) + ALIGN_SIZE(vec_size) +
+                             ALIGN_SIZE(neighbors_size));
+      assert(raw_mem != nullptr);
+      assert(ALIGN_SIZE(sizeof(Node)) + ALIGN_SIZE(vec_size) ==
+             hnsw.m_neighbors_offset);
+      Node *node = new (raw_mem) Node(id, base_pk, layer);
+      memcpy(node->get_vec(), vec, vec_size);
+      memset(node->get_neighbors(hnsw), 0, neighbors_size);
+      return node;
+    }
+
+    Node(const Node &) = delete;
+    Node &operator=(const Node &) = delete;
+    Node(Node &&) = delete;
+    Node &operator=(Node &&) = delete;
+
+    char *get_vec() const {
+      return reinterpret_cast<char *>(const_cast<Node *>(this)) +
+             ALIGN_SIZE(sizeof(Node));
+    }
+    Node **get_neighbors(const HNSW &hnsw) const {
+      return reinterpret_cast<Node **>(
+          reinterpret_cast<char *>(const_cast<Node *>(this)) +
+          hnsw.m_neighbors_offset);
+    }
+
+    // Neighbor slot range for a layer: [neighbors_begin, neighbors_end).
+    // Layout and per-layer width: see Node class comment / get_Mmax().
+    Node **neighbors_begin(const HNSW &hnsw, uint8_t layer) const {
+      return get_neighbors(hnsw) + (m_layer - layer) * hnsw.m_M;
+    }
+    Node **neighbors_end(const HNSW &hnsw, uint8_t layer) const {
+      return neighbors_begin(hnsw, layer) + hnsw.get_Mmax(layer);
+    }
+
+    /// Unique graph node id.
+    const uint64_t m_id;
+    /// Base table row pk (duplicates allowed).
+    const uint64_t m_base_pk;
+    /// Top layer on which the node is present
+    /// (it is also present on all lower layers).
+    const uint8_t m_layer;
+
+   private:
+    Node(uint64_t id, uint64_t base_pk, uint8_t layer)
+        : m_id(id), m_base_pk(base_pk), m_layer(layer) {}
+  };
+
+  /** Byte offset from Node* to neighbor slots. */
+  static size_t calc_neighbors_offset(size_t dimensions) {
+    return ALIGN_SIZE(sizeof(Node)) + ALIGN_SIZE(dimensions * sizeof(float));
+  }
+
+  struct NodeDist {
+    Node *node;
+    double distance;
+  };
+
+  ArenaAllocator m_allocator;
+  const size_t m_dimensions;
+  vec_dist_func_t *const m_dist_func;
+  const size_t m_M;
+  const size_t m_ef_construction;
+  const double m_layer_factor;
+  const size_t m_neighbors_offset;
+
+  // Nodes are arena-allocated; pointers are non-owning.
+  std::unordered_map<uint64_t, Node *> m_nodes;
+  Node *m_entry_point{nullptr};
+  std::default_random_engine m_rng;
+
+  /**
+    Max neighbor slots on @p layer: 2*M on layer 0 (as suggested by the HNSW
+    paper), M on higher layers.
+  */
+  size_t get_Mmax(size_t layer) const { return layer == 0 ? 2 * m_M : m_M; }
+
+  /**
+    Draw the top layer for a new node (HNSW paper level generation).
+
+    @param current_max_layer  Current entry-point layer (0 if the index
+                              is empty).
+
+    @return Top layer index for the node being inserted.
+            Value 0 is most likely to be returned, while higher values
+            get exponentially sparser until reaching 255 (uint8_t max) cap.
+            We additionally cap result to current_max_layer + 1 in order to
+            throttle layer growth to avoid HNSW graph becoming too tall
+            right from the start
+  */
+  uint8_t random_layer(uint8_t current_max_layer) {
+    // Avoid log(0) by using minimum double value.
+    const double u =
+        std::max(std::uniform_real_distribution<double>(0.0, 1.0)(m_rng),
+                 std::numeric_limits<double>::min());
+    // Throttle layer growth and avoid UB caused by double -> uint8_t overflow.
+    const uint8_t layer_cap = std::min<int>(
+        current_max_layer + 1, std::numeric_limits<uint8_t>::max());
+    return static_cast<uint8_t>(
+        std::min<double>(-std::log(u) * m_layer_factor, layer_cap));
+  }
+
+  struct NodeDistMinCmp {
+    bool operator()(const NodeDist &a, const NodeDist &b) const {
+      return a.distance > b.distance;
+    }
+  };
+
+  struct NodeDistMaxCmp {
+    bool operator()(const NodeDist &a, const NodeDist &b) const {
+      return a.distance < b.distance;
+    }
+  };
+
+  /**
+    Max-heap of (node, distance) pairs for a single-layer HNSW search.
+
+    Used as SEARCH-LAYER entry points, working set W, and return value.
+    Iteration walks the underlying vector in heap layout (not sorted by
+    distance). Move-only.
+  */
+  struct SearchLayerResult
+      : std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistMaxCmp> {
+    explicit SearchLayerResult(const NodeDist &ep) { this->push(ep); }
+
+    SearchLayerResult(const SearchLayerResult &) = delete;
+    SearchLayerResult &operator=(const SearchLayerResult &) = delete;
+    SearchLayerResult(SearchLayerResult &&) = default;
+    SearchLayerResult &operator=(SearchLayerResult &&) = default;
+
+    std::vector<NodeDist>::const_iterator begin() const {
+      return this->c.begin();
+    }
+    std::vector<NodeDist>::const_iterator end() const { return this->c.end(); }
+  };
+
+  double dist(const char *q, const Node *node) const {
+    return m_dist_func(q, node->get_vec(), static_cast<uint32_t>(m_dimensions));
+  }
+
+  /**
+    Greedy one-nearest-neighbor search on a single layer (ef = 1).
+
+    Corresponds to SEARCH-LAYER(..., ef=1) (algorithm 2) in the HNSW paper.
+    Used when descending from the top layer toward the target layer during
+    INSERT and K-NN-SEARCH, where only the nearest neighbor of the query is
+    needed as the entry point for the next lower layer.
+
+    Kept separate from search_layer() to avoid the overhead of a visited set
+    and candidate priority queues when ef = 1.
+
+    @param q            Query vector.
+    @param entry_point  Entry element on this layer (node and distance to q).
+    @param layer        Layer index to search.
+
+    @return Nearest neighbor of q found on the given layer, with distance.
+  */
+  NodeDist search_layer_ef_1(const char *q, const NodeDist &entry_point,
+                             uint8_t layer) const {
+    Node *best_node = entry_point.node;
+    double best_dist = entry_point.distance;
+
+    for (;;) {
+      Node *cur_node = best_node;
+
+      for (Node *const *it = cur_node->neighbors_begin(*this, layer);
+           it != cur_node->neighbors_end(*this, layer) && *it != nullptr;
+           ++it) {
+        Node *neighbor = *it;
+        const double neighbor_dist = dist(q, neighbor);
+        if (neighbor_dist < best_dist) {
+          best_node = neighbor;
+          best_dist = neighbor_dist;
+        }
+      }
+
+      if (best_node == cur_node) {
+        return {best_node, best_dist};
+      }
+    }
+  }
+
+  /**
+    Search for up to ef nearest neighbors of q on a single layer.
+
+    Corresponds to SEARCH-LAYER (algorithm 2) in the HNSW paper.
+    Used on the construction layers during INSERT (with ef = m_ef_construction)
+    and on layer 0 during K-NN-SEARCH (with ef = ef_search).
+
+    @param q   Query vector.
+    @param entry_points  Entry points on this layer.
+    @param ef  Size of the dynamic candidate / result list.
+    @param layer  Layer index to search.
+
+    @return Up to ef nearest neighbors of q on the given layer (as a
+            max-heap of node/distance pairs; not sorted by distance when
+            iterated).
+  */
+  SearchLayerResult search_layer(const char *q, SearchLayerResult entry_points,
+                                 size_t ef, uint8_t layer) const {
+    assert(!entry_points.empty());
+    std::unordered_set<Node *> visited;  // v in the paper
+    // Guesstimate the number of unique nodes to visit in the layer.
+    visited.reserve(ef * get_Mmax(layer));
+    // C in the paper
+    std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistMinCmp>
+        candidates;
+    // W in the paper
+    SearchLayerResult result = std::move(entry_points);
+
+    for (const NodeDist &entry : result) {
+      const bool res [[maybe_unused]] = visited.insert(entry.node).second;
+      assert(res == true);
+      candidates.push(entry);
+    }
+
+    while (!candidates.empty()) {
+      const NodeDist c = candidates.top();
+      candidates.pop();
+
+      if (c.distance > result.top().distance) {
+        break;
+      }
+
+      for (Node *const *it = c.node->neighbors_begin(*this, layer);
+           it != c.node->neighbors_end(*this, layer) && *it != nullptr; ++it) {
+        Node *e = *it;
+        if (!visited.insert(e).second) {
+          continue;
+        }
+
+        const double e_dist = dist(q, e);
+        if (e_dist < result.top().distance || result.size() < ef) {
+          candidates.push({e, e_dist});
+          result.push({e, e_dist});
+          if (result.size() > ef) {
+            result.pop();
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+    Select up to max_neighbors neighbors of q from candidate set.
+
+    Corresponds to SELECT-NEIGHBORS (heuristic, algorithm 4) in the HNSW
+    paper, including keepPrunedConnections but excluding extendCandidates.
+
+    @param q    Query / base element vector (unused; distances come from
+                candidates; kept for consistency with the paper).
+    @param candidates     Candidate neighbors with distances to q.
+    @param max_neighbors  Maximum number of neighbors to select.
+    @param out  Output buffer of at least max_neighbors Node* slots;
+                selected neighbors are written to out[0 .. return_value).
+                Together with r_size/return value corresponds to R in the paper.
+
+    @return Number of neighbors written to out (at most max_neighbors).
+  */
+  template <typename NodeDistRange>
+  size_t select_neighbors(const char * /* q */, const NodeDistRange &candidates,
+                          size_t max_neighbors, Node **out) const {
+    size_t r_size = 0;
+    // W in the paper.
+    std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistMinCmp>
+        work_queue;
+    // Discarded candidates in nearest-first order (same order as pops from W).
+    std::vector<Node *> discarded;  // Wd from the paper.
+
+    for (const NodeDist &entry : candidates) {
+      work_queue.push(entry);
+    }
+
+    while (!work_queue.empty() && r_size < max_neighbors) {
+      const NodeDist e = work_queue.top();
+      work_queue.pop();
+
+      bool discard = false;
+      for (size_t i = 0; i < r_size; ++i) {
+        const double r_dist = dist(e.node->get_vec(), out[i]);
+        /*
+          A candidate e is discarded when it is closer or at least as close
+          to some already-selected neighbor as it is to the query vector q.
+        */
+        if (e.distance >= r_dist) {
+          discard = true;
+          break;
+        }
+      }
+      if (!discard) {
+        out[r_size++] = e.node;
+      } else {
+        discarded.push_back(e.node);
+      }
+    }
+
+    for (size_t i = 0; i < discarded.size() && r_size < max_neighbors; ++i) {
+      out[r_size++] = discarded[i];
+    }
+
+    return r_size;
+  }
+};
+
+#endif  // HNSW_H_INCLUDED


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11266

Added basic implementation of in-memory HNSW index.

It supports insert and approximate k-NN search per the HNSW paper
(https://arxiv.org/abs/1603.09320) and uses arena allocator for nodes.

Streaming approximate NN search is also supported.

Added unit tests.