### PR TITLE
PS-11483: Wrong query results when an internal temporary table is converted to on-disk InnoDB

### DIFF
--- a/mysql-test/r/with_recursive_innodb_tmp_table.result
+++ b/mysql-test/r/with_recursive_innodb_tmp_table.result
@@ -366,29 +366,30 @@ drop table t1;
 #
 create table t1 (
 id int primary key,
-col1 varchar(32),
+col1 varchar(300) character set latin1,
 key index_col1(col1)
 );
 create table t2 (
 id int primary key,
-col1 varchar(32)
+col1 varchar(300) character set latin1
 );
 create procedure insert_bug_37308710_data()
 begin
 declare num int;
 set num = 1;
-while num < 100 do
-insert into t1 values (num, lpad(num, 32, '0'));
-insert into t2 values (num, lpad(num, 32, '0'));
+while num <= 4000 do
+insert into t1 values (num, lpad(num, 300, '0'));
+insert into t2 values (num, lpad(num, 300, '0'));
 set num = num + 1;
 end while;
 end//
-call insert_bug_37308710_data();
 set @old_internal_tmp_mem_storage_engine =
 @@session.internal_tmp_mem_storage_engine;
 set session internal_tmp_mem_storage_engine = 'memory';
 set @old_tmp_table_size = @@tmp_table_size;
-set @@tmp_table_size = 102400;
+set @old_max_heap_table_size = @@max_heap_table_size;
+set @@max_heap_table_size = 16*1024*1024;
+set @@tmp_table_size = 16*1024*1024;
 flush status;
 explain select count(distinct d.col1)
 from (
@@ -401,13 +402,13 @@ from t1
 join t2 on d.col1 = t2.col1
 where t2.id = 1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
-1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
-2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	#	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	303	const	#	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	#	NULL	Using temporary
 Warnings:
-Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001'))
 select count(distinct d.col1)
 from (
 select t1.col1
@@ -423,7 +424,7 @@ count(distinct d.col1)
 show status like 'Created_tmp_disk_tables';
 Variable_name	Value
 Created_tmp_disk_tables	0
-set @@tmp_table_size = 1024;
+set @@tmp_table_size = 1024*1024;
 flush status;
 explain select count(distinct d.col1)
 from (
@@ -436,13 +437,13 @@ from t1
 join t2 on d.col1 = t2.col1
 where t2.id = 1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
-1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
-2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	#	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	303	const	#	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	#	NULL	Using temporary
 Warnings:
-Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001'))
 select count(distinct d.col1)
 from (
 select t1.col1
@@ -461,6 +462,7 @@ Created_tmp_disk_tables	1
 set session internal_tmp_mem_storage_engine =
 @old_internal_tmp_mem_storage_engine;
 set @@tmp_table_size = @old_tmp_table_size;
+set @@max_heap_table_size = @old_max_heap_table_size;
 drop procedure insert_bug_37308710_data;
 drop table t1, t2;
 # cleanup

--- a/mysql-test/r/with_recursive_innodb_tmp_table.result
+++ b/mysql-test/r/with_recursive_innodb_tmp_table.result
@@ -360,6 +360,108 @@ Warning	1287	Setting user variables within expressions is deprecated and will be
 show status like 'Created_tmp_disk_tables';
 Variable_name	Value
 Created_tmp_disk_tables	0
-# cleanup
 drop table t1;
+#
+# Bug 37308710 - const access after MEMORY to InnoDB temp-table overflow
+#
+create table t1 (
+id int primary key,
+col1 varchar(32),
+key index_col1(col1)
+);
+create table t2 (
+id int primary key,
+col1 varchar(32)
+);
+create procedure insert_bug_37308710_data()
+begin
+declare num int;
+set num = 1;
+while num < 100 do
+insert into t1 values (num, lpad(num, 32, '0'));
+insert into t2 values (num, lpad(num, 32, '0'));
+set num = num + 1;
+end while;
+end//
+call insert_bug_37308710_data();
+set @old_internal_tmp_mem_storage_engine =
+@@session.internal_tmp_mem_storage_engine;
+set session internal_tmp_mem_storage_engine = 'memory';
+set @old_tmp_table_size = @@tmp_table_size;
+set @@tmp_table_size = 102400;
+flush status;
+explain select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+count(distinct d.col1)
+1
+show status like 'Created_tmp_disk_tables';
+Variable_name	Value
+Created_tmp_disk_tables	0
+set @@tmp_table_size = 1024;
+flush status;
+explain select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+count(distinct d.col1)
+1
+show status like 'Created_tmp_disk_tables';
+Variable_name	Value
+Created_tmp_disk_tables	1
+set session internal_tmp_mem_storage_engine =
+@old_internal_tmp_mem_storage_engine;
+set @@tmp_table_size = @old_tmp_table_size;
+drop procedure insert_bug_37308710_data;
+drop table t1, t2;
+# cleanup
 set session internal_tmp_mem_storage_engine=default;

--- a/mysql-test/t/with_recursive_innodb_tmp_table.test
+++ b/mysql-test/t/with_recursive_innodb_tmp_table.test
@@ -74,15 +74,28 @@ drop table t1;
 --echo # Bug 37308710 - const access after MEMORY to InnoDB temp-table overflow
 --echo #
 
+# Note (PXC): the upstream reproducer relied on `tmp_table_size` values below
+# 1 MiB (102400 and 1024 bytes) to keep the small case in memory and force the
+# large case onto disk. Percona's PS-8647 patch in sql/sys_vars.cc silently
+# clamps any tmp_table_size < 1 MiB up to 1 MiB (and emits a warning), so the
+# original values no longer differentiate the two runs and the small case
+# never overflows to disk. To preserve the intent of the test on PXC we widen
+# col1, insert enough rows to make the materialized derived table exceed
+# 1 MiB, and use tmp_table_size values at/above the 1-MiB clamp threshold:
+#   - big case:   tmp_table_size = 16 MiB   -> data fits in MEMORY
+#   - small case: tmp_table_size =  1 MiB   -> data overflows to InnoDB
+#                                              (also exactly at the PS-8647
+#                                               floor, so no clamp warning)
+
 create table t1 (
   id int primary key,
-  col1 varchar(32),
+  col1 varchar(300) character set latin1,
   key index_col1(col1)
 );
 
 create table t2 (
   id int primary key,
-  col1 varchar(32)
+  col1 varchar(300) character set latin1
 );
 
 delimiter //;
@@ -90,21 +103,26 @@ create procedure insert_bug_37308710_data()
 begin
   declare num int;
   set num = 1;
-  while num < 100 do
-    insert into t1 values (num, lpad(num, 32, '0'));
-    insert into t2 values (num, lpad(num, 32, '0'));
+  while num <= 4000 do
+    insert into t1 values (num, lpad(num, 300, '0'));
+    insert into t2 values (num, lpad(num, 300, '0'));
     set num = num + 1;
   end while;
 end//
 delimiter ;//
 
+--disable_query_log
 call insert_bug_37308710_data();
+--enable_query_log
 
 set @old_internal_tmp_mem_storage_engine =
   @@session.internal_tmp_mem_storage_engine;
 set session internal_tmp_mem_storage_engine = 'memory';
 set @old_tmp_table_size = @@tmp_table_size;
-set @@tmp_table_size = 102400;
+set @old_max_heap_table_size = @@max_heap_table_size;
+# Ensure MEMORY-table cap is not the earlier section's 61000-byte value.
+set @@max_heap_table_size = 16*1024*1024;
+set @@tmp_table_size = 16*1024*1024;
 
 let $query =
 select count(distinct d.col1)
@@ -119,13 +137,19 @@ join t2 on d.col1 = t2.col1
 where t2.id = 1;
 
 flush status;
+# InnoDB's live rows-estimate for t1 fluctuates between runs; mask it out
+# so the test only checks the columns we actually care about.
+--replace_column 10 #
 eval explain $query;
 eval $query;
 show status like 'Created_tmp_disk_tables';
 
-set @@tmp_table_size = 1024;
+set @@tmp_table_size = 1024*1024;
 
 flush status;
+# InnoDB's live rows-estimate for t1 fluctuates between runs; mask it out
+# so the test only checks the columns we actually care about.
+--replace_column 10 #
 eval explain $query;
 eval $query;
 show status like 'Created_tmp_disk_tables';
@@ -133,6 +157,7 @@ show status like 'Created_tmp_disk_tables';
 set session internal_tmp_mem_storage_engine =
   @old_internal_tmp_mem_storage_engine;
 set @@tmp_table_size = @old_tmp_table_size;
+set @@max_heap_table_size = @old_max_heap_table_size;
 drop procedure insert_bug_37308710_data;
 drop table t1, t2;
 

--- a/mysql-test/t/with_recursive_innodb_tmp_table.test
+++ b/mysql-test/t/with_recursive_innodb_tmp_table.test
@@ -68,6 +68,73 @@ set @@tmp_table_size=30000,@@max_heap_table_size=30000;
 set @@tmp_table_size=60000,@@max_heap_table_size=61000;
 --source include/with_recursive_wl9248.inc
 
---echo # cleanup
 drop table t1;
+
+--echo #
+--echo # Bug 37308710 - const access after MEMORY to InnoDB temp-table overflow
+--echo #
+
+create table t1 (
+  id int primary key,
+  col1 varchar(32),
+  key index_col1(col1)
+);
+
+create table t2 (
+  id int primary key,
+  col1 varchar(32)
+);
+
+delimiter //;
+create procedure insert_bug_37308710_data()
+begin
+  declare num int;
+  set num = 1;
+  while num < 100 do
+    insert into t1 values (num, lpad(num, 32, '0'));
+    insert into t2 values (num, lpad(num, 32, '0'));
+    set num = num + 1;
+  end while;
+end//
+delimiter ;//
+
+call insert_bug_37308710_data();
+
+set @old_internal_tmp_mem_storage_engine =
+  @@session.internal_tmp_mem_storage_engine;
+set session internal_tmp_mem_storage_engine = 'memory';
+set @old_tmp_table_size = @@tmp_table_size;
+set @@tmp_table_size = 102400;
+
+let $query =
+select count(distinct d.col1)
+from (
+  select t1.col1
+  from t1
+  union
+  select t1.col1
+  from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+
+flush status;
+eval explain $query;
+eval $query;
+show status like 'Created_tmp_disk_tables';
+
+set @@tmp_table_size = 1024;
+
+flush status;
+eval explain $query;
+eval $query;
+show status like 'Created_tmp_disk_tables';
+
+set session internal_tmp_mem_storage_engine =
+  @old_internal_tmp_mem_storage_engine;
+set @@tmp_table_size = @old_tmp_table_size;
+drop procedure insert_bug_37308710_data;
+drop table t1, t2;
+
+--echo # cleanup
 set session internal_tmp_mem_storage_engine=default;

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -2887,6 +2887,13 @@ bool create_ondisk_from_heap(THD *thd, TABLE *wtable, int error,
     thd_proc_info(thd, (!strcmp(save_proc_info, "Copying to tmp table")
                             ? "Copying to tmp table on disk"
                             : save_proc_info));
+
+  /*
+    Reading from the in-memory table clears wtable's not-started state, so reset
+    it here.
+  */
+  wtable->set_not_started();
+
   return false;
 
 err_after_open:


### PR DESCRIPTION
## Summary

Backports upstream MySQL fix for [Bug #116741](https://bugs.mysql.com/bug.php?id=116741) (Oracle commit [`cde9f3eaaf9`](https://github.com/mysql/mysql-server/commit/cde9f3eaaf9), ships in MySQL 8.4.11) to the Percona Server 8.4 series, plus the Percona-specific test adjustment required to make the upstream reproducer actually exercise the fixed path on this branch.

- Jira: https://perconadev.atlassian.net/browse/PS-11483
- Customer ticket: CUSTOM-258
- Target: `8.4` (branch base is 8.4.10-10)
- Sibling PR (PXC): percona/percona-xtradb-cluster#2348

Without the fix, a query can silently return an incorrect result set — no error, no warning — when an internal temporary table is converted from MEMORY to an on-disk InnoDB table mid-execution. Rows that exist are dropped from the result. The only "workaround" is avoiding the conversion, which does not hold in production as data volume grows.

## Commits

| Commit | Scope |
| --- | --- |
| `7ab214a` Bug#37308710 — Innodb tmp table causes incorrect query results | `sql/sql_tmp_table.cc` (+7), `main.with_recursive_innodb_tmp_table` test + result |
| `a8ea488` CUSTOM-258 | `main.with_recursive_innodb_tmp_table` test + result only |

Whole-PR diff is exactly three files:

```
mysql-test/r/with_recursive_innodb_tmp_table.result
mysql-test/t/with_recursive_innodb_tmp_table.test
sql/sql_tmp_table.cc
```

The only source change is one statement in `create_ondisk_from_heap()`:

```c
/*
  Reading from the in-memory table clears wtable's not-started state, so reset
  it here.
*/
wtable->set_not_started();
```

Reading rows from the in-memory temporary table advances table state. After conversion the table kept a *started* state, so subsequent reads from the on-disk temporary table could miss the expected row for CONST access.

## Why the second commit is needed (Percona divergence from upstream)

The upstream subtest reaches the conversion path by running the query at `tmp_table_size = 102400` (in-memory) and then at `tmp_table_size = 1024` (expected to spill to disk).

Percona-only patch **PS-8647** in `sql/sys_vars.cc` silently rewrites any `tmp_table_size` below 1 MiB up to exactly 1 MiB and pushes a warning. The rewrite is unconditional and independent of `internal_tmp_mem_storage_engine`, so it also applies when the session uses the MEMORY engine.

Consequence on this branch: the effective `tmp_table_size` is 1 MiB in *both* runs. The 99-row derived result (~40-byte reclength) fits comfortably in 1 MiB, `create_ondisk_from_heap()` is never entered, and the MEMORY→InnoDB transition the backport is meant to exercise never happens. The upstream test therefore failed with two diff hunks: unexpected `Tmp_table_size is set below 1MiB` warnings on each `SET`, and `Created_tmp_disk_tables` reporting 0 where upstream expects 1.

`a8ea488` is **test-only** — the backported source fix stays as-is. It gives the reproducer enough data to overflow the 1-MiB floor PS-8647 imposes:

- `col1` widened to `VARCHAR(300) CHARACTER SET latin1`, generator grown to 4000 rows → derived table ~1.2 MiB
- `max_heap_table_size` explicitly saved/restored and set to 16 MiB for this section (the preceding `with_recursive_wl9248` block left it at 61000, which would cap MEMORY well below `tmp_table_size` and defeat the size differential)
- `tmp_table_size` values at or above the PS-8647 threshold: 16 MiB in-memory (`Created_tmp_disk_tables = 0`) and exactly 1 MiB on-disk (`Created_tmp_disk_tables = 1`) — both ≥ 1 MiB, so the strict `<` check never fires and no unexpected warnings appear

The `count(distinct d.col1) = 1` assertion — the actual bug being verified — is untouched. A comment block documents the divergence so the next porter does not "fix" the values back to the upstream ones.

## Testing

Full MTR (`FULL_MTR=yes`, `--big-test`, `CI_FS_MTR=yes`, `WITH_PS_PROTOCOL=yes`), x86_64:

| Config | Job | Build | OS | Result | Failures |
| --- | --- | --- | --- | --- | --- |
| Debug | `percona-server-8.4-pipeline-parallel-mtr` | [#1431](https://ps80.cd.percona.com/job/percona-server-8.4-pipeline-parallel-mtr/1431/) | ubuntu:noble | UNSTABLE | 1 |
| RelWithDebInfo | `percona-server-8.4-pipeline-parallel-mtr` | [#1432](https://ps80.cd.percona.com/job/percona-server-8.4-pipeline-parallel-mtr/1432/) | ubuntu:noble | UNSTABLE | 5 |
| Debug + ASAN | `percona-server-8.4-ASAN-pipeline-parallel-mtr` | [#22](https://ps80.cd.percona.com/job/percona-server-8.4-ASAN-pipeline-parallel-mtr/22/) | ubuntu:resolute | UNSTABLE | 69 |

### The target test now passes in every configuration

| Build | Result |
| --- | --- |
| #1431 Debug | `main.with_recursive_innodb_tmp_table  w3  [ pass ]  42288` |
| #1432 RelWithDebInfo | `main.with_recursive_innodb_tmp_table  w8  [ pass ]   3369` |
| #22 ASAN | `main.with_recursive_innodb_tmp_table  w3  [ pass ]  80485` |

### Baseline diff

Baselines are the most recent runs of the same jobs, [#1430](https://ps80.cd.percona.com/job/percona-server-8.4-pipeline-parallel-mtr/1430/) (Debug) and [#21](https://ps80.cd.percona.com/job/percona-server-8.4-ASAN-pipeline-parallel-mtr/21/) (ASAN) — both on `release-8.4.11-11`, i.e. **a different patch base than this branch (8.4.10-10)**. Deltas below are interpreted with that in mind.

**Debug — #1431 vs #1430**

One failure, `main.all_persisted_variables`, deterministic (failed, then `retry-fail`). Root cause is a persisted-variable count mismatch, not a behaviour change:

```
-include/assert.inc [Expect 489 persisted variables in the table.]
+include/assert.inc [Expect 490 persisted variables in the table.]
```

The 8.4.10-10 base has one more persistable system variable than the test's hard-coded expectation. **This PR registers no system variable** — its entire diff is three files, none of them `sql/sys_vars.{cc,h}` or `all_persisted_variables.{test,result}` — so it cannot move this count. Pre-existing on the branch base; the 8.4.11-11 baseline passes because the count was reconciled there.

The baseline's own failure (the `unit_tests` ctest roll-up) does not reproduce in #1431.

**RelWithDebInfo — #1432**

`rocksdb_rpl.rpl_rocksdb_row_img_idx_{noblob,full,min}.row`, one `shutdown_report`, and the `unit_tests` roll-up (also failing in baseline #1430). None touch the temporary-table path. No same-config/same-OS baseline exists for RelWithDebInfo on this job — the nearest, #1425, ran on `debian:bullseye` with `KEYRING_VAULT_MTR=yes`.

**ASAN — #22 vs #21**

69 vs 28. All 28 baseline failures reproduce; the ~41 additional ones are dominated by an environment regression in the `ubuntu:resolute` image, not by this change. Tests that shell out to external binaries (`main.symlink`, `main.import_symlink`, `main.mysqld_safe`, `main.mysql_system_cmd_unix`, `main.log_errchk`, `main.temp_table_debug`) now fail on LeakSanitizer reports raised against Ubuntu resolute's **rust-coreutils**, not against `mysqld`. Sample, from `main.temp_table_debug`:

```
==237077==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 ... in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 ... (/usr/lib/cargo/bin/coreutils/ln+0x53f5e6)
```

`ubuntu:resolute` is a development release and the image is pulled fresh per build; #21 ran 5 days earlier. The remaining clusters (10 × `rocksdb`, 2 × `rocksdb_stress`, 9 × `group_replication` clone/recovery) are whole-worker environmental/timing failures under instrumentation.

Both #21 and #22 carry the identical pre-existing ASAN `DEADLYSIGNAL` SEGV signature (`pc 0x0`, `<unknown module>`), so that one is not new either.

## Caveats / follow-ups

1. **Baselines are on 8.4.11-11, this branch is on 8.4.10-10.** Notably #22 reports leak signatures absent from #21 (2602 B/2 allocs, 43224 B/68, 33 B/1, 86448 B/136). None are in the temporary-table path and a `set_not_started()` state reset allocates nothing, but formally classifying them needs an ASAN run on the unmodified 8.4.10-10 base. Recommend firing that before merge; happy to do it on request.
2. `main.all_persisted_variables` on 8.4.10-10 (489 vs 490) deserves its own ticket — it will fail for anyone testing this base.
3. `SLACK_CHANNEL` in `Percona-Lab/ps-build` `jenkins/pipeline-parallel-mtr.groovy` is interpolated as `"#${SLACK_CHANNEL}"` against a default that already carries `#`, producing `channel: ##ps-upstream-merges`. Slack notifications from these jobs never land. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
