### PR TITLE
PS-11210 [8.4] component_encryption_udf.dh_4096* failures

### DIFF
--- a/mysql-test/suite/component_encryption_udf/t/dh_4096.test
+++ b/mysql-test/suite/component_encryption_udf/t/dh_4096.test
@@ -1,6 +1,12 @@
 --source include/big_test.inc
 --source include/have_encryption_udf_component.inc
 
+let $have_arm64 = `SELECT convert(@@version_compile_machine USING latin1) IN ("arm64", "aarch64")`;
+if ($have_arm64)
+{
+   skip Test requires: 'not ARM64';
+}
+
 --let $key_length = 4096
 
 --source ../include/dh.inc

--- a/mysql-test/suite/component_encryption_udf/t/dh_4096_ext.test
+++ b/mysql-test/suite/component_encryption_udf/t/dh_4096_ext.test
@@ -2,7 +2,11 @@
 --source include/have_encryption_udf_component.inc
 --let $openssl_binary_version = 1\\.0\\.2|1\\.1\\.\\d+|3\\.\\d+\\.\\d+
 --source include/have_openssl_binary_version.inc
-
+let $have_arm64 = `SELECT convert(@@version_compile_machine USING latin1) IN ("arm64", "aarch64")`;
+if ($have_arm64)
+{
+   skip Test requires: 'not ARM64';
+}
 --let $key_length = 4096
 --let $use_openssl_binary = 1
 


### PR DESCRIPTION
Problem: the tests ocasionally fail on ARM64 architectures. Generating random safe prime numbers are computationally exchaustive and caused Jenkins pipeline ocassionally stop MTR.

Fix: disable tests on ARM64.