### PR TITLE
PS-11291 [9.7] Telemetry tests failing on MacOS

### DIFF
--- a/mysql-test/suite/component_percona_telemetry/r/delete_obsolete_file.result
+++ b/mysql-test/suite/component_percona_telemetry/r/delete_obsolete_file.result
@@ -1,6 +1,4 @@
 CALL mtr.add_suppression("Component percona_telemetry reported: 'Skipping file deletion this_file_should_not_be_removed'");
 # restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.history_keep_interval=80 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>
 File with the name not conforming to the pattern still should be there
-1
-Obsolete file should be removed
-0
+Obsolete file should be removed (the below command returns nothing)

--- a/mysql-test/suite/component_percona_telemetry/r/invalid_path.result
+++ b/mysql-test/suite/component_percona_telemetry/r/invalid_path.result
@@ -1,6 +1,6 @@
 # restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.history_keep_interval=80 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>
 Server should still be alive
-CALL mtr.add_suppression("Component percona_telemetry reported: 'Problem during telemetry file write: filesystem error: directory iterator cannot open directory: No such file or directory");
+CALL mtr.add_suppression("Component percona_telemetry reported: 'Problem during telemetry file write: filesystem error:");
 include/assert_grep.inc [Percona Telemetry Component warns about nonexistent directory]
 Telemetry root dir should contain 1 file
-1
+XXX.json

--- a/mysql-test/suite/component_percona_telemetry/r/no_user.result
+++ b/mysql-test/suite/component_percona_telemetry/r/no_user.result
@@ -7,7 +7,7 @@ Warnings:
 Warning	4005	User 'root'@'localhost' is referenced as a definer account in a stored routine.
 Warning	4005	User 'root'@'localhost' is referenced as a definer account in a trigger.
 'root' user used by component's 1st verison does not exist. Telemetry dir should contain 1 file.
-1
+XXX.json
 RENAME USER 'root.tmp'@'localhost' to 'root'@'localhost';
 Warnings:
 Warning	4005	User 'root'@'localhost' is referenced as a definer account in a stored routine.
@@ -16,7 +16,7 @@ Warning	4005	User 'root'@'localhost' is referenced as a definer account in a tri
 RENAME USER 'percona.telemetry'@'localhost' to 'percona.telemetry.tmp'@'localhost';
 include/assert.inc [No orphaned sessions expected in processlist]
 'percona.telemetry' user used by component does not exist. Telemetry dir should still contain 1 file.
-1
+XXX.json
 RENAME USER 'percona.telemetry.tmp'@'localhost' to 'percona.telemetry'@'localhost';
 # restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>
 DROP USER 'percona.telemetry'@'localhost';

--- a/mysql-test/suite/component_percona_telemetry/r/telemetry_file_creation.result
+++ b/mysql-test/suite/component_percona_telemetry/r/telemetry_file_creation.result
@@ -1,11 +1,15 @@
 # restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.history_keep_interval=80 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>
 Time passed: 10.0000. Still in grace_interval. Telemetry root dir should contain 0 files
-0
 Time passed: 40.0000. Time after grace_interval: 10.0000. Telemetry root dir should contain 1 file
-1
+XXX.json
 Time passed: 70.0000. Time after grace_interval: 40.0000. Telemetry root dir should contain 2 files
-2
+XXX.json
+XXX.json
 Time passed: 100.0000. Time after grace_interval: 70.0000. Telemetry root dir should contain 3 files
-3
+XXX.json
+XXX.json
+XXX.json
 Time passed: 130.0000. Time after grace_interval: 100.0000. Telemetry root dir should still contain 3 files
-3
+XXX.json
+XXX.json
+XXX.json

--- a/mysql-test/suite/component_percona_telemetry/t/delete_obsolete_file.test
+++ b/mysql-test/suite/component_percona_telemetry/t/delete_obsolete_file.test
@@ -31,10 +31,9 @@ CALL mtr.add_suppression("Component percona_telemetry reported: 'Skipping file d
 
 --echo File with the name not conforming to the pattern still should be there
 --file_exists $untouchable_file
---exec ls -1 $telemetry_root_dir | grep $untouchable_file_name | wc -l
 
---echo Obsolete file should be removed
---exec ls -1 $telemetry_root_dir | grep $obsolete_file_name | wc -l
+--echo Obsolete file should be removed (the below command returns nothing)
+--list_files $telemetry_root_dir $obsolete_file_name
 
 # cleanup
 --force-rmdir $telemetry_root_dir

--- a/mysql-test/suite/component_percona_telemetry/t/invalid_path.test
+++ b/mysql-test/suite/component_percona_telemetry/t/invalid_path.test
@@ -21,7 +21,7 @@
 --sleep $timeout
 --echo Server should still be alive
 
---let $warning_message = Component percona_telemetry reported: 'Problem during telemetry file write: filesystem error: directory iterator cannot open directory: No such file or directory
+--let $warning_message = Component percona_telemetry reported: 'Problem during telemetry file write: filesystem error:
 --eval CALL mtr.add_suppression("$warning_message")
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_select = $warning_message
@@ -36,7 +36,8 @@
 --let $timeout = $scrape_interval
 --sleep $timeout
 --echo Telemetry root dir should contain 1 file
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 # cleanup
 --force-rmdir $telemetry_root_dir

--- a/mysql-test/suite/component_percona_telemetry/t/no_user.test
+++ b/mysql-test/suite/component_percona_telemetry/t/no_user.test
@@ -31,7 +31,8 @@ RENAME USER 'root'@'localhost' to 'root.tmp'@'localhost';
 --sleep $timeout
 
 --echo 'root' user used by component's 1st verison does not exist. Telemetry dir should contain 1 file.
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 #
 # It should be possible to restart the server.
@@ -57,7 +58,8 @@ RENAME USER 'percona.telemetry'@'localhost' to 'percona.telemetry.tmp'@'localhos
 
 # Check that no new telemetry file was created
 --echo 'percona.telemetry' user used by component does not exist. Telemetry dir should still contain 1 file.
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 
 #

--- a/mysql-test/suite/component_percona_telemetry/t/telemetry_file_creation.test
+++ b/mysql-test/suite/component_percona_telemetry/t/telemetry_file_creation.test
@@ -25,7 +25,7 @@
 
 ### now we are withing grace_interval
 --echo Time passed: $time_passed. Still in grace_interval. Telemetry root dir should contain 0 files
---exec ls -1 $telemetry_root_dir | wc -l
+--list_files $telemetry_root_dir
 
 
 
@@ -37,7 +37,8 @@
 
 ### now we are in 1st scrape interval
 --echo Time passed: $time_passed. Time after grace_interval: $time_after_grace_interval. Telemetry root dir should contain 1 file
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 
 
@@ -49,7 +50,8 @@
 
 ### now we are in 2nd scrape interval
 --echo Time passed: $time_passed. Time after grace_interval: $time_after_grace_interval. Telemetry root dir should contain 2 files
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 
 # Wait a bit more. New telemetry file should be created
@@ -60,7 +62,8 @@
 
 ### now we are in 3rd scrape interval
 --echo Time passed: $time_passed. Time after grace_interval: $time_after_grace_interval. Telemetry root dir should contain 3 files
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 
 # Due to history_keep_interval, new files should be created, but old ones should be deleted.
@@ -70,7 +73,8 @@
 --let $time_after_grace_interval = `select $time_passed - $grace_interval`
 
 --echo Time passed: $time_passed. Time after grace_interval: $time_after_grace_interval. Telemetry root dir should still contain 3 files
---exec ls -1 $telemetry_root_dir | wc -l
+--replace_regex /.+\.json/XXX.json/
+--list_files $telemetry_root_dir
 
 # cleanup
 --force-rmdir $telemetry_root_dir


### PR DESCRIPTION
Fix:
- using MTR commands (OS independant) instead of OS commands in tests
- extracting OS specific part from expected error messages