### PR TITLE
PS-11435: Skip OIDC MTR tests when plugin is not built

### DIFF
--- a/mysql-test/suite/auth_openid_connect/inc/set_idp_vars.inc
+++ b/mysql-test/suite/auth_openid_connect/inc/set_idp_vars.inc
@@ -1,3 +1,11 @@
+# Skip when the server build does not provide the auth_openid_connect
+# plugin (built with -DWITH_AUTH_OPENID_CONNECT=OFF). $AUTH_OIDC is empty
+# in that case and INSTALL PLUGIN would run with an empty SONAME.
+if (!$AUTH_OIDC)
+{
+  --skip Auth OpenID Connect plugin not available in this build
+}
+
 if ($MTR_OIDC_IDP_HOST)
 {
   --let $IDP_HOST = $MTR_OIDC_IDP_HOST


### PR DESCRIPTION
**Bug**
- On servers built with `-DWITH_AUTH_OPENID_CONNECT=OFF`, `idp.test` and `proxy.test` fail instead of skipping: they gate only on IdP reachability, and with `$AUTH_OIDC` empty they run `INSTALL PLUGIN auth_openid_connect SONAME ''` (ERROR 1126). Once [PR 6076](https://github.com/percona/percona-server/pull/6076) puts the suite in the default set, this breaks every default MTR run on such builds.

**Fix**
- Guard the shared `set_idp_vars.inc` include: both tests skip when the plugin is not built.

**Tickets**
- [PS-11435](https://perconadev.atlassian.net/browse/PS-11435) (this), companion to [PR 6076](https://github.com/percona/percona-server/pull/6076) (adds the suite to default runs on 8.4, approved and unmerged)
- Siblings: [PR 6141](https://github.com/percona/percona-server/pull/6141) (9.7), [PR 6142](https://github.com/percona/percona-server/pull/6142) (trunk) carry the same guard


[PS-11435]: https://perconadev.atlassian.net/browse/PS-11435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ