### PR TITLE
PS-11530 [8.4] Members of one Group Replication group assign different GNOs to the same transaction

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
@@ -1753,6 +1753,15 @@ static void push_msg_3p(site_def const *site, pax_machine *p, pax_msg *msg,
         STRLIT(pax_op_to_str(msg->op)));
 }
 
+/* A reserved synode is only ours while we still hold the node index it was
+   reserved under. A view change that renumbers us hands that slot to another
+   node, which may reserve it as well. */
+bool_t reservation_is_stale(synode_no msgno) {
+  site_def const *site = find_site_def(msgno);
+  node_no me = site ? get_nodeno(site) : VOID_NODE_NO;
+  return me != VOID_NODE_NO && me != msgno.node;
+}
+
 /* Brand client message with unique ID */
 static void brand_client_msg(pax_msg *msg, synode_no msgno) {
   assert(!synode_eq(msgno, null_synode));
@@ -2512,6 +2521,13 @@ static int proposer_task(task_arg arg) {
 
     brand_client_msg(ep->client_msg->p, ep->msgno);
 
+    /* Only a locally allocated synode carries our own node index; a remote or
+       global allocation carries the allocating leader's, by design. */
+    if (ep->synode_allocation == synode_allocation_type::local &&
+        reservation_is_stale(ep->msgno)) {
+      GOTO(retry_new);
+    }
+
     for (;;) { /* Loop until the client message has been learned */
       /* Get a Paxos instance to send the client message */
 
@@ -2520,6 +2536,13 @@ static int proposer_task(task_arg arg) {
         G_MESSAGE("Could not get a pax_machine for msgno %lu. Retrying",
                   (unsigned long)ep->msgno.msgno);
         goto retry_new;
+      }
+
+      /* Checked again after wait_for_cache: that call can suspend, and a view
+         change during the wait leaves the reservation stale. */
+      if (ep->synode_allocation == synode_allocation_type::local &&
+          reservation_is_stale(ep->msgno)) {
+        GOTO(retry_new);
       }
 
       assert(ep->p);

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.h
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.h
@@ -70,6 +70,8 @@ void *xcom_thread_main(void *cp);
 
 synode_no incr_synode(synode_no synode);
 
+bool_t reservation_is_stale(synode_no msgno);
+
 synode_no decr_synode(synode_no synode);
 
 char *dbg_pax_msg(pax_msg const *p);

--- a/unittest/gunit/libmysqlgcs/CMakeLists.txt
+++ b/unittest/gunit/libmysqlgcs/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(GCS_XCOM_TESTS
   xcom/gcs_xcom_xcom_transport
   xcom/gcs_xcom_communication_protocol_changer
   xcom/gcs_xcom_xcom_cache
+  xcom/gcs_xcom_stale_reservation
   xcom/gcs_xcom_control_interface
   xcom/gcs_xcom_view_identifier
   xcom/gcs_message_stage_fragmentation

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_stale_reservation-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_stale_reservation-t.cc
@@ -1,0 +1,96 @@
+/* Copyright (c) 2026, Oracle and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is designed to work with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have either included with
+   the program or referenced in the documentation.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#include <xcom/xcom_profile.h>
+#include <xcom_vp.h>
+#include "gcs_base_test.h"
+
+#include "site_def.h"
+#include "xcom_base.h"
+
+namespace xcom_stale_reservation_unittest {
+
+/* Bug#121063: a synode reserved under one node index must be recognised as no
+   longer ours once a view change gives this member a different index. */
+class XcomStaleReservation : public GcsBaseTest {
+ protected:
+  void SetUp() override {
+    /* The view in force when the synode is reserved: this member is node 1. */
+    char const *names[]{"127.0.0.1:12341", "127.0.0.1:12342",
+                        "127.0.0.1:12343"};
+    node_address *na = new_node_address(3, names);
+
+    site_def *before = new_site_def();
+    init_site_def(3, na, before);
+    before->start = synode_no{1, 10, 0};
+    before->nodeno = 1;
+    push_site_def(before);
+    delete_node_address(3, na);
+  }
+
+  /* The view installed while the reservation is held: the first member is
+     gone, so this one is now node 0. */
+  void install_new_view() {
+    char const *names[]{"127.0.0.1:12342", "127.0.0.1:12343"};
+    node_address *na = new_node_address(2, names);
+
+    site_def *after = new_site_def();
+    init_site_def(2, na, after);
+    after->start = synode_no{1, 20, 0};
+    after->nodeno = 0;
+    push_site_def(after);
+    delete_node_address(2, na);
+  }
+
+  void TearDown() override { free_site_defs(); }
+};
+
+/* Under the view it was taken in, the reservation is ours. */
+TEST_F(XcomStaleReservation, reservation_under_the_current_index_is_fresh) {
+  install_new_view();
+  synode_no const reserved{1, 15, 1};
+  ASSERT_FALSE(reservation_is_stale(reserved));
+}
+
+/* After the renumbering, the same index belongs to another node. */
+TEST_F(XcomStaleReservation, reservation_outliving_a_renumbering_is_stale) {
+  synode_no const reserved{1, 25, 1};
+  ASSERT_FALSE(reservation_is_stale(reserved));
+  install_new_view();
+  ASSERT_TRUE(reservation_is_stale(reserved));
+}
+
+/* A slot that carries the index this member holds now is usable. */
+TEST_F(XcomStaleReservation, slot_matching_the_new_index_is_fresh) {
+  install_new_view();
+  synode_no const reserved{1, 25, 0};
+  ASSERT_FALSE(reservation_is_stale(reserved));
+}
+
+/* Without a site there is nothing to compare against. */
+TEST_F(XcomStaleReservation, unknown_site_is_not_reported_stale) {
+  synode_no const other_group{99, 25, 0};
+  ASSERT_FALSE(reservation_is_stale(other_group));
+}
+
+}  // namespace xcom_stale_reservation_unittest


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11530

Upstream bug:
Bug#121063: https://bugs.mysql.com/bug.php?id=121063

Problem:
Two members of the same group assign different GNOs to the same transaction, in multi-primary mode, when a member leaves and rejoins during a rolling restart under write load. The group splits into internally consistent sets that disagree on the GTID of the same transaction. It can surface on the `group_replication_applier` channel as Error_code 1032 or 1062, or stay silent with every member ONLINE and the disagreement present only in the binary logs.

Cause:
A reserved synode is only ours while we still hold the node index it was reserved under.

`local_synode_allocator` stamps the member's current index into the synode, `synode.node = my_nodeno`. Still inside `reserve_synode_number`, the task yields in the `while (too_far(*msgno))` loop at `TIMED_TASK_WAIT`. During that yield, `site_install_action` reassigns `site->nodeno`. The reservation still carries the old index, so `proposer_task` brands and proposes into a slot that now belongs to another node.

The header comment of `xcom_base.cc` states the rule: only node N may propose a value for synode {X N}. With two proposers on the same slot at `cnt=0`, `acceptor.promise` is never raised, since it is assigned in exactly one place, inside `handle_simple_prepare`, which is the phase 1 decision. Both proposals are accepted, both are learned, and `handle_learn` keeps whichever LEARN arrived first because of the `/* Avoid re-learn */` guard. Members that heard different values first deliver different payloads.

Solution:
Before proposing, verify the reservation still carries the member's own node index. If it does not, drop it through `retry_new` and take a new one.

This is the same check `incr_msgno` already makes whenever it advances, with the comment `In case site and node number has changed`. The client transaction is not lost, it goes out in a slot that does belong to the member.

Ported from upstream MySQL PR
https://github.com/mysql/mysql-server/pull/736
by Matias Sanchez.