### PR TITLE
DISTMYSQL-645 [8.4] Check commit subjects for key and branch tag

### DIFF
--- a/.github/scripts/check-pr-commit-subjects.sh
+++ b/.github/scripts/check-pr-commit-subjects.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# Check that a pull request to a percona-server version branch follows the
+# commit-subject convention: the title and every commit subject name a ticket
+# key and carry the base branch tag, for example "PS-11435 [8.4] Add ...".
+# The tag is what survives the upward null-merges (8.0 -> 8.4 -> 9.7 -> trunk)
+# and what release tooling greps for, so a squash merged under a rewritten
+# subject loses the change for both.
+#
+# Inputs (environment):
+#   REPO       owner/name, default percona/percona-server
+#   PR_NUMBER  pull request number
+#   GH_TOKEN   GitHub API token, read access is enough
+#
+# The base branch, the title and the commit count are read from the API rather
+# than from the triggering event, so re-running an old run judges the pull
+# request as it is now instead of as it was.
+#
+# Exit 0 when the pull request conforms or is out of scope (non-version base
+# branch, or a pull request that carries a merge commit). Exit 1 with one
+# ::error:: line per violation otherwise.
+
+# has_key is a predicate, so it runs inside an if condition on purpose.
+# shellcheck disable=SC2310
+set -euo pipefail
+
+# A ticket key with word boundaries. LC_ALL=C at the call site keeps [:alnum:]
+# meaning ASCII, so the runner's locale cannot change the verdict.
+readonly KEY_RE='(^|[^[:alnum:]_])(PS|PXB|PXC|DISTMYSQL)-[0-9]+([^[:alnum:]_]|$)'
+readonly REPO="${REPO:-percona/percona-server}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+# The tag a PR to this base branch must carry, empty when the base is out of scope.
+tag_for_base() {
+  case "$1" in
+    8.0) echo '[8.0]' ;;
+    8.4) echo '[8.4]' ;;
+    9.7) echo '[9.7]' ;;
+    trunk) echo '[trunk]' ;;
+    *) ;;
+  esac
+}
+
+# Every version tag a subject might carry. [10.x] is listed so a trunk change
+# still tagged that way is told what replaced it.
+readonly -a VERSION_TAGS=('[8.0]' '[8.4]' '[9.7]' '[trunk]' '[10.x]')
+
+# Prints the version tag a subject carries when it is not the expected one, so
+# a forward port still tagged [8.4] or a trunk change still tagged [10.x] is
+# told what to replace rather than what it lacks. Prints nothing otherwise.
+other_tag() {
+  local subject="$1" expected="$2" candidate
+  for candidate in "${VERSION_TAGS[@]}"; do
+    if [[ "${candidate}" != "${expected}" && "${subject}" == *"${candidate}"* ]]; then
+      printf '%s' "${candidate}"
+      return
+    fi
+  done
+}
+
+# A workflow command ends at a carriage return or a newline and is percent
+# decoded, so a commit subject would otherwise be able to open one of its own.
+escape_annotation() {
+  local text="$1"
+  text="${text//'%'/%25}"
+  text="${text//$'\r'/%0D}"
+  text="${text//$'\n'/%0A}"
+  printf '%s' "${text}"
+}
+
+note() { printf '::notice::%s\n' "$(escape_annotation "$*")"; }
+warn() { printf '::warning::%s\n' "$(escape_annotation "$*")"; }
+fail() { printf '::error::%s\n' "$(escape_annotation "$*")"; }
+
+has_key() { LC_ALL=C grep -Eq "${KEY_RE}" <<<"$1"; }
+
+# Reports a title or subject that does not carry the expected tag.
+fail_tag() {
+  local what="$1" subject="$2" base_ref="$3" tag="$4" found
+  found="$(other_tag "${subject}" "${tag}")"
+  if [[ -n "${found}" ]]; then
+    fail "${what} carries ${found} but a pull request to ${base_ref} needs ${tag}: ${subject}"
+  else
+    fail "${what} lacks the ${tag} branch tag: ${subject}"
+  fi
+}
+
+main() {
+  # One call for the three pieces of metadata, unit-separator joined because a
+  # title may hold anything else.
+  local meta
+  meta="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+    --jq '[.base.ref, (.commits | tostring), .title] | join("\u001f")')"
+  if [[ -z "${meta}" ]]; then
+    fail "could not read pull request ${PR_NUMBER} from ${REPO}"
+    return 1
+  fi
+  local base_ref total title
+  IFS=$'\x1f' read -r base_ref total title <<<"${meta}"
+  if [[ -z "${base_ref}" || ! "${total}" =~ ^[0-9]+$ ]]; then
+    fail "could not read the base branch and commit count of PR ${PR_NUMBER}, got: ${meta//$'\x1f'/ | }"
+    return 1
+  fi
+
+  local tag
+  tag="$(tag_for_base "${base_ref}")"
+  if [[ -z "${tag}" ]]; then
+    note "base branch ${base_ref} is not a version branch, nothing to check"
+    return 0
+  fi
+  local expected="<KEY>-<n> ${tag} <what changed>"
+
+  # One line per commit, unit-separator delimited so tabs in a subject survive:
+  # sha<US>parent count<US>subject.
+  local commits
+  commits="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+    --jq '.[] | "\(.sha[0:12])\u001f\(.parents | length)\u001f\(.commit.message | split("\n")[0])"')"
+  if [[ -z "${commits}" ]]; then
+    fail "no commits found on PR ${PR_NUMBER}"
+    return 1
+  fi
+
+  # A merge commit is what marks an upstream merge or a null merge, whose
+  # subjects come from another branch and are not this convention's to enforce.
+  # The commit graph decides that, never the title: fewer than half of the
+  # merged null-merge pull requests in this repository open with "Merge" or
+  # "Null-merge", so a title pattern would reject the real ones, while a merge
+  # commit is the one mark every one of them carries. The cost is that merging
+  # the base branch into a working branch also exempts a pull request, so the
+  # exemption is a warning rather than a silent pass.
+  if awk -F$'\x1f' '$2 > 1 { found = 1 } END { exit !found }' <<<"${commits}"; then
+    warn "PR contains a merge commit (upstream or null merge), subjects not checked"
+    return 0
+  fi
+
+  # The listing endpoint stops at 250 commits, so compare against the PR's own
+  # count. Checked after the merge exemption because a null merge legitimately
+  # runs to hundreds of commits.
+  local fetched
+  fetched="$(wc -l <<<"${commits}")"
+  if (( fetched < 10#${total} )); then
+    fail "PR has ${total} commits but only ${fetched} could be listed, split it or check the subjects by hand"
+    return 1
+  fi
+
+  local violations=0
+  # A squash merge of several commits takes the PR title as its subject, and the
+  # title is the convention's own record either way, so it is checked too.
+  if ! has_key "${title}"; then
+    fail "PR title lacks a ticket key (PS-<n>, PXB-<n>, PXC-<n> or DISTMYSQL-<n>): ${title}"
+    violations=$((violations + 1))
+  fi
+  if [[ "${title}" != *"${tag}"* ]]; then
+    fail_tag "PR title" "${title}" "${base_ref}" "${tag}"
+    violations=$((violations + 1))
+  fi
+
+  local sha subject
+  while IFS=$'\x1f' read -r sha _ subject; do
+    # A revert keeps the reverted subject verbatim, and reverting a subject that
+    # broke this convention is exactly how the convention gets repaired, so a
+    # revert cannot be required to conform. Announced, so it is visible in review.
+    if [[ "${subject}" == 'Revert "'* ]]; then
+      note "${sha}: revert, subject checks skipped: ${subject}"
+      continue
+    fi
+    if ! has_key "${subject}"; then
+      fail "${sha}: subject lacks a ticket key: ${subject}"
+      violations=$((violations + 1))
+      continue
+    fi
+    if [[ "${subject}" != *"${tag}"* ]]; then
+      fail_tag "${sha}: subject" "${subject}" "${base_ref}" "${tag}"
+      violations=$((violations + 1))
+    fi
+  done <<<"${commits}"
+
+  if (( violations > 0 )); then
+    echo
+    echo "Expected subject form: ${expected}"
+    echo "Reword the commits (git rebase -i, reword) and force-push the PR branch."
+    return 1
+  fi
+  note "PR title and every commit subject carry a ticket key and the ${tag} tag"
+}
+
+main "$@"

--- a/.github/scripts/tests/check-pr-commit-subjects.test.sh
+++ b/.github/scripts/tests/check-pr-commit-subjects.test.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# Behaviour tests for check-pr-commit-subjects.sh against a stubbed gh.
+#
+# The checker makes two API calls. The stub answers both:
+#   repos/O/R/pulls/N          -> CASE_BASE US CASE_TOTAL US CASE_TITLE
+#   repos/O/R/pulls/N/commits  -> CASE_COMMITS verbatim
+# CASE_RC makes gh fail, CASE_META overrides the metadata line wholesale.
+set -uo pipefail
+
+readonly SCRIPT="$1"
+BIN="$(mktemp -d)"
+readonly BIN
+readonly US=$'\x1f'
+
+cat >"${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${FIXTURE_RC:-0}" -ne 0 ]]; then
+  echo "gh: API error" >&2
+  exit "${FIXTURE_RC}"
+fi
+for arg in "$@"; do
+  case "${arg}" in
+    */commits) printf '%s' "${FIXTURE_COMMITS}"; exit 0 ;;
+  esac
+done
+printf '%s\n' "${FIXTURE_META}"
+STUB
+chmod +x "${BIN}/gh"
+export PATH="${BIN}:${PATH}"
+
+pass=0
+fail=0
+
+# run_case <name> <want_exit> <want_grep> ; reads CASE_* from the environment.
+run_case() {
+  local name="$1" want_exit="$2" want_grep="$3"
+  local meta out rc
+  meta="${CASE_META-${CASE_BASE}${US}${CASE_TOTAL}${US}${CASE_TITLE}}"
+  out="$(PR_NUMBER=1 REPO=percona/percona-server \
+    FIXTURE_META="${meta}" FIXTURE_COMMITS="${CASE_COMMITS}" \
+    FIXTURE_RC="${CASE_RC:-0}" LC_ALL="${CASE_LOCALE:-C.utf8}" \
+    bash "${SCRIPT}" 2>&1)"
+  rc=$?
+  if [[ "${rc}" -ne "${want_exit}" ]]; then
+    echo "FAIL ${name}: exit ${rc}, want ${want_exit}"
+    indent "${out}"
+    fail=$((fail + 1))
+    return
+  fi
+  if [[ -n "${want_grep}" ]] && ! grep -q "${want_grep}" <<<"${out}"; then
+    echo "FAIL ${name}: output lacks '${want_grep}'"
+    indent "${out}"
+    fail=$((fail + 1))
+    return
+  fi
+  printf 'ok   %s\n' "${name}"
+  pass=$((pass + 1))
+}
+
+commit() { printf '%s%s%s%s%s\n' "$1" "${US}" "$2" "${US}" "$3"; }
+indent() { printf '       %s\n' "${1//$'\n'/$'\n'       }"; }
+section() { echo; echo "-- $1"; }
+
+CASE_RC=0
+
+# ---------------------------------------------------------------- review fixes
+section 'the three maintainer findings'
+
+CASE_BASE=8.4 CASE_TITLE='Merge partition pruning optimization' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'partition pruning optimization')"
+run_case 'Merge title does not bypass the commit check' 1 'subject lacks a ticket key'
+run_case 'Merge title is itself flagged' 1 'PR title lacks a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='Null-merge 8.0 into 8.4' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'cherry-picked fix, no key')"
+run_case 'Null-merge title does not bypass' 1 'subject lacks a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-123 Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-123 [8.4] Add feature')"
+run_case 'single-commit title needs the tag' 1 'PR title lacks the \[8.4\] branch tag'
+
+CASE_BASE=trunk CASE_TITLE='PS-123 [10.x] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-123 [10.x] Add feature')"
+run_case '[10.x] rejected on trunk' 1 'carries \[10.x\] but a pull request to trunk needs \[trunk\]'
+
+CASE_BASE=trunk CASE_TITLE='PS-123 [trunk] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-123 [trunk] Add feature')"
+run_case '[trunk] accepted on trunk' 0 'carry a ticket key'
+
+# ------------------------------------------------------- second-review findings
+section 'findings from the multi-model review'
+
+# Metadata comes from the API, so a re-run of an old event judges the PR as it is.
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Title fixed after the run' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'metadata is read from the API, not the event' 0 'carry a ticket key'
+
+CASE_META='' CASE_BASE=8.4 CASE_TITLE=x CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'unreadable PR metadata fails' 1 'could not read pull request'
+unset CASE_META
+
+CASE_META="${US}${US}" CASE_BASE=8.4 CASE_TITLE=x CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'blank base branch fails instead of skipping' 1 'could not read the base branch'
+unset CASE_META
+
+# A zero-padded count used to be read as octal, so the truncation guard silently
+# did not fire.
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Big' CASE_TOTAL=08
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'a zero-padded count still trips the truncation guard' 1 'only 1 could be listed'
+
+# The revert exemption survives, because PR 6149 reverted a subject that carried
+# neither key nor tag. That is how the convention gets repaired.
+CASE_BASE=8.4 CASE_TITLE='PS-11435 [8.4] Re-apply OIDC MTR suite change' CASE_TOTAL=2
+CASE_COMMITS="$(commit abc123abc123 1 'Revert "fix(mtr): load OpenID Connect defaults for tests (#6076)"'
+                commit def456def456 1 'PS-11435 [8.4] Add auth_openid_connect suite to default MTR runs')"
+run_case 'the real PR 6149 shape passes' 0 'revert, subject checks skipped'
+
+# Reapply is no longer exempt: a conforming one passes on its own merits.
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Reapply' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'Reapply "PS-1 [8.4] one"')"
+run_case 'a conforming reapply passes unaided' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Reapply' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'Reapply "sloppy subject"')"
+run_case 'a non-conforming reapply is no longer exempt' 1 'subject lacks a ticket key'
+
+# The merge exemption is announced, not silent.
+CASE_BASE=8.4 CASE_TITLE='garbage' CASE_TOTAL=2
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] a'; commit def456def456 2 'Merge branch 8.0 into 8.4')"
+run_case 'the merge exemption warns rather than passing silently' 0 '::warning::'
+
+# A carriage return in a subject must not open a second workflow command.
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] CR' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 $'no key\r::stop-commands::PWN')"
+run_case 'a CR in a subject is escaped' 1 '%0D'
+CASE_COMMITS="$(commit abc123abc123 1 $'no key\r::stop-commands::PWN')"
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] CR' CASE_TOTAL=1
+out="$(PR_NUMBER=1 REPO=percona/percona-server \
+  FIXTURE_META="8.4${US}1${US}PS-1 [8.4] CR" FIXTURE_COMMITS="${CASE_COMMITS}" \
+  bash "${SCRIPT}" 2>&1)" || true
+if grep -q $'\r' <<<"${out}"; then
+  echo "FAIL no raw CR reaches the log"
+  fail=$((fail + 1))
+else
+  echo "ok   no raw CR reaches the log"
+  pass=$((pass + 1))
+fi
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] percent 100%' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'no key 50% off')"
+run_case 'a percent sign is escaped' 1 '50%25 off'
+
+# The key regex must not change verdict with the runner locale.
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Fix it' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'éPS-1 [8.4] Fix it')"
+for loc in C C.utf8 en_US.UTF-8; do
+  CASE_LOCALE="${loc}" run_case "verdict is the same under LC_ALL=${loc}" 0 'carry a ticket key'
+done
+unset CASE_LOCALE
+
+# Same input, two locales, byte-identical output.
+run_locale() {
+  PR_NUMBER=1 REPO=percona/percona-server LC_ALL="$1" \
+    FIXTURE_META="8.4${US}1${US}PS-1 [8.4] Fix it" \
+    FIXTURE_COMMITS="$(commit abc123abc123 1 'éPS-1 [8.4] Fix it')" \
+    bash "${SCRIPT}" 2>&1
+}
+if [[ "$(run_locale C)" == "$(run_locale C.utf8)" ]]; then
+  echo "ok   output is byte-identical across locales"
+  pass=$((pass + 1))
+else
+  echo "FAIL output differs across locales"
+  fail=$((fail + 1))
+fi
+
+# ------------------------------------------------------------ real-repo sweep
+section 'wrong tag versus missing tag, from the sweep of merged pull requests'
+
+# A forward port that kept the lower branch tag on its commit.
+CASE_BASE=9.7 CASE_TITLE='PS-11291 [9.7] Telemetry tests failing on MacOS' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-11291 [8.4] Telemetry tests failing on MacOS')"
+run_case 'a forward-ported [8.4] commit on 9.7 is told to use [9.7]' 1 'subject carries \[8.4\] but a pull request to 9.7 needs \[9.7\]'
+
+# The title is reported the same way.
+CASE_BASE=trunk CASE_TITLE='PS-11202 [10.x]: Handle corrupted page-tracking groups' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-11202 [trunk]: Handle corrupted page-tracking groups')"
+run_case 'a [10.x] title on trunk is told to use [trunk]' 1 'PR title carries \[10.x\] but a pull request to trunk needs \[trunk\]'
+
+# Several wrong tags in one pull request each get their own line.
+CASE_BASE=trunk CASE_TITLE='PS-10999 [trunk] OIDC authentication' CASE_TOTAL=3
+CASE_COMMITS="$(commit abc123abc123 1 'PS-11248 [8.4]: External roles never revoked'
+                commit def456def456 1 'PS-10999 [9.7]: OIDC Authentication'
+                commit 789789789789 1 'PS-11413 [8.4] Improve the json error handling')"
+out="$(PR_NUMBER=1 REPO=percona/percona-server \
+  FIXTURE_META="trunk${US}3${US}${CASE_TITLE}" FIXTURE_COMMITS="${CASE_COMMITS}" \
+  bash "${SCRIPT}" 2>&1)" || true
+if [[ "$(grep -c 'carries \[8.4\]' <<<"${out}")" -eq 2 && "$(grep -c 'carries \[9.7\]' <<<"${out}")" -eq 1 ]]; then
+  echo "ok   each wrong-tagged commit names its own tag"
+  pass=$((pass + 1))
+else
+  echo "FAIL each wrong-tagged commit names its own tag"
+  indent "${out}"
+  fail=$((fail + 1))
+fi
+
+# No tag at all keeps the plain wording.
+CASE_BASE=8.4 CASE_TITLE='PS-11238 [8.4] debian package postinst inconsistency' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-11238 debian package postinst inconsistency')"
+run_case 'a subject with no tag is told it lacks one' 1 'subject lacks the \[8.4\] branch tag'
+
+# A bracket that is not a version tag is not reported as one.
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] upstream fix' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 '[upstream] PS-1 fix')"
+run_case '[upstream] is not mistaken for a wrong version tag' 1 'subject lacks the \[8.4\] branch tag'
+
+# A parenthesised branch in the title is not the tag.
+CASE_BASE=9.7 CASE_TITLE='(9.7)PS-11216: Timestamps needed in the GCS_DEBUG_TRACE file' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-11216: Timestamps needed in the GCS_DEBUG_TRACE file')"
+run_case '(9.7) in parentheses is not the tag' 1 'PR title lacks the \[9.7\] branch tag'
+
+# A branch-name-derived title has no key.
+CASE_BASE=9.7 CASE_TITLE='Ps 10999 9.7 OIDC authentication' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-10999 [9.7]: OIDC Authentication')"
+run_case 'a branch-name title like "Ps 10999" has no key' 1 'PR title lacks a ticket key'
+
+# ---------------------------------------------------------------- happy paths
+section 'conforming pull requests'
+
+CASE_BASE=8.4 CASE_TITLE='DISTMYSQL-645 [8.4] Check commit subjects' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'DISTMYSQL-645 [8.4] Check commit subjects')"
+run_case 'single conforming commit passes' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Two commits' CASE_TOTAL=2
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one'; commit def456def456 1 'PS-1 [8.4] two')"
+run_case 'multiple conforming commits pass' 0 'carry a ticket key'
+
+for key in PS PXB PXC DISTMYSQL; do
+  CASE_BASE=8.0 CASE_TITLE="${key}-42 [8.0] Fix it" CASE_TOTAL=1
+  CASE_COMMITS="$(commit abc123abc123 1 "${key}-42 [8.0] Fix it")"
+  run_case "${key} key accepted" 0 'carry a ticket key'
+done
+
+CASE_BASE=9.7 CASE_TITLE='PS-1 [9.7] Fix it' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [9.7] Fix it')"
+run_case '9.7 base accepted' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 Fix the thing [8.4]' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 Fix the thing [8.4]')"
+run_case 'tag anywhere in the subject is accepted' 0 'carry a ticket key'
+
+# ------------------------------------------------------------------ out of scope
+section 'out of scope'
+
+CASE_BASE=release-8.4.0 CASE_TITLE='anything at all' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'no key no tag')"
+run_case 'non-version base skips' 0 'not a version branch'
+
+CASE_BASE=8.4 CASE_TITLE='Merge remote-tracking branch' CASE_TOTAL=2
+CASE_COMMITS="$(commit abc123abc123 1 'upstream commit with no key'; commit def456def456 2 'Merge branch 8.0 into 8.4')"
+run_case 'a merge commit skips the PR' 0 'contains a merge commit'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] not a merge by title' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 2 'Merge branch 8.0 into 8.4')"
+run_case 'merge commit skips regardless of title' 0 'contains a merge commit'
+
+CASE_BASE=8.4 CASE_TITLE='Merge three branches' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 3 'Merge branches a, b and c')"
+run_case 'octopus merge skips' 0 'contains a merge commit'
+
+# A real null merge runs to hundreds of commits, so the exemption comes first.
+CASE_BASE=8.4 CASE_TITLE="Null-merge branch '8.0' (after 8.0.40) into '8.4'" CASE_TOTAL=300
+CASE_COMMITS="$(commit abc123abc123 1 'Bug#36302624 upstream subject'; commit def456def456 2 'Merge branch 8.0')"
+run_case 'a 300-commit null merge is exempt, not a truncation failure' 0 'contains a merge commit'
+
+# ------------------------------------------------------------------ near misses
+section 'tag and key near misses'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4.0] Fix it' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4.0] Fix it')"
+run_case '[8.4.0] is not [8.4]' 1 'lacks the \[8.4\] branch tag'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 8.4 Fix it' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 8.4 Fix it')"
+run_case 'bare 8.4 without brackets is not the tag' 1 'lacks the \[8.4\] branch tag'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.0] Wrong branch tag' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.0] Wrong branch tag')"
+run_case 'the wrong version tag is rejected' 1 'carries \[8.0\] but a pull request to 8.4 needs \[8.4\]'
+
+CASE_BASE=8.4 CASE_TITLE='XPS-123 [8.4] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'XPS-123 [8.4] Add feature')"
+run_case 'XPS-123 is not a ticket key' 1 'lacks a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-123x [8.4] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-123x [8.4] Add feature')"
+run_case 'PS-123x is not a ticket key' 1 'lacks a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS- [8.4] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS- [8.4] Add feature')"
+run_case 'PS- with no number is not a ticket key' 1 'lacks a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='(PS-123) [8.4] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 '(PS-123) [8.4] Add feature')"
+run_case 'a key in parentheses is still a key' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='ps-123 [8.4] Add feature' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'ps-123 [8.4] Add feature')"
+run_case 'a lowercase key is rejected' 1 'lacks a ticket key'
+
+# ------------------------------------------------------------------ counting
+section 'commit counting and API failures'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Big' CASE_TOTAL=300
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'a truncated listing fails loudly' 1 'only 1 could be listed'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Empty' CASE_TOTAL=0 CASE_COMMITS=''
+run_case 'an empty commit listing fails' 1 'no commits found'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Null' CASE_TOTAL='null'
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'a non-numeric commit count fails' 1 'could not read the base branch'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Boom' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')" CASE_RC=1
+run_case 'a failing gh call aborts, it does not pass' 1 ''
+CASE_RC=0
+
+# ------------------------------------------------------------------ odd subjects
+section 'odd subjects'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Tabbed' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 $'PS-1 [8.4]\ttabbed subject')"
+run_case 'a tab in the subject survives the split' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE=$'PS-1 [8.4]\ttabbed title' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] one')"
+run_case 'a tab in the title survives the metadata split' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Quotes and globs' CASE_TOTAL=1
+# shellcheck disable=SC2016  # the literal $VARS is what this case feeds the checker
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] handle *.cc and "quoted" $VARS')"
+run_case 'globs, quotes and dollars in a subject are literal' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Backslash' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 [8.4] path C:\temp\new')"
+run_case 'backslashes are not interpreted' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Empty subject' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 '')"
+run_case 'an empty commit subject fails' 1 'subject lacks a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Leading spaces' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 '   PS-1 [8.4] indented subject')"
+run_case 'a subject with leading spaces still matches' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='no key no tag' CASE_TOTAL=2
+CASE_COMMITS="$(commit abc123abc123 1 'first bad'; commit def456def456 1 'PS-1 second untagged')"
+out="$(PR_NUMBER=1 REPO=percona/percona-server \
+  FIXTURE_META="8.4${US}2${US}${CASE_TITLE}" FIXTURE_COMMITS="${CASE_COMMITS}" \
+  bash "${SCRIPT}" 2>&1)" || true
+n_errors="$(grep -c '::error::' <<<"${out}")"
+if [[ "${n_errors}" -eq 4 ]]; then
+  echo "ok   every violation is reported (4 ::error:: lines)"
+  pass=$((pass + 1))
+else
+  echo "FAIL every violation is reported: ${n_errors} ::error:: lines, want 4"
+  indent "${out}"
+  fail=$((fail + 1))
+fi
+
+# ------------------------------------------------------------------ inputs
+section 'required inputs'
+
+out="$(env PR_NUMBER= REPO=percona/percona-server FIXTURE_META="8.4${US}1${US}x" \
+  FIXTURE_COMMITS=x bash "${SCRIPT}" 2>&1)"
+rc=$?
+if [[ "${rc}" -ne 0 ]] && grep -q 'PR_NUMBER is required' <<<"${out}"; then
+  echo "ok   missing PR_NUMBER aborts with a clear message"
+  pass=$((pass + 1))
+else
+  echo "FAIL missing PR_NUMBER: exit ${rc}"
+  indent "${out}"
+  fail=$((fail + 1))
+fi
+
+rm -rf "${BIN}"
+echo
+echo "---"
+echo "pass ${pass}  fail ${fail}"
+[[ "${fail}" -eq 0 ]]

--- a/.github/workflows/pr-commit-subjects-tests.yml
+++ b/.github/workflows/pr-commit-subjects-tests.yml
@@ -1,0 +1,34 @@
+# Run the checker's own test suite when the checker or the suite changes.
+#
+# pull_request, not pull_request_target: this one does run code from the pull
+# request, so it gets the unprivileged trigger, no secrets and a read-only
+# token. The suite stubs the gh CLI and makes no network calls.
+
+name: pr-commit-subjects-tests
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/check-pr-commit-subjects.sh
+      - .github/scripts/tests/check-pr-commit-subjects.test.sh
+      - .github/workflows/pr-commit-subjects*.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-commit-subjects-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test the commit-subject checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
+        with:
+          persist-credentials: false
+      - name: shellcheck
+        run: shellcheck .github/scripts/check-pr-commit-subjects.sh .github/scripts/tests/check-pr-commit-subjects.test.sh
+      - name: Behaviour tests
+        run: .github/scripts/tests/check-pr-commit-subjects.test.sh .github/scripts/check-pr-commit-subjects.sh

--- a/.github/workflows/pr-commit-subjects.yml
+++ b/.github/workflows/pr-commit-subjects.yml
@@ -1,0 +1,53 @@
+# Check that the title and every commit subject of a pull request to a version
+# branch names a ticket key and carries the base branch tag ("PS-11435 [8.4]
+# ..."). The tag is what survives the upward null-merges (8.0 -> 8.4 -> 9.7 ->
+# trunk) and what release tooling greps for, so a squash merged under a
+# rewritten subject loses the change for both, and a squash merge of several
+# commits takes the pull request title as its subject. Pull requests carrying a
+# merge commit (upstream merges, null merges) and pull requests to non-version
+# branches are skipped.
+#
+# Read-only: no secrets, the default token with read scopes, a GitHub-hosted
+# runner. Nothing from the pull request is interpolated into the shell, and the
+# title and base branch are read from the API by the script itself.
+#
+# pull_request_target on purpose: the workflow and the script come from the
+# repository, not from the pull request, so a pull request cannot edit its own
+# checker into a no-op. Nothing from the head is checked out or executed.
+#
+# Since 2025-12-08 GitHub takes the pull_request_target workflow file from the
+# DEFAULT branch whatever the base branch is, so the checkout pins
+# github.workflow_sha: the script then always comes from the same commit as the
+# workflow that is running. Checking out the base branch instead would break
+# every pull request to a branch that does not carry the script yet.
+
+name: pr-commit-subjects
+
+on:
+  pull_request_target:  # zizmor: ignore[dangerous-triggers] repository checkout only, no PR code runs
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read  # actions/checkout fetches the script
+  pull-requests: read  # gh api reads the title, base branch and commits
+
+concurrency:
+  group: pr-commit-subjects-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check PR title and commit subjects
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.2.2
+        with:
+          ref: ${{ github.workflow_sha }}  # the running workflow's own commit, never the PR head
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+      - name: Check PR title and commit subjects
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/check-pr-commit-subjects.sh


### PR DESCRIPTION
**Feature**
- A `pr-commit-subjects` check fails a PR to 8.0, 8.4, 9.7 or trunk when the title or any commit subject lacks the ticket key or the `[<base>]` tag. The title is checked too, since a squash merge can take it as the subject.

**Why**
- The tag is what survives the upward null-merges and what release tooling greps for. A squash merged under a rewritten subject loses the change for both, and the only repair is revert and re-apply ([PR 6149](https://github.com/percona/percona-server/pull/6149), [PR 6150](https://github.com/percona/percona-server/pull/6150)).
- Exemption is decided by the commit graph, never by the title. A PR carrying a merge commit is an upstream or a null merge, and the skip is announced as a warning. Reverts keep the reverted subject verbatim, so they are exempt and announced too.
- The title and the base branch are read from the API, so re-running an old run judges the PR as it is now. Annotations escape percent, carriage return and newline, so a subject cannot open a workflow command of its own.
- Runs on `pull_request_target` with the read-only default token and no PR code, and pins the checkout to `github.workflow_sha`. GitHub takes that workflow from the default branch, `8.4`, so the check covers every version branch as soon as it lands.
- What it cannot catch is a subject typed by hand into the squash dialog. Closing that needs a commit-message ruleset or rebase-only merges, both repository settings. A behaviour suite runs on `pull_request` whenever the checker changes.

**Tickets**
- [DISTMYSQL-645](https://perconadev.atlassian.net/browse/DISTMYSQL-645) (this). Origin: the [PR 6076](https://github.com/percona/percona-server/pull/6076) and [PR 6142](https://github.com/percona/percona-server/pull/6142) squash subjects.


[DISTMYSQL-645]: https://perconadev.atlassian.net/browse/DISTMYSQL-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ