### PR TITLE
DISTMYSQL-645 (2) [8.4] Name the numbered-commit form in the checker hint

### DIFF
--- a/.github/scripts/check-pr-commit-subjects.sh
+++ b/.github/scripts/check-pr-commit-subjects.sh
@@ -2,7 +2,9 @@
 #
 # Check that a pull request to a percona-server version branch follows the
 # commit-subject convention: the title and every commit subject name a ticket
-# key and carry the base branch tag, for example "PS-11435 [8.4] Add ...".
+# key and carry the base branch tag, for example "PS-11435 [8.4] Add ...". A
+# ticket's later commits are numbered, "PS-11435 (2) [8.4] Add ... (part 2)",
+# and the number sits between the key and the tag, so it passes unchanged.
 # The tag is what survives the upward null-merges (8.0 -> 8.4 -> 9.7 -> trunk)
 # and what release tooling greps for, so a squash merged under a rewritten
 # subject loses the change for both.
@@ -179,6 +181,7 @@ main() {
     echo
     echo "Expected subject form: ${expected}"
     echo "Reword the commits (git rebase -i, reword) and force-push the PR branch."
+    echo "A ticket's second commit is numbered: <KEY>-<n> (2) ${tag} <what changed>."
     return 1
   fi
   note "PR title and every commit subject carry a ticket key and the ${tag} tag"

--- a/.github/scripts/tests/check-pr-commit-subjects.test.sh
+++ b/.github/scripts/tests/check-pr-commit-subjects.test.sh
@@ -226,6 +226,21 @@ CASE_BASE=9.7 CASE_TITLE='Ps 10999 9.7 OIDC authentication' CASE_TOTAL=1
 CASE_COMMITS="$(commit abc123abc123 1 'PS-10999 [9.7]: OIDC Authentication')"
 run_case 'a branch-name title like "Ps 10999" has no key' 1 'PR title lacks a ticket key'
 
+# ------------------------------------------------------------ numbered commits
+section 'numbered commits of one ticket'
+
+CASE_BASE=9.7 CASE_TITLE='PS-11435 (2) [9.7] Add auth_openid_connect suite to default MTR runs (part 2)' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-11435 (2) [9.7] Add auth_openid_connect suite to default MTR runs (part 2)')"
+run_case 'the (NN) number between key and tag passes' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 (1) [8.4] First of a series' CASE_TOTAL=2
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 (1) [8.4] First of a series'; commit def456def456 1 'PS-1 (2) [8.4] Second of a series')"
+run_case 'an explicitly numbered series passes' 0 'carry a ticket key'
+
+CASE_BASE=8.4 CASE_TITLE='PS-1 [8.4] Fix' CASE_TOTAL=1
+CASE_COMMITS="$(commit abc123abc123 1 'PS-1 Fix without a tag')"
+run_case 'the failure hint shows the numbered form' 1 '(2) \[8.4\]'
+
 # ---------------------------------------------------------------- happy paths
 section 'conforming pull requests'
 


### PR DESCRIPTION
**Bug**
- The `pr-commit-subjects` failure hint shows one form, `<KEY>-<n> [8.4] <what changed>`. A contributor with two commits for one ticket cannot tell from the output that the second one is written with `(2)`, the number that marks it as a squash target when the linear branch is built.

**Fix**
- One line in the checker, next to the existing hint:
  ```bash
  echo "A ticket's second commit is numbered: <KEY>-<n> (2) ${tag} <what changed>."
  ```
- What a failing PR prints after the per-commit errors:
  ```
  Expected subject form: <KEY>-<n> [8.4] <what changed>
  Reword the commits (git rebase -i, reword) and force-push the PR branch.
  A ticket's second commit is numbered: <KEY>-<n> (2) [8.4] <what changed>.
  ```
- The form as it lives on 9.7 today:
  ```
  $ git log --oneline 9.7 | grep 'PS-11435 .*\[9.7\]'
  814d3d7 PS-11435 (2) [9.7] Add auth_openid_connect suite to default MTR runs (part 2)
  cfd5d43 PS-11435 [9.7] Add auth_openid_connect suite to default MTR runs (#6141)
  ```

**Tickets**
- [DISTMYSQL-645](https://perconadev.atlassian.net/browse/DISTMYSQL-645) (this), follow-up to [PR 6151](https://github.com/percona/percona-server/pull/6151).


[DISTMYSQL-645]: https://perconadev.atlassian.net/browse/DISTMYSQL-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ